### PR TITLE
Add original image panel and layout options to Captum visualiser

### DIFF
--- a/docs/consumers/configuration.md
+++ b/docs/consumers/configuration.md
@@ -47,6 +47,8 @@ Select built-in presets by name on the CLI.
 
 You can optionally show sample names in visual outputs via visualiser `call` arguments.
 
+For `CaptumImageVisualiser`, the original image is shown next to the attribution by default when `inputs` are available. You can disable that paired layout via the visualiser `constructor`.
+
 - `show_sample_names` defaults to `false`
 - names come from loaded sample IDs (filename stem, extension removed)
 - if name count and batch size differ, names are trimmed to the plotted batch
@@ -70,8 +72,22 @@ transparency:
           show_sample_names: true
 ```
 
+Disable the original-image side panel explicitly:
+
+```yaml
+transparency:
+  captum_saliency:
+    _target_: CaptumExplainer
+    algorithm: Saliency
+    visualisers:
+      - _target_: CaptumImageVisualiser
+        constructor:
+          include_original_image: false
+```
+
 Notes:
 
+- `CaptumImageVisualiser` renders paired titles when sample names are enabled, for example `Original Image: ISIC_0001` and `Heat Map: ISIC_0001`.
 - Visualisers with native support (for example `CaptumImageVisualiser`) render per-sample titles.
 - Other visualisers fall back to a figure title using the first name (format: `first (+N)`).
 

--- a/src/raitap/transparency/visualisers/captum_visualisers.py
+++ b/src/raitap/transparency/visualisers/captum_visualisers.py
@@ -64,6 +64,14 @@ def _compose_title(base_title: str | None, sample_name: str | None = None) -> st
     return base_title or sample_name
 
 
+def _resolve_title(
+    *, explicit_title: str | None, fallback_title: str | None, sample_name: str | None = None
+) -> str | None:
+    """Resolve titles while preserving an explicitly provided empty string."""
+    base_title = explicit_title if explicit_title is not None else fallback_title
+    return _compose_title(base_title, sample_name)
+
+
 def _last_mappable(ax: Any) -> Any:
     """Return the last Matplotlib mappable drawn on an axis, if any."""
     if getattr(ax, "images", None):
@@ -201,9 +209,11 @@ class CaptumImageVisualiser(BaseVisualiser):
                 else:
                     original_ax, attr_ax = axes[i]
                 original_title = _compose_title("Original Image", sample_name)
-                attr_title = _compose_title(
-                    str(kwargs.get("title") or self.title or _method_label(self.method)),
-                    sample_name,
+                explicit_title = kwargs.get("title")
+                attr_title = _resolve_title(
+                    explicit_title=explicit_title,
+                    fallback_title=self.title or _method_label(self.method),
+                    sample_name=sample_name,
                 )
 
                 _, _ = viz.visualize_image_attr(

--- a/src/raitap/transparency/visualisers/captum_visualisers.py
+++ b/src/raitap/transparency/visualisers/captum_visualisers.py
@@ -44,6 +44,35 @@ def _resize_attr_to_hw(attr: np.ndarray, target_hw: tuple[int, int]) -> np.ndarr
     return attr
 
 
+def _normalise_image(image: np.ndarray) -> np.ndarray:
+    """Normalise an image array to the [0, 1] range when possible."""
+    lo, hi = image.min(), image.max()
+    if hi > lo:
+        return (image - lo) / (hi - lo)
+    return image
+
+
+def _method_label(method: str) -> str:
+    """Convert a Captum method key into a human-readable plot title."""
+    return method.replace("_", " ").title()
+
+
+def _compose_title(base_title: str | None, sample_name: str | None = None) -> str | None:
+    """Combine a base title and optional sample name."""
+    if base_title and sample_name:
+        return f"{base_title}: {sample_name}"
+    return base_title or sample_name
+
+
+def _last_mappable(ax: Any) -> Any:
+    """Return the last Matplotlib mappable drawn on an axis, if any."""
+    if getattr(ax, "images", None):
+        return ax.images[-1]
+    if getattr(ax, "collections", None):
+        return ax.collections[-1]
+    return None
+
+
 class CaptumImageVisualiser(BaseVisualiser):
     """
     Visualise image attributions using ``captum.attr.visualization.visualize_image_attr``.
@@ -60,6 +89,7 @@ class CaptumImageVisualiser(BaseVisualiser):
         sign: str = "all",
         show_colorbar: bool = True,
         title: str | None = None,
+        include_original_image: bool = True,
     ):
         """
         Args:
@@ -72,11 +102,15 @@ class CaptumImageVisualiser(BaseVisualiser):
                           ``"absolute_value"``.  Default: ``"all"``.
             show_colorbar: Whether to add a colorbar.  Default: ``True``.
             title:        Optional subplot title forwarded to Captum.
+            include_original_image: Whether to render the original image next to
+                          the attribution plot when ``inputs`` are provided.
+                          Default: ``True``.
         """
         self.method = method
         self.sign = sign
         self.show_colorbar = show_colorbar
         self.title = title
+        self.include_original_image = include_original_image
 
     def visualise(
         self,
@@ -123,19 +157,32 @@ class CaptumImageVisualiser(BaseVisualiser):
 
         names = [] if sample_names is None else [str(name) for name in sample_names[:n]]
 
-        fig, axes = plt.subplots(1, n, figsize=(4 * n, 4))
-        axes_list = [axes] if n == 1 else list(axes)
+        show_original_panel = (
+            self.include_original_image and origs is not None and self.method != "original_image"
+        )
 
-        for i, ax in enumerate(axes_list):
+        if show_original_panel and self.show_colorbar:
+            fig, axes = plt.subplots(
+                n,
+                3,
+                figsize=(8.5, 4 * n),
+                squeeze=False,
+                gridspec_kw={"width_ratios": [1, 1, 0.05]},
+            )
+        elif show_original_panel:
+            fig, axes = plt.subplots(n, 2, figsize=(8, 4 * n), squeeze=False)
+        else:
+            fig, axes = plt.subplots(1, n, figsize=(4 * n, 4))
+            axes = np.atleast_1d(axes)
+
+        for i in range(n):
             # (C, H, W) -> (H, W, C)
             attr_i = np.transpose(attrs[i], (1, 2, 0)) if attrs[i].ndim == 3 else attrs[i]
 
             orig_i = None
             if origs is not None:
                 orig_i = np.transpose(origs[i], (1, 2, 0)) if origs[i].ndim == 3 else origs[i]
-                lo, hi = orig_i.min(), orig_i.max()
-                if hi > lo:
-                    orig_i = (orig_i - lo) / (hi - lo)
+                orig_i = _normalise_image(orig_i)
 
                 # Layer methods (e.g., LayerGradCam) can yield low-res maps;
                 # masked modes need same HxW.
@@ -145,6 +192,52 @@ class CaptumImageVisualiser(BaseVisualiser):
                     if attr_hw != orig_hw:
                         attr_i = _resize_attr_to_hw(attr_i, orig_hw)
 
+            sample_name = names[i] if show_sample_names and i < len(names) else None
+
+            if show_original_panel:
+                colorbar_ax = None
+                if self.show_colorbar:
+                    original_ax, attr_ax, colorbar_ax = axes[i]
+                else:
+                    original_ax, attr_ax = axes[i]
+                original_title = _compose_title("Original Image", sample_name)
+                attr_title = _compose_title(
+                    str(kwargs.get("title") or self.title or _method_label(self.method)),
+                    sample_name,
+                )
+
+                _, _ = viz.visualize_image_attr(
+                    attr_i,
+                    orig_i,
+                    method="original_image",
+                    sign="all",
+                    show_colorbar=False,
+                    plt_fig_axis=(fig, original_ax),
+                    use_pyplot=False,
+                    title=original_title,
+                )
+
+                attr_viz_kwargs = dict(kwargs)
+                attr_viz_kwargs["title"] = attr_title
+                _, _ = viz.visualize_image_attr(
+                    attr_i,
+                    orig_i,
+                    method=self.method,
+                    sign=self.sign,
+                    show_colorbar=False,
+                    plt_fig_axis=(fig, attr_ax),
+                    use_pyplot=False,
+                    **attr_viz_kwargs,
+                )
+                if self.show_colorbar and colorbar_ax is not None:
+                    mappable = _last_mappable(attr_ax)
+                    if mappable is None:
+                        colorbar_ax.set_visible(False)
+                    else:
+                        fig.colorbar(mappable, cax=colorbar_ax)
+                continue
+
+            ax = axes[i]
             viz_kwargs = dict(kwargs)
             if self.title is not None and "title" not in viz_kwargs:
                 viz_kwargs["title"] = self.title

--- a/src/raitap/transparency/visualisers/tests/test_visualisers.py
+++ b/src/raitap/transparency/visualisers/tests/test_visualisers.py
@@ -29,6 +29,7 @@ class TestCaptumImageVisualiser:
     def test_initialization(self) -> None:
         visualiser = CaptumImageVisualiser()
         assert visualiser is not None
+        assert visualiser.include_original_image is True
 
     @pytest.mark.usefixtures("needs_captum")
     def test_visualise_tensor(self, sample_images: torch.Tensor) -> None:
@@ -54,6 +55,44 @@ class TestCaptumImageVisualiser:
 
         fig = visualiser.visualise(attributions, inputs=sample_images)
         assert fig is not None
+        titles = [ax.get_title() for ax in fig.axes[:2]]
+        assert titles == ["Original Image", "Blended Heat Map"]
+
+    @pytest.mark.usefixtures("needs_captum")
+    def test_original_and_attribution_panels_have_equal_size(
+        self, sample_images: torch.Tensor
+    ) -> None:
+        visualiser = CaptumImageVisualiser(method="heat_map", show_colorbar=True)
+        attributions = torch.randn_like(sample_images)
+
+        fig = visualiser.visualise(attributions, inputs=sample_images, max_samples=1)
+
+        original_pos = fig.axes[0].get_position()
+        attr_pos = fig.axes[1].get_position()
+        assert original_pos.width == pytest.approx(attr_pos.width, rel=1e-3)
+        assert original_pos.height == pytest.approx(attr_pos.height, rel=1e-3)
+
+    @pytest.mark.usefixtures("needs_captum")
+    def test_can_disable_original_image_panel(self, sample_images: torch.Tensor) -> None:
+        visualiser = CaptumImageVisualiser(method="heat_map", include_original_image=False)
+        attributions = torch.randn_like(sample_images)
+
+        fig = visualiser.visualise(attributions, inputs=sample_images, max_samples=2)
+
+        assert len(fig.axes) >= 2
+        assert fig.axes[0].get_title() == ""
+
+    @pytest.mark.usefixtures("needs_captum")
+    def test_original_image_method_avoids_duplicate_panels(
+        self, sample_images: torch.Tensor
+    ) -> None:
+        visualiser = CaptumImageVisualiser(method="original_image")
+        attributions = torch.randn_like(sample_images)
+
+        fig = visualiser.visualise(attributions, inputs=sample_images, max_samples=1)
+
+        assert len(fig.axes) == 2
+        assert fig.axes[0].get_title() == ""
 
     @pytest.mark.usefixtures("needs_captum")
     def test_masked_image_resizes_low_res_attributions(self) -> None:
@@ -80,13 +119,37 @@ class TestCaptumImageVisualiser:
 
         fig = visualiser.visualise(
             attributions,
-            max_samples=2,
+            inputs=sample_images,
+            max_samples=1,
             sample_names=["ISIC_0001", "ISIC_0002", "ISIC_0003"],
             show_sample_names=True,
         )
 
         titles = [ax.get_title() for ax in fig.axes[:2]]
-        assert titles == ["ISIC_0001", "ISIC_0002"]
+        assert titles == ["Original Image: ISIC_0001", "Heat Map: ISIC_0001"]
+
+    @pytest.mark.usefixtures("needs_captum")
+    def test_show_sample_names_sets_titles_for_each_sample_pair(
+        self, sample_images: torch.Tensor
+    ) -> None:
+        visualiser = CaptumImageVisualiser(method="heat_map")
+        attributions = torch.randn_like(sample_images)
+
+        fig = visualiser.visualise(
+            attributions,
+            inputs=sample_images,
+            max_samples=2,
+            sample_names=["ISIC_0001", "ISIC_0002", "ISIC_0003"],
+            show_sample_names=True,
+        )
+
+        titles = [ax.get_title() for ax in fig.axes if ax.get_title()]
+        assert titles == [
+            "Original Image: ISIC_0001",
+            "Heat Map: ISIC_0001",
+            "Original Image: ISIC_0002",
+            "Heat Map: ISIC_0002",
+        ]
 
     @pytest.mark.usefixtures("needs_captum")
     def test_sample_names_are_hidden_by_default(self, sample_images: torch.Tensor) -> None:
@@ -108,13 +171,15 @@ class TestCaptumImageVisualiser:
 
         fig = visualiser.visualise(
             attributions,
+            inputs=sample_images,
             max_samples=1,
             sample_names=["ISIC_1234"],
             show_sample_names=True,
             title="LayerGradCAM",
         )
 
-        assert fig.axes[0].get_title() == "LayerGradCAM: ISIC_1234"
+        titles = [ax.get_title() for ax in fig.axes[:2]]
+        assert titles == ["Original Image: ISIC_1234", "LayerGradCAM: ISIC_1234"]
 
 
 class TestTabularBarChartVisualiser:

--- a/src/raitap/transparency/visualisers/tests/test_visualisers.py
+++ b/src/raitap/transparency/visualisers/tests/test_visualisers.py
@@ -181,6 +181,23 @@ class TestCaptumImageVisualiser:
         titles = [ax.get_title() for ax in fig.axes[:2]]
         assert titles == ["Original Image: ISIC_1234", "LayerGradCAM: ISIC_1234"]
 
+    @pytest.mark.usefixtures("needs_captum")
+    def test_explicit_empty_title_is_preserved_in_paired_layout(
+        self, sample_images: torch.Tensor
+    ) -> None:
+        visualiser = CaptumImageVisualiser(method="heat_map")
+        attributions = torch.randn_like(sample_images)
+
+        fig = visualiser.visualise(
+            attributions,
+            inputs=sample_images,
+            max_samples=1,
+            title="",
+        )
+
+        titles = [ax.get_title() for ax in fig.axes[:2]]
+        assert titles == ["Original Image", ""]
+
 
 class TestTabularBarChartVisualiser:
     """Test tabular visualiser"""


### PR DESCRIPTION


Includes optional paired original-image display, new utility functions for normalization and title composition, and updated tests/documentation.
