### PR TITLE
feat(data)!: path-based labels.csv resolution + recursive image walk

### DIFF
--- a/docs/contributor/data.md
+++ b/docs/contributor/data.md
@@ -34,3 +34,22 @@ To add a new built-in dataset config:
 4. **Update documentation**
 
     Add the new dataset name to the list in `docs/modules/data/own-vs-built-in.md`.
+
+## Sample discovery and label alignment
+
+`data.source` directories are walked **recursively** (`Path.rglob`) and
+sample ids are computed as posix-style paths relative to the source root
+(e.g. `NORMAL/IM-0001.jpeg`). This supports nested `ImageFolder`-style
+layouts where filename stems may collide across class subdirs.
+
+Label alignment is governed by `data.labels.id_strategy`:
+
+- `"auto"` (default) — inspects the id column once. If any value contains
+  `/` or `\`, switches to `"relative_path"`; otherwise `"stem"`.
+- `"relative_path"` — strips only the file extension during comparison;
+  directory components are retained.
+- `"stem"` — legacy flat-dir behaviour (`Path(id).stem`).
+
+Both sides (sample ids from disk + label ids from the file) are normalised
+the same way before lookup. Duplicate normalised label ids raise a
+warning and disable label-based metrics for that run.

--- a/docs/modules/data/configuration.md
+++ b/docs/modules/data/configuration.md
@@ -76,27 +76,5 @@ data:
 :cli: data.source="./data/images" data.labels.source="./data/labels.csv" data.labels.column=label
 ```
 
-## Nested ImageFolder layout
-
-`data.source` is walked recursively. To support layouts like
-
-```
-data/test/
-├── NORMAL/IM-0001.jpeg
-├── NORMAL/IM-0002.jpeg
-└── PNEUMONIA/IM-0001.jpeg   # colliding stem with NORMAL/
-```
-
-write the labels file with relative posix paths:
-
-```csv
-image,label
-NORMAL/IM-0001.jpeg,0
-NORMAL/IM-0002.jpeg,0
-PNEUMONIA/IM-0001.jpeg,1
-```
-
-The default `labels.id_strategy: "auto"` detects the path separators and
-matches by relative path (extension is stripped during comparison, so
-`NORMAL/IM-0001.jpeg` and `NORMAL/IM-0001` both work). Sample order is
-sorted by relative posix path.
+For nested `ImageFolder`-style layouts (e.g. `data/test/<class>/<file>.jpg`)
+see {doc}`own-vs-built-in`.

--- a/docs/modules/data/configuration.md
+++ b/docs/modules/data/configuration.md
@@ -49,6 +49,17 @@
 :default: null
 :description: Optional label parsing strategy.
 
+:option: labels.id_strategy
+:allowed: "auto", "relative_path", "stem"
+:default: "auto"
+:description: How label-file ids are matched against discovered sample
+  files. `"auto"` (default) inspects the id column and switches to
+  `"relative_path"` if any value contains `/` or `\`, otherwise falls back
+  to `"stem"`. `"relative_path"` keeps directory components and supports
+  nested ImageFolder layouts (e.g. `NORMAL/IM-0001.jpeg`) — required when
+  filename stems collide across class subdirs. `"stem"` is the legacy
+  flat-dir behaviour.
+
 :yaml:
 data:
   name: "my-dataset"
@@ -60,6 +71,32 @@ data:
     id_column: "image"
     column: "label"
     encoding: "index"
+    id_strategy: "auto"
 
 :cli: data.source="./data/images" data.labels.source="./data/labels.csv" data.labels.column=label
 ```
+
+## Nested ImageFolder layout
+
+`data.source` is walked recursively. To support layouts like
+
+```
+data/test/
+├── NORMAL/IM-0001.jpeg
+├── NORMAL/IM-0002.jpeg
+└── PNEUMONIA/IM-0001.jpeg   # colliding stem with NORMAL/
+```
+
+write the labels file with relative posix paths:
+
+```csv
+image,label
+NORMAL/IM-0001.jpeg,0
+NORMAL/IM-0002.jpeg,0
+PNEUMONIA/IM-0001.jpeg,1
+```
+
+The default `labels.id_strategy: "auto"` detects the path separators and
+matches by relative path (extension is stripped during comparison, so
+`NORMAL/IM-0001.jpeg` and `NORMAL/IM-0001` both work). Sample order is
+sorted by relative posix path.

--- a/docs/modules/data/own-vs-built-in.md
+++ b/docs/modules/data/own-vs-built-in.md
@@ -26,6 +26,13 @@ data:
 
 Example (nested ImageFolder layout — `data/test/<class>/<file>.jpg`):
 
+```
+data/test/
+├── NORMAL/IM-0001.jpeg
+├── NORMAL/IM-0002.jpeg
+└── PNEUMONIA/IM-0001.jpeg   # colliding stem with NORMAL/
+```
+
 ```yaml
 data:
   source: "./data/test"
@@ -36,8 +43,20 @@ data:
     # id_strategy: "auto"   # default — relative paths auto-detected
 ```
 
-with `labels.csv` rows like `NORMAL/IM-0001.jpeg,0`. See
-{doc}`configuration` for the full `id_strategy` reference.
+with `labels.csv` rows like:
+
+```text
+image,label
+NORMAL/IM-0001.jpeg,0
+NORMAL/IM-0002.jpeg,0
+PNEUMONIA/IM-0001.jpeg,1
+```
+
+The default `labels.id_strategy: "auto"` detects the path separators and
+matches by relative path (extension is stripped during comparison, so
+`NORMAL/IM-0001.jpeg` and `NORMAL/IM-0001` both work). Sample order is
+sorted by relative posix path. See {doc}`configuration` for the full
+`id_strategy` reference.
 
 If you want to evaluate metrics against ground-truth labels, configure the
 optional `data.labels` block as described in {doc}`configuration`.

--- a/docs/modules/data/own-vs-built-in.md
+++ b/docs/modules/data/own-vs-built-in.md
@@ -8,11 +8,12 @@ directory.
 Supported inputs include:
 
 - A directory of images such as `.jpg`, `.png`, `.bmp`, or `.webp`
+  (walked recursively — nested `ImageFolder`-style layouts are supported)
 - A single image file
 - A CSV, TSV, or Parquet file
 - A directory containing CSV, TSV, or Parquet files
 
-Example:
+Example (flat directory):
 
 ```yaml
 data:
@@ -22,6 +23,21 @@ data:
     id_column: "image"
     column: "label"
 ```
+
+Example (nested ImageFolder layout — `data/test/<class>/<file>.jpg`):
+
+```yaml
+data:
+  source: "./data/test"
+  labels:
+    source: "./data/labels.csv"
+    id_column: "image"
+    column: "label"
+    # id_strategy: "auto"   # default — relative paths auto-detected
+```
+
+with `labels.csv` rows like `NORMAL/IM-0001.jpeg,0`. See
+{doc}`configuration` for the full `id_strategy` reference.
 
 If you want to evaluate metrics against ground-truth labels, configure the
 optional `data.labels` block as described in {doc}`configuration`.

--- a/src/raitap/configs/schema.py
+++ b/src/raitap/configs/schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any
 
 
 @dataclass
@@ -20,12 +20,12 @@ class LabelsConfig:
     column: str | None = None
     # Optional parsing strategy for labels: "index", "one_hot", or "argmax".
     encoding: str | None = None
-    # Strategy for matching label-file ids to discovered sample files:
+    # Strategy for matching label-file ids to discovered sample files. One of:
     #   "auto"          — pick "relative_path" if any id contains "/" or "\\"; else "stem".
     #   "relative_path" — ids are resolved as posix-style paths relative to ``data.source``
     #                     (supports nested ImageFolder layouts with colliding stems).
     #   "stem"          — legacy flat-dir behaviour: match by ``Path(id).stem`` only.
-    id_strategy: Literal["auto", "relative_path", "stem"] = "auto"
+    id_strategy: str = "auto"
 
 
 @dataclass

--- a/src/raitap/configs/schema.py
+++ b/src/raitap/configs/schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 
 @dataclass
@@ -20,6 +20,12 @@ class LabelsConfig:
     column: str | None = None
     # Optional parsing strategy for labels: "index", "one_hot", or "argmax".
     encoding: str | None = None
+    # Strategy for matching label-file ids to discovered sample files:
+    #   "auto"          — pick "relative_path" if any id contains "/" or "\\"; else "stem".
+    #   "relative_path" — ids are resolved as posix-style paths relative to ``data.source``
+    #                     (supports nested ImageFolder layouts with colliding stems).
+    #   "stem"          — legacy flat-dir behaviour: match by ``Path(id).stem`` only.
+    id_strategy: Literal["auto", "relative_path", "stem"] = "auto"
 
 
 @dataclass

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -76,9 +76,8 @@ class Data(Trackable):
                 )
 
         if path.is_dir():
-            all_files = list(path.iterdir())
-            image_files = [f for f in all_files if f.suffix.lower() in _IMAGE_EXTENSIONS]
-            tabular_files = [f for f in all_files if f.suffix.lower() in _TABULAR_EXTENSIONS]
+            image_files = _list_images_recursive(path)
+            tabular_files = _list_tabular_recursive(path)
             if image_files and tabular_files:
                 raise ValueError(
                     f"Directory {path} contains both image and tabular files. "
@@ -86,7 +85,7 @@ class Data(Trackable):
                 )
             if image_files:
                 tensor = _load_images(path)
-                return tensor, _resolve_sample_ids(image_files)
+                return tensor, _resolve_sample_ids(image_files, root=path)
             if tabular_files:
                 return _load_tabular_dir(path), None
             raise FileNotFoundError(
@@ -97,7 +96,7 @@ class Data(Trackable):
 
         suffix = path.suffix.lower()
         if suffix in _IMAGE_EXTENSIONS:
-            return _load_images(path), _resolve_sample_ids([path])
+            return _load_images(path), _resolve_sample_ids([path], root=path.parent)
         if suffix in _TABULAR_EXTENSIONS:
             return _load_tabular(path), None
 
@@ -267,9 +266,8 @@ def load_numpy_from_source(source: str, n_samples: int | None = None) -> np.ndar
 def _load_numpy_from_path(path: Path) -> np.ndarray[Any, Any]:
     """Load a numpy array from a single file or directory (no sample IDs returned)."""
     if path.is_dir():
-        all_files = list(path.iterdir())
-        image_files = [f for f in all_files if f.suffix.lower() in _IMAGE_EXTENSIONS]
-        tabular_files = [f for f in all_files if f.suffix.lower() in _TABULAR_EXTENSIONS]
+        image_files = _list_images_recursive(path)
+        tabular_files = _list_tabular_recursive(path)
         if image_files and tabular_files:
             raise ValueError(
                 f"Directory {path} contains both image and tabular files. "
@@ -340,10 +338,26 @@ def get_source_path(source: str) -> Path:
     )
 
 
+def _list_images_recursive(root: Path) -> list[Path]:
+    """Discover image files under ``root`` recursively, sorted by relative posix path."""
+    files = [
+        p for p in root.rglob("*") if p.is_file() and p.suffix.lower() in _IMAGE_EXTENSIONS
+    ]
+    return sorted(files, key=lambda p: p.relative_to(root).as_posix())
+
+
+def _list_tabular_recursive(root: Path) -> list[Path]:
+    """Discover tabular files under ``root`` recursively, sorted by relative posix path."""
+    files = [
+        p for p in root.rglob("*") if p.is_file() and p.suffix.lower() in _TABULAR_EXTENSIONS
+    ]
+    return sorted(files, key=lambda p: p.relative_to(root).as_posix())
+
+
 def _load_images_numpy(path: Path) -> np.ndarray[Any, Any]:
     """Load image files from a directory (or a single file) as NCHW float32 arrays in [0, 1]."""
     if path.is_dir():
-        files = sorted(f for f in path.iterdir() if f.suffix.lower() in _IMAGE_EXTENSIONS)
+        files = _list_images_recursive(path)
         if not files:
             raise FileNotFoundError(f"No image files found in {path}")
     else:
@@ -479,8 +493,9 @@ def _extract_class_labels(
     return matrix.argmax(axis=1).astype(int).tolist()
 
 
-def _resolve_sample_ids(files: list[Path]) -> list[str]:
-    return sorted(_normalise_sample_id(path.name) for path in files)
+def _resolve_sample_ids(files: list[Path], root: Path) -> list[str]:
+    """Sample ids are posix-style paths relative to ``root`` (extension included)."""
+    return sorted(p.relative_to(root).as_posix() for p in files)
 
 
 def _normalise_sample_id(value: object) -> str:
@@ -502,6 +517,7 @@ def _align_labels_to_samples(
     raw_label_ids: pd.Series,
     encoded_labels: list[int],
 ) -> list[int]:
+    normalised_sample_ids = [_normalise_sample_id(sid) for sid in sample_ids]
     normalised_label_ids = [_normalise_sample_id(raw_id) for raw_id in raw_label_ids.tolist()]
     duplicates = sorted(
         [row_id for row_id, count in Counter(normalised_label_ids).items() if count > 1]
@@ -516,19 +532,19 @@ def _align_labels_to_samples(
         row_id: int(label)
         for row_id, label in zip(normalised_label_ids, encoded_labels, strict=False)
     }
-    missing_ids = [sample_id for sample_id in sample_ids if sample_id not in label_by_id]
+    missing_ids = [sid for sid in normalised_sample_ids if sid not in label_by_id]
     if missing_ids:
         preview = ", ".join(missing_ids[:5])
         raise ValueError(
             "Missing labels for some sample IDs "
             f"({preview}{'...' if len(missing_ids) > 5 else ''})."
         )
-    return [label_by_id[sample_id] for sample_id in sample_ids]
+    return [label_by_id[sid] for sid in normalised_sample_ids]
 
 
 def _load_tabular_dir_numpy(path: Path) -> np.ndarray[Any, Any]:
     """Load all tabular files from a directory as a single float32 array, concatenating rows."""
-    files = sorted(f for f in path.iterdir() if f.suffix.lower() in _TABULAR_EXTENSIONS)
+    files = _list_tabular_recursive(path)
     arrays = [_load_tabular_numpy(f) for f in files]
     try:
         return np.concatenate(arrays)

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -84,10 +84,10 @@ class Data(Trackable):
                     "Separate them into different directories."
                 )
             if image_files:
-                tensor = _load_images(path)
+                tensor = torch.from_numpy(_stack_images_numpy(image_files))
                 return tensor, _resolve_sample_ids(image_files, root=path)
             if tabular_files:
-                return _load_tabular_dir(path), None
+                return torch.from_numpy(_concat_tabular_numpy(tabular_files)), None
             raise FileNotFoundError(
                 f"No supported files found in {path}.\n"
                 f"Supported image formats: {_IMAGE_EXTENSIONS}\n"
@@ -277,9 +277,9 @@ def _load_numpy_from_path(path: Path) -> np.ndarray[Any, Any]:
                 "Separate them into different directories."
             )
         if image_files:
-            return _load_images_numpy(path)
+            return _stack_images_numpy(image_files)
         if tabular_files:
-            return _load_tabular_dir_numpy(path)
+            return _concat_tabular_numpy(tabular_files)
         raise FileNotFoundError(
             f"No supported files found in {path}.\n"
             f"Supported image formats: {_IMAGE_EXTENSIONS}\n"
@@ -343,29 +343,18 @@ def get_source_path(source: str) -> Path:
 
 def _list_images_recursive(root: Path) -> list[Path]:
     """Discover image files under ``root`` recursively, sorted by relative posix path."""
-    files = [
-        p for p in root.rglob("*") if p.is_file() and p.suffix.lower() in _IMAGE_EXTENSIONS
-    ]
+    files = [p for p in root.rglob("*") if p.is_file() and p.suffix.lower() in _IMAGE_EXTENSIONS]
     return sorted(files, key=lambda p: p.relative_to(root).as_posix())
 
 
 def _list_tabular_recursive(root: Path) -> list[Path]:
     """Discover tabular files under ``root`` recursively, sorted by relative posix path."""
-    files = [
-        p for p in root.rglob("*") if p.is_file() and p.suffix.lower() in _TABULAR_EXTENSIONS
-    ]
+    files = [p for p in root.rglob("*") if p.is_file() and p.suffix.lower() in _TABULAR_EXTENSIONS]
     return sorted(files, key=lambda p: p.relative_to(root).as_posix())
 
 
-def _load_images_numpy(path: Path) -> np.ndarray[Any, Any]:
-    """Load image files from a directory (or a single file) as NCHW float32 arrays in [0, 1]."""
-    if path.is_dir():
-        files = _list_images_recursive(path)
-        if not files:
-            raise FileNotFoundError(f"No image files found in {path}")
-    else:
-        files = [path]
-
+def _stack_images_numpy(files: list[Path]) -> np.ndarray[Any, Any]:
+    """Stack pre-discovered image files into an NCHW float32 array in [0, 1]."""
     arrays = []
     for f in files:
         arr = np.array(Image.open(f).convert("RGB"))  # HWC uint8
@@ -379,6 +368,17 @@ def _load_images_numpy(path: Path) -> np.ndarray[Any, Any]:
             f"Images have inconsistent shapes: {sizes}. "
             "Resize them to a common size before loading."
         ) from None
+
+
+def _load_images_numpy(path: Path) -> np.ndarray[Any, Any]:
+    """Load image files from a directory (or a single file) as NCHW float32 arrays in [0, 1]."""
+    if path.is_dir():
+        files = _list_images_recursive(path)
+        if not files:
+            raise FileNotFoundError(f"No image files found in {path}")
+    else:
+        files = [path]
+    return _stack_images_numpy(files)
 
 
 def _load_images(path: Path) -> torch.Tensor:
@@ -526,8 +526,7 @@ def _resolve_id_strategy(strategy: str, raw_label_ids: pd.Series) -> str:
     if strategy in {"relative_path", "stem"}:
         return strategy
     raise ValueError(
-        f"Unsupported data.labels.id_strategy {strategy!r}. "
-        "Use 'auto', 'relative_path', or 'stem'."
+        f"Unsupported data.labels.id_strategy {strategy!r}. Use 'auto', 'relative_path', or 'stem'."
     )
 
 
@@ -573,9 +572,8 @@ def _align_labels_to_samples(
     return [label_by_id[sid] for sid in normalised_sample_ids]
 
 
-def _load_tabular_dir_numpy(path: Path) -> np.ndarray[Any, Any]:
-    """Load all tabular files from a directory as a single float32 array, concatenating rows."""
-    files = _list_tabular_recursive(path)
+def _concat_tabular_numpy(files: list[Path]) -> np.ndarray[Any, Any]:
+    """Concatenate pre-discovered tabular files row-wise into a float32 array."""
     arrays = [_load_tabular_numpy(f) for f in files]
     try:
         return np.concatenate(arrays)
@@ -585,6 +583,11 @@ def _load_tabular_dir_numpy(path: Path) -> np.ndarray[Any, Any]:
             f"Tabular files have inconsistent column counts: {shapes}. "
             "All files must have the same number of columns."
         ) from None
+
+
+def _load_tabular_dir_numpy(path: Path) -> np.ndarray[Any, Any]:
+    """Load all tabular files from a directory as a single float32 array, concatenating rows."""
+    return _concat_tabular_numpy(_list_tabular_recursive(path))
 
 
 def _load_tabular_dir(path: Path) -> torch.Tensor:

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -124,6 +124,7 @@ class Data(Trackable):
         id_column = _resolve_labels_id_column(labels_df, labels_id_column)
         labels_column = _get_optional_config_value(labels_cfg, "column")
         labels_encoding = _get_optional_config_value(labels_cfg, "encoding")
+        labels_id_strategy = _get_optional_config_value(labels_cfg, "id_strategy") or "auto"
         encoded_labels = _extract_class_labels(
             labels_df,
             labels_column=labels_column,
@@ -134,11 +135,13 @@ class Data(Trackable):
         expected = int(self.tensor.shape[0])
         if self.sample_ids and id_column:
             id_series = _column_as_series(labels_df, id_column)
+            strategy = _resolve_id_strategy(labels_id_strategy, id_series)
             try:
                 aligned_labels = _align_labels_to_samples(
                     sample_ids=self.sample_ids,
                     raw_label_ids=id_series,
                     encoded_labels=encoded_labels,
+                    strategy=strategy,
                 )
             except ValueError as error:
                 warnings.warn(
@@ -498,9 +501,34 @@ def _resolve_sample_ids(files: list[Path], root: Path) -> list[str]:
     return sorted(p.relative_to(root).as_posix() for p in files)
 
 
-def _normalise_sample_id(value: object) -> str:
-    text = str(value).strip()
-    return Path(text).stem
+def _normalise_sample_id(value: object, strategy: str = "stem") -> str:
+    """Normalise a label-file id or discovered sample id into a comparable key.
+
+    - ``strategy="stem"``: legacy behaviour. Strip the directory and the
+      extension; e.g. ``"NORMAL/IM-0001.jpeg"`` → ``"IM-0001"``.
+    - ``strategy="relative_path"``: keep the directory; strip only the
+      extension. e.g. ``"NORMAL\\IM-0001.jpeg"`` → ``"NORMAL/IM-0001"``.
+    """
+    text = str(value).strip().replace("\\", "/")
+    p = Path(text)
+    if strategy == "relative_path":
+        return p.with_suffix("").as_posix()
+    return p.stem
+
+
+def _resolve_id_strategy(strategy: str, raw_label_ids: pd.Series) -> str:
+    if strategy == "auto":
+        for raw in raw_label_ids.tolist():
+            text = str(raw)
+            if "/" in text or "\\" in text:
+                return "relative_path"
+        return "stem"
+    if strategy in {"relative_path", "stem"}:
+        return strategy
+    raise ValueError(
+        f"Unsupported data.labels.id_strategy {strategy!r}. "
+        "Use 'auto', 'relative_path', or 'stem'."
+    )
 
 
 def _column_as_series(df: pd.DataFrame, column_name: str) -> pd.Series:
@@ -516,9 +544,12 @@ def _align_labels_to_samples(
     sample_ids: list[str],
     raw_label_ids: pd.Series,
     encoded_labels: list[int],
+    strategy: str = "stem",
 ) -> list[int]:
-    normalised_sample_ids = [_normalise_sample_id(sid) for sid in sample_ids]
-    normalised_label_ids = [_normalise_sample_id(raw_id) for raw_id in raw_label_ids.tolist()]
+    normalised_sample_ids = [_normalise_sample_id(sid, strategy) for sid in sample_ids]
+    normalised_label_ids = [
+        _normalise_sample_id(raw_id, strategy) for raw_id in raw_label_ids.tolist()
+    ]
     duplicates = sorted(
         [row_id for row_id, count in Counter(normalised_label_ids).items() if count > 1]
     )

--- a/src/raitap/data/tests/test_data_class.py
+++ b/src/raitap/data/tests/test_data_class.py
@@ -187,9 +187,7 @@ class TestDataConstructor:
         _write_image(data_dir / "NORMAL" / "IM-0001.jpeg")
         _write_image(data_dir / "PNEUMONIA" / "IM-0001.jpeg")
         labels_file = tmp_path / "labels.csv"
-        labels_file.write_text(
-            "image,label\nNORMAL/IM-0001.jpeg,0\nPNEUMONIA/IM-0001.jpeg,1\n"
-        )
+        labels_file.write_text("image,label\nNORMAL/IM-0001.jpeg,0\nPNEUMONIA/IM-0001.jpeg,1\n")
         config = _make_config(
             str(data_dir),
             labels_source=str(labels_file),
@@ -227,18 +225,14 @@ class TestDataConstructor:
         assert data.labels is not None
         assert data.labels.tolist() == [7, 8]
 
-    def test_data_explicit_stem_strategy_with_nested_collisions_warns(
-        self, tmp_path: Path
-    ) -> None:
+    def test_data_explicit_stem_strategy_with_nested_collisions_warns(self, tmp_path: Path) -> None:
         data_dir = tmp_path / "images"
         (data_dir / "NORMAL").mkdir(parents=True)
         (data_dir / "PNEUMONIA").mkdir(parents=True)
         _write_image(data_dir / "NORMAL" / "IM-0001.jpeg")
         _write_image(data_dir / "PNEUMONIA" / "IM-0001.jpeg")
         labels_file = tmp_path / "labels.csv"
-        labels_file.write_text(
-            "image,label\nNORMAL/IM-0001.jpeg,0\nPNEUMONIA/IM-0001.jpeg,1\n"
-        )
+        labels_file.write_text("image,label\nNORMAL/IM-0001.jpeg,0\nPNEUMONIA/IM-0001.jpeg,1\n")
         config = _make_config(
             str(data_dir),
             labels_source=str(labels_file),
@@ -268,7 +262,7 @@ class TestDataConstructor:
             labels_id_strategy="bogus",
         )
 
-        with pytest.raises(ValueError, match="Unsupported data.labels.id_strategy"):
+        with pytest.raises(ValueError, match=r"Unsupported data\.labels\.id_strategy"):
             Data(config)
 
     def test_data_raises_for_unsupported_labels_encoding(self, tmp_path: Path) -> None:

--- a/src/raitap/data/tests/test_data_class.py
+++ b/src/raitap/data/tests/test_data_class.py
@@ -31,6 +31,7 @@ def _make_config(
     labels_id_column: str | None = None,
     labels_column: str | None = None,
     labels_encoding: str | None = None,
+    labels_id_strategy: str | None = None,
 ) -> AppConfig:
     return cast(
         "AppConfig",
@@ -43,6 +44,7 @@ def _make_config(
                     id_column=labels_id_column,
                     column=labels_column,
                     encoding=labels_encoding,
+                    id_strategy=labels_id_strategy,
                 ),
             )
         ),
@@ -175,6 +177,99 @@ class TestDataConstructor:
             data = Data(config)
 
         assert data.labels is None
+
+    def test_data_loads_nested_layout_with_relative_paths(self, tmp_path: Path) -> None:
+        # Colliding stems across class subdirs — old stem-only matching would
+        # silently drop rows; new id_strategy=auto resolves them as paths.
+        data_dir = tmp_path / "images"
+        (data_dir / "NORMAL").mkdir(parents=True)
+        (data_dir / "PNEUMONIA").mkdir(parents=True)
+        _write_image(data_dir / "NORMAL" / "IM-0001.jpeg")
+        _write_image(data_dir / "PNEUMONIA" / "IM-0001.jpeg")
+        labels_file = tmp_path / "labels.csv"
+        labels_file.write_text(
+            "image,label\nNORMAL/IM-0001.jpeg,0\nPNEUMONIA/IM-0001.jpeg,1\n"
+        )
+        config = _make_config(
+            str(data_dir),
+            labels_source=str(labels_file),
+            labels_id_column="image",
+            labels_column="label",
+            labels_encoding="index",
+        )
+
+        data = Data(config)
+
+        assert data.tensor.shape[0] == 2
+        assert data.labels is not None
+        # Sample order is sorted by relative posix path: NORMAL/* < PNEUMONIA/*.
+        assert data.labels.tolist() == [0, 1]
+
+    def test_data_auto_detects_relative_paths_from_separators(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "images"
+        (data_dir / "a").mkdir(parents=True)
+        (data_dir / "b").mkdir(parents=True)
+        _write_image(data_dir / "a" / "x.jpg")
+        _write_image(data_dir / "b" / "x.jpg")
+        labels_file = tmp_path / "labels.csv"
+        # Backslash separator should also trigger relative_path mode.
+        labels_file.write_text("image,label\na\\x.jpg,7\nb\\x.jpg,8\n")
+        config = _make_config(
+            str(data_dir),
+            labels_source=str(labels_file),
+            labels_id_column="image",
+            labels_column="label",
+            labels_encoding="index",
+        )
+
+        data = Data(config)
+
+        assert data.labels is not None
+        assert data.labels.tolist() == [7, 8]
+
+    def test_data_explicit_stem_strategy_with_nested_collisions_warns(
+        self, tmp_path: Path
+    ) -> None:
+        data_dir = tmp_path / "images"
+        (data_dir / "NORMAL").mkdir(parents=True)
+        (data_dir / "PNEUMONIA").mkdir(parents=True)
+        _write_image(data_dir / "NORMAL" / "IM-0001.jpeg")
+        _write_image(data_dir / "PNEUMONIA" / "IM-0001.jpeg")
+        labels_file = tmp_path / "labels.csv"
+        labels_file.write_text(
+            "image,label\nNORMAL/IM-0001.jpeg,0\nPNEUMONIA/IM-0001.jpeg,1\n"
+        )
+        config = _make_config(
+            str(data_dir),
+            labels_source=str(labels_file),
+            labels_id_column="image",
+            labels_column="label",
+            labels_encoding="index",
+            labels_id_strategy="stem",
+        )
+
+        # Forcing stem mode collapses both rows to the same key → duplicate.
+        with pytest.warns(UserWarning, match="Duplicate label IDs"):
+            data = Data(config)
+        assert data.labels is None
+
+    def test_data_raises_for_unsupported_id_strategy(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "images"
+        data_dir.mkdir()
+        _write_image(data_dir / "x.jpg")
+        labels_file = tmp_path / "labels.csv"
+        labels_file.write_text("image,label\nx,0\n")
+        config = _make_config(
+            str(data_dir),
+            labels_source=str(labels_file),
+            labels_id_column="image",
+            labels_column="label",
+            labels_encoding="index",
+            labels_id_strategy="bogus",
+        )
+
+        with pytest.raises(ValueError, match="Unsupported data.labels.id_strategy"):
+            Data(config)
 
     def test_data_raises_for_unsupported_labels_encoding(self, tmp_path: Path) -> None:
         csv_file = tmp_path / "data.csv"


### PR DESCRIPTION
Closes #95.

## Summary

`data.source` directories are now walked recursively, sample ids are
posix-style paths relative to the source root (e.g.
`NORMAL/IM-0001.jpeg`), and a new `data.labels.id_strategy` knob controls
how label-file ids are matched.

This unblocks consumers using nested `ImageFolder`-style layouts where
filename stems collide across class subdirs (e.g. Kaggle Chest X-Ray
Pneumonia: `NORMAL/IM-0001.jpeg` and `PNEUMONIA/IM-0001.jpeg` both exist).
Previously such users had to flatten + rename in a parallel directory.

## Changes

- `LabelsConfig` gains `id_strategy: str = "auto"` (`"auto"`,
  `"relative_path"`, `"stem"`).
- `_load_images_numpy` / `_load_tabular_dir_numpy` walk recursively
  via `Path.rglob`.
- `_resolve_sample_ids(files, root)` returns relative posix paths.
- `_normalise_sample_id` becomes strategy-aware. `"auto"` inspects the id
  column once and picks `"relative_path"` if any value contains `/` or
  `\`, else `"stem"`.
- 4 new tests in `test_data_class.py` cover nested layouts, auto-detection,
  stem-collision warning under explicit `id_strategy: stem`, and bogus
  strategy rejection.
- Docs: `docs/modules/data/configuration.md`,
  `docs/modules/data/own-vs-built-in.md`, `docs/contributor/data.md`.

## Breaking

- `LabelsConfig` gains a default-valued field — typed instantiations need
  to account for it.
- Sample ids returned from `Data` are now relative posix paths instead of
  bare stems. Downstream code that assumed stem-only ids should normalise
  via `Path(id).stem` themselves, or rely on `id_strategy: "stem"` to keep
  the legacy comparison behaviour for label alignment.

## Test plan

- [x] `uv run pytest src/raitap/data/tests/ -q` — 64 passed.
- [x] `uv run pytest src -q -m "not e2e and not cuda"` — pre-existing 4
      SHAP failures only (missing `shap` extra in venv); unrelated.