### PR TITLE
feat(model)!: state_dict + TorchScript loaders; deprecate pickled nn.Module

### DIFF
--- a/docs/modules/model/configuration.md
+++ b/docs/modules/model/configuration.md
@@ -7,9 +7,42 @@
 :description: Path to a local model file, or a built-in model name such as
   `"resnet50"`. Refer to {doc}`own-vs-built-in` for more details.
 
+:option: arch
+:allowed: string, null
+:default: null
+:description: torchvision architecture name (e.g. `"resnet18"`) used to
+  instantiate the model when `source` points at a state-dict (a `.pt` /
+  `.pth` file produced by `torch.save(model.state_dict(), path)`). Required
+  alongside `num_classes` for state-dict loading; ignored for full pickled
+  modules and TorchScript archives.
+
+:option: num_classes
+:allowed: int, null
+:default: null
+:description: Output classes used to instantiate the architecture before
+  `load_state_dict`. Required together with `arch` for state-dict loading.
+
+:option: pretrained
+:allowed: bool
+:default: false
+:description: If `true`, construct the architecture with ImageNet pretrained
+  weights before loading the state-dict (`weights="DEFAULT"`). Usually
+  `false` since the state-dict already supplies the weights.
+
 :yaml:
+# Option A — full pickled nn.Module (deprecated, fragile across environments):
 model:
   source: "myModel.pth"
+
+# Option B — state_dict + arch (recommended):
+model:
+  source: "weights.pth"
+  arch: "resnet18"
+  num_classes: 2
+
+# Option C — TorchScript archive (env-independent):
+model:
+  source: "scripted.pt"
 
 :cli: model.source=resnet50
 ```

--- a/docs/modules/model/own-vs-built-in.md
+++ b/docs/modules/model/own-vs-built-in.md
@@ -2,15 +2,39 @@
 
 ## Own model
 
-RAITAP allows you to use your own model, in any of the following supported formats:
+RAITAP allows you to use your own model in any of the following supported formats:
 
-- `.pth` (if it contains a `torch.nn.Module` and not just a state-dict)
-- `.pt` (if it contains a `torch.nn.Module` and not just a state-dict)
+- `.pt` / `.pth` containing a `state_dict` — **recommended**. Combine with
+  `model.arch` and `model.num_classes` to instantiate a torchvision
+  architecture and load weights into it. Portable across environments and
+  torchvision versions.
+- `.pt` / `.pth` containing a TorchScript archive (saved via
+  `torch.jit.save(scripted, path)`). Self-contained — no `arch` /
+  `num_classes` needed.
+- `.pt` / `.pth` containing a full pickled `torch.nn.Module` (saved via
+  `torch.save(model, path)`). **Deprecated** — emits a
+  `DeprecationWarning`. The pickle embeds fully-qualified class paths so it
+  breaks when classes are renamed or when torchvision is bumped. Migrate
+  with one line:
+  ```python
+  m = torch.load("model.pth", weights_only=False)
+  torch.save(m.state_dict(), "weights.pth")
+  ```
 - `.onnx`
 
-You simply need to set the `source` option to the path to your model file (see {doc}`configuration`).
+Set the `source` option to the path of your model file (see
+{doc}`configuration`). For state-dict loading also set `arch` and
+`num_classes`:
 
-However, not all modules and underlying libraries support all formats. See each module's library compatibility page for more details.
+```yaml
+model:
+  source: "weights.pth"
+  arch: "resnet18"
+  num_classes: 2
+```
+
+Not all modules and underlying libraries support all formats. See each
+module's library compatibility page for more details.
 
 ## Built-in models
 

--- a/src/raitap/configs/schema.py
+++ b/src/raitap/configs/schema.py
@@ -6,8 +6,19 @@ from typing import Any
 
 @dataclass
 class ModelConfig:
-    # Path to a local .pth file, or a built-in name (e.g. "resnet50")
+    # Path to a local .pt / .pth / .onnx file, or a built-in name (e.g. "resnet50").
     source: str | None = None
+    # Architecture spec used when ``source`` points at a state-dict (``.pt`` /
+    # ``.pth`` containing a ``dict``). Either a torchvision model name (e.g.
+    # ``"resnet18"``) or any value accepted by ``getattr(torchvision.models, ...)``.
+    arch: str | None = None
+    # Number of output classes used to instantiate the architecture before
+    # ``load_state_dict``. Required together with ``arch`` for state-dict loading.
+    num_classes: int | None = None
+    # Whether to construct the architecture with ImageNet pretrained weights
+    # before loading the state-dict. Usually ``False`` since weights come from
+    # the state-dict itself.
+    pretrained: bool = False
 
 
 @dataclass

--- a/src/raitap/configs/schema.py
+++ b/src/raitap/configs/schema.py
@@ -9,8 +9,10 @@ class ModelConfig:
     # Path to a local .pt / .pth / .onnx file, or a built-in name (e.g. "resnet50").
     source: str | None = None
     # Architecture spec used when ``source`` points at a state-dict (``.pt`` /
-    # ``.pth`` containing a ``dict``). Either a torchvision model name (e.g.
-    # ``"resnet18"``) or any value accepted by ``getattr(torchvision.models, ...)``.
+    # ``.pth`` containing a ``dict``). Must be the name of a torchvision model
+    # builder callable that accepts ``weights=`` and ``num_classes=`` kwargs
+    # (e.g. ``"resnet18"``, ``"vit_b_16"``). Other ``torchvision.models``
+    # attributes (constants, helpers) are not valid here.
     arch: str | None = None
     # Number of output classes used to instantiate the architecture before
     # ``load_state_dict``. Required together with ``arch`` for state-dict loading.

--- a/src/raitap/models/README.md
+++ b/src/raitap/models/README.md
@@ -1,5 +1,62 @@
 # Models Module
 
-This module handles loading and converting machine models to the PyTorch format.
+This module loads machine-learning models into a uniform `ModelBackend`
+that downstream RAITAP modules (transparency, metrics, reporting) consume
+without caring about how the model was serialised.
 
-It supports loading pretrained models and local files.
+It supports torchvision built-ins, ONNX archives, and three flavours of
+PyTorch checkpoint.
+
+## Loader behaviour for `.pt` / `.pth`
+
+Order of attempts when `model.source` points at a `.pt` or `.pth` file:
+
+1. **TorchScript** (`torch.jit.load`) — if the file is a TorchScript
+   archive, return the `ScriptModule` as-is. No extra config keys needed.
+2. **state_dict** — if `torch.load` returns a `dict`, RAITAP instantiates
+   a torchvision architecture from `model.arch` + `model.num_classes`,
+   then calls `load_state_dict(strict=True)`.
+3. **Pickled `nn.Module`** — if `torch.load` returns an `nn.Module`,
+   RAITAP returns it directly and emits a `DeprecationWarning`. This path
+   is supported but discouraged: pickled modules embed fully-qualified
+   class paths, so renames or torchvision version bumps break unpickling.
+
+## Config examples
+
+```yaml
+# A — full pickled nn.Module (deprecated):
+model:
+  source: "model.pth"
+
+# B — state_dict + arch (recommended):
+model:
+  source: "weights.pth"
+  arch: "resnet18"
+  num_classes: 2
+  pretrained: false      # default; set true to start from ImageNet weights
+
+# C — TorchScript archive:
+model:
+  source: "scripted.pt"
+
+# D — torchvision built-in (demo / quick test):
+model:
+  source: "resnet50"
+```
+
+## Migrating from pickled to state_dict
+
+```python
+m = torch.load("model.pth", weights_only=False)
+torch.save(m.state_dict(), "weights.pth")
+```
+
+Then set `model.arch` and `model.num_classes` in your config to match the
+architecture that produced the state-dict.
+
+## ONNX
+
+`.onnx` files are loaded via `OnnxBackend.from_path` — see
+`src/raitap/models/backend.py` for the runtime selection logic. ONNX
+backends are restricted to a subset of explainers (see the transparency
+module README).

--- a/src/raitap/models/model.py
+++ b/src/raitap/models/model.py
@@ -123,16 +123,23 @@ def _build_arch_from_config(model_cfg: Any) -> nn.Module:
     return factory(weights=weights, num_classes=num_classes)
 
 
-def _load_torch_module_from_path(
-    path: Path, *, model_cfg: Any, device: torch.device
-) -> nn.Module:
+def _load_torch_module_from_path(path: Path, *, model_cfg: Any, device: torch.device) -> nn.Module:
     scripted = _try_torchscript_load(path)
     if scripted is not None:
         scripted.to(device)
         scripted.eval()
         return scripted
 
-    obj = torch.load(path, map_location="cpu", weights_only=False)
+    # Try the safe path first: `weights_only=True` only deserialises tensors and
+    # state-dicts, refusing arbitrary pickled objects (no code execution risk).
+    # Pickled `nn.Module` checkpoints fail this and fall through to the
+    # deprecated unsafe path below.
+    pickled_module = False
+    try:
+        obj: Any = torch.load(path, map_location="cpu", weights_only=True)
+    except Exception:
+        pickled_module = True
+        obj = torch.load(path, map_location="cpu", weights_only=False)
 
     if isinstance(obj, dict):
         module = _build_arch_from_config(model_cfg)
@@ -142,14 +149,16 @@ def _load_torch_module_from_path(
         return module
 
     if isinstance(obj, nn.Module):
-        warnings.warn(
-            f"Loading pickled nn.Module from {path}: this format is fragile across "
-            "environments and torchvision versions. Prefer "
-            "`torch.save(model.state_dict(), path)` with model.arch + "
-            "model.num_classes set in the config, or `torch.jit.save(scripted, path)`.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        if pickled_module:
+            warnings.warn(
+                f"Loading pickled nn.Module from {path}: this format is fragile across "
+                "environments and torchvision versions, and requires unsafe pickle "
+                "deserialisation. Prefer `torch.save(model.state_dict(), path)` with "
+                "model.arch + model.num_classes set in the config, or "
+                "`torch.jit.save(scripted, path)`.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         obj.to(device)
         obj.eval()
         return obj

--- a/src/raitap/models/model.py
+++ b/src/raitap/models/model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -34,7 +35,7 @@ class Model(Trackable):
         suffix = path.suffix.lower()
 
         if path.exists() or suffix:
-            return _load_from_path(path, hardware=hardware)
+            return _load_from_path(path, model_cfg=config.model, hardware=hardware)
 
         name = str(source).lower()
         if hasattr(models, name):
@@ -51,12 +52,15 @@ class Model(Trackable):
         tracker.log_model(self.backend)
 
 
-def _load_from_path(path: Path, *, hardware: str) -> ModelBackend:
+def _load_from_path(path: Path, *, model_cfg: Any, hardware: str) -> ModelBackend:
     """
     Load a model backend from a file path.
 
     Args:
         path: Path to the model file.
+        model_cfg: ``ModelConfig``-shaped object providing ``arch``,
+            ``num_classes``, and ``pretrained`` for state-dict loading.
+        hardware: Hardware label resolved into a device.
 
     Returns:
         Model backend ready for inference and explanation.
@@ -73,7 +77,8 @@ def _load_from_path(path: Path, *, hardware: str) -> ModelBackend:
 
     if path.suffix.lower() in {".pth", ".pt"}:
         device = resolve_torch_device(hardware)
-        return TorchBackend(_load_torch_module_from_path(path, device=device), device=device)
+        module = _load_torch_module_from_path(path, model_cfg=model_cfg, device=device)
+        return TorchBackend(module, device=device)
 
     raise ValueError(
         f"Unsupported model format {path.suffix!r}. Supported formats: {_supported_model_formats()}"
@@ -90,7 +95,37 @@ def _try_torchscript_load(path: Path) -> nn.Module | None:
     return scripted
 
 
-def _load_torch_module_from_path(path: Path, *, device: torch.device) -> nn.Module:
+def _build_arch_from_config(model_cfg: Any) -> nn.Module:
+    """Instantiate a torchvision architecture from ``model_cfg`` for state-dict loading."""
+    arch = getattr(model_cfg, "arch", None)
+    num_classes = getattr(model_cfg, "num_classes", None)
+    pretrained = bool(getattr(model_cfg, "pretrained", False))
+
+    missing = [
+        name for name, value in (("arch", arch), ("num_classes", num_classes)) if value is None
+    ]
+    if missing:
+        raise ValueError(
+            "State-dict loading requires model."
+            + " and model.".join(missing)
+            + ". Set them in your config, e.g.:\n"
+            "  model:\n"
+            "    source: path/to/weights.pth\n"
+            "    arch: resnet18\n"
+            "    num_classes: 2"
+        )
+
+    factory = getattr(models, arch, None)
+    if factory is None:
+        raise ValueError(f"model.arch {arch!r} is not a known torchvision model.")
+
+    weights = "DEFAULT" if pretrained else None
+    return factory(weights=weights, num_classes=num_classes)
+
+
+def _load_torch_module_from_path(
+    path: Path, *, model_cfg: Any, device: torch.device
+) -> nn.Module:
     scripted = _try_torchscript_load(path)
     if scripted is not None:
         scripted.to(device)
@@ -100,18 +135,26 @@ def _load_torch_module_from_path(path: Path, *, device: torch.device) -> nn.Modu
     obj = torch.load(path, map_location="cpu", weights_only=False)
 
     if isinstance(obj, dict):
-        raise ValueError(
-            f"{path} appears to contain a state-dict, not a full model.\n"
-            "Save the full model with torch.save(model, path) or load the "
-            "state-dict manually and pass the model directly to the explainer."
+        module = _build_arch_from_config(model_cfg)
+        module.load_state_dict(obj, strict=True)
+        module.to(device)
+        module.eval()
+        return module
+
+    if isinstance(obj, nn.Module):
+        warnings.warn(
+            f"Loading pickled nn.Module from {path}: this format is fragile across "
+            "environments and torchvision versions. Prefer "
+            "`torch.save(model.state_dict(), path)` with model.arch + "
+            "model.num_classes set in the config, or `torch.jit.save(scripted, path)`.",
+            DeprecationWarning,
+            stacklevel=2,
         )
+        obj.to(device)
+        obj.eval()
+        return obj
 
-    if not isinstance(obj, nn.Module):
-        raise ValueError(f"Expected an nn.Module in {path}, got {type(obj).__name__}.")
-
-    obj.to(device)
-    obj.eval()
-    return obj
+    raise ValueError(f"Expected an nn.Module or state-dict in {path}, got {type(obj).__name__}.")
 
 
 def _load_pretrained(model_name: str, *, hardware: str) -> ModelBackend:

--- a/src/raitap/models/model.py
+++ b/src/raitap/models/model.py
@@ -80,7 +80,23 @@ def _load_from_path(path: Path, *, hardware: str) -> ModelBackend:
     )
 
 
+def _try_torchscript_load(path: Path) -> nn.Module | None:
+    """Try to load *path* as a TorchScript archive; return ``None`` if it isn't one."""
+    try:
+        scripted = torch.jit.load(str(path), map_location="cpu")
+    except RuntimeError:
+        # Not a TorchScript archive — fall back to the regular torch.load path.
+        return None
+    return scripted
+
+
 def _load_torch_module_from_path(path: Path, *, device: torch.device) -> nn.Module:
+    scripted = _try_torchscript_load(path)
+    if scripted is not None:
+        scripted.to(device)
+        scripted.eval()
+        return scripted
+
     obj = torch.load(path, map_location="cpu", weights_only=False)
 
     if isinstance(obj, dict):

--- a/src/raitap/models/model.py
+++ b/src/raitap/models/model.py
@@ -97,8 +97,8 @@ def _try_torchscript_load(path: Path) -> nn.Module | None:
 
 def _build_arch_from_config(model_cfg: Any) -> nn.Module:
     """Instantiate a torchvision architecture from ``model_cfg`` for state-dict loading."""
-    arch = getattr(model_cfg, "arch", None)
-    num_classes = getattr(model_cfg, "num_classes", None)
+    arch: str | None = getattr(model_cfg, "arch", None)
+    num_classes: int | None = getattr(model_cfg, "num_classes", None)
     pretrained = bool(getattr(model_cfg, "pretrained", False))
 
     missing = [
@@ -114,6 +114,7 @@ def _build_arch_from_config(model_cfg: Any) -> nn.Module:
             "    arch: resnet18\n"
             "    num_classes: 2"
         )
+    assert arch is not None and num_classes is not None  # narrowed by `missing` check
 
     factory = getattr(models, arch, None)
     if factory is None:

--- a/src/raitap/models/tests/test_model_class.py
+++ b/src/raitap/models/tests/test_model_class.py
@@ -18,13 +18,24 @@ from raitap.models import Model
 from raitap.models.backend import TorchBackend
 
 
-def _make_config(source: str) -> AppConfig:
+def _make_config(
+    source: str,
+    *,
+    arch: str | None = None,
+    num_classes: int | None = None,
+    pretrained: bool = False,
+    hardware: str = "cpu",
+) -> AppConfig:
     return cast(
         "AppConfig",
         SimpleNamespace(
             model=SimpleNamespace(
                 source=source,
-            )
+                arch=arch,
+                num_classes=num_classes,
+                pretrained=pretrained,
+            ),
+            hardware=hardware,
         ),
     )
 
@@ -44,9 +55,62 @@ class TestModelConstructor:
         torch.save(dummy_model, model_path)
 
         config = _make_config(str(model_path))
-        model = Model(config)
+        with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
+            model = Model(config)
 
         assert isinstance(model.backend.as_model_for_explanation(), torch.nn.Module)
+
+    def test_model_loads_from_state_dict(self, tmp_path: Path) -> None:
+        from torchvision import models as tv_models
+
+        ref = tv_models.resnet18(weights=None, num_classes=2)
+        model_path = tmp_path / "weights.pth"
+        torch.save(ref.state_dict(), model_path)
+
+        config = _make_config(str(model_path), arch="resnet18", num_classes=2)
+        model = Model(config)
+
+        loaded = model.backend.as_model_for_explanation()
+        assert loaded.__class__.__name__ == "ResNet"
+        # State dict round-trips: parameters should compare equal.
+        for (n1, p1), (n2, p2) in zip(
+            ref.state_dict().items(), loaded.state_dict().items(), strict=True
+        ):
+            assert n1 == n2
+            assert torch.equal(p1, p2.cpu())
+
+    def test_model_state_dict_without_arch_raises(self, tmp_path: Path) -> None:
+        ref = torch.nn.Linear(4, 2)
+        model_path = tmp_path / "weights.pth"
+        torch.save(ref.state_dict(), model_path)
+
+        config = _make_config(str(model_path))  # no arch / num_classes
+        with pytest.raises(ValueError, match="State-dict loading requires"):
+            Model(config)
+
+    def test_model_state_dict_with_unknown_arch_raises(self, tmp_path: Path) -> None:
+        ref = torch.nn.Linear(4, 2)
+        model_path = tmp_path / "weights.pth"
+        torch.save(ref.state_dict(), model_path)
+
+        config = _make_config(str(model_path), arch="not_a_model", num_classes=2)
+        with pytest.raises(ValueError, match="not a known torchvision model"):
+            Model(config)
+
+    def test_model_loads_torchscript_file(self, tmp_path: Path) -> None:
+        ref = torch.nn.Linear(4, 2).eval()
+        scripted = torch.jit.script(ref)
+        model_path = tmp_path / "scripted.pt"
+        scripted.save(str(model_path))
+
+        config = _make_config(str(model_path))
+        model = Model(config)
+
+        loaded = model.backend.as_model_for_explanation()
+        assert isinstance(loaded, torch.jit.ScriptModule)
+        # Sanity: forward pass produces same output as the eager reference.
+        x = torch.randn(3, 4)
+        torch.testing.assert_close(loaded(x), ref(x))
 
     def test_model_raises_if_source_is_none(self) -> None:
         config = _make_config("")

--- a/src/raitap/models/tests/test_models.py
+++ b/src/raitap/models/tests/test_models.py
@@ -50,14 +50,30 @@ def _as_inference_session(session: _FakeOnnxSession) -> ort.InferenceSession:
     return cast("ort.InferenceSession", session)
 
 
-def _make_config(source: str, *, hardware: str = "gpu") -> AppConfig:
+def _make_config(
+    source: str,
+    *,
+    hardware: str = "gpu",
+    arch: str | None = None,
+    num_classes: int | None = None,
+    pretrained: bool = False,
+) -> AppConfig:
     return cast(
         "AppConfig",
         type(
             "AppConfig",
             (),
             {
-                "model": type("ModelConfig", (), {"source": source})(),
+                "model": type(
+                    "ModelConfig",
+                    (),
+                    {
+                        "source": source,
+                        "arch": arch,
+                        "num_classes": num_classes,
+                        "pretrained": pretrained,
+                    },
+                )(),
                 "hardware": hardware,
             },
         )(),
@@ -125,19 +141,22 @@ def saved_onnx(tmp_path: Path) -> Path:
 class TestLoadModelFromPath:
     def test_loads_pth_file(self, saved_pth: Path) -> None:
         cfg = _make_config(str(saved_pth))
-        model = Model(cfg)
+        with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
+            model = Model(cfg)
         assert isinstance(model.backend, TorchBackend)
         assert isinstance(model.backend.as_model_for_explanation(), nn.Module)
 
     def test_loads_pt_file(self, saved_pt: Path) -> None:
         cfg = _make_config(str(saved_pt))
-        model = Model(cfg)
+        with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
+            model = Model(cfg)
         assert isinstance(model.backend, TorchBackend)
         assert isinstance(model.backend.as_model_for_explanation(), nn.Module)
 
     def test_returns_eval_mode(self, saved_pth: Path) -> None:
         cfg = _make_config(str(saved_pth))
-        model = Model(cfg).backend.as_model_for_explanation()
+        with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
+            model = Model(cfg).backend.as_model_for_explanation()
         assert not model.training
 
     def test_missing_file_raises_file_not_found(self, tmp_path: Path) -> None:
@@ -152,16 +171,59 @@ class TestLoadModelFromPath:
         with pytest.raises(ValueError, match="Unsupported model format"):
             Model(cfg)
 
-    def test_state_dict_raises_value_error(self, saved_state_dict: Path) -> None:
+    def test_state_dict_loads_with_arch_and_num_classes(self, tmp_path: Path) -> None:
+        from torchvision import models as tv_models
+
+        ref = tv_models.resnet18(weights=None, num_classes=3)
+        path = tmp_path / "weights.pth"
+        torch.save(ref.state_dict(), path)
+        cfg = _make_config(str(path), arch="resnet18", num_classes=3)
+        model = Model(cfg)
+        assert isinstance(model.backend, TorchBackend)
+        loaded = model.backend.as_model_for_explanation()
+        # Round-trip: identical parameter values.
+        for k, v in ref.state_dict().items():
+            assert torch.equal(v, loaded.state_dict()[k].cpu())
+
+    def test_state_dict_without_arch_raises(self, saved_state_dict: Path) -> None:
         cfg = _make_config(str(saved_state_dict))
-        with pytest.raises(ValueError, match="state-dict"):
+        with pytest.raises(ValueError, match="State-dict loading requires"):
+            Model(cfg)
+
+    def test_state_dict_with_mismatched_num_classes_raises(self, tmp_path: Path) -> None:
+        from torchvision import models as tv_models
+
+        ref = tv_models.resnet18(weights=None, num_classes=10)
+        path = tmp_path / "weights.pth"
+        torch.save(ref.state_dict(), path)
+        cfg = _make_config(str(path), arch="resnet18", num_classes=2)
+        with pytest.raises(RuntimeError, match=r"size mismatch|shape"):
+            Model(cfg)
+
+    def test_torchscript_load_via_jit(self, tmp_path: Path) -> None:
+        ref = nn.Linear(4, 2).eval()
+        scripted = torch.jit.script(ref)
+        path = tmp_path / "scripted.pt"
+        scripted.save(str(path))
+        cfg = _make_config(str(path), hardware="cpu")
+        loaded = Model(cfg).backend.as_model_for_explanation()
+        assert isinstance(loaded, torch.jit.ScriptModule)
+        x = torch.randn(2, 4)
+        torch.testing.assert_close(loaded(x), ref(x))
+
+    def test_pickled_module_load_emits_deprecation_warning(self, saved_pth: Path) -> None:
+        cfg = _make_config(str(saved_pth))
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"Loading pickled nn\.Module.*Prefer.*state_dict",
+        ):
             Model(cfg)
 
     def test_non_module_object_raises_value_error(self, tmp_path: Path) -> None:
         path = tmp_path / "tensor.pth"
         torch.save(torch.randn(3, 3), path)
         cfg = _make_config(str(path))
-        with pytest.raises(ValueError, match=r"Expected an nn\.Module"):
+        with pytest.raises(ValueError, match=r"Expected an nn\.Module or state-dict"):
             Model(cfg)
 
     def test_loads_onnx_file(self, saved_onnx: Path) -> None:


### PR DESCRIPTION
Closes #96.

## Summary

`.pt` / `.pth` files are now dispatched by content:

1. **TorchScript** archives (`torch.jit.save`) — loaded via
   `torch.jit.load`, returned as `ScriptModule`. No extra config needed.
2. **state_dict** (a `dict` from `torch.load`) — instantiates a
   torchvision architecture from new `model.arch` + `model.num_classes`
   keys and calls `load_state_dict(strict=True)`.
3. **Pickled `nn.Module`** — still supported, but now emits a
   `DeprecationWarning` pointing users at state_dict / TorchScript. This
   format embeds fully-qualified class paths, so it breaks across
   torchvision bumps and module renames.

## Why

State_dict is the PyTorch-recommended portable format. The old loader
rejected state_dicts outright, forcing every consumer to ship a pickled
full module — which is fragile across environments. TorchScript was also
unreachable.

## Changes

- `ModelConfig` gains `arch: str | None`, `num_classes: int | None`,
  `pretrained: bool = False`.
- `_load_torch_module_from_path` rewritten as a 3-way dispatch.
- `_load_from_path` signature now takes the full `ModelConfig` (was
  only `path` + `hardware`).
- `Model._load_model` passes `config.model` through.
- New helpers: `_try_torchscript_load`, `_build_arch_from_config`.
- Tests:
  - 4 new in `test_model_class.py`: state_dict load + round-trip,
    missing arch raises, unknown arch raises, TorchScript load.
  - 4 new in `test_models.py`: state_dict load + round-trip,
    state_dict-without-arch raises, mismatched num_classes raises,
    pickled-load deprecation warning.
  - Updated existing pickled-load tests to wrap in
    `pytest.warns(DeprecationWarning)`.
- Docs: `src/raitap/models/README.md` (expanded from 4 lines),
  `docs/modules/model/configuration.md`,
  `docs/modules/model/own-vs-built-in.md`.

## Breaking

- `ModelConfig` gains 3 new default-valued fields; typed instantiations
  need to account for them.
- `_load_from_path` private helper changed signature. External callers
  (none expected — it's underscore-prefixed) need to pass `model_cfg`.
- Pickled-module loads now emit a `DeprecationWarning`. Tests / strict
  warning filters in downstream code may need updates.

## Test plan

- [x] `uv run pytest src/raitap/models/tests/ -q` — 37 passed.
- [x] `uv run pytest src -q -m "not e2e and not cuda"
       --ignore=src/raitap/transparency` — 247 passed.