### PR TITLE
fix(data): suggest id_strategy in label-alignment error messages

### DIFF
--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -547,9 +547,7 @@ def _align_labels_to_samples(
 ) -> list[int]:
     raw_label_ids_list = raw_label_ids.tolist()
     normalised_sample_ids = [_normalise_sample_id(sid, strategy) for sid in sample_ids]
-    normalised_label_ids = [
-        _normalise_sample_id(raw_id, strategy) for raw_id in raw_label_ids_list
-    ]
+    normalised_label_ids = [_normalise_sample_id(raw_id, strategy) for raw_id in raw_label_ids_list]
     duplicates = sorted(
         [row_id for row_id, count in Counter(normalised_label_ids).items() if count > 1]
     )
@@ -582,9 +580,7 @@ def _align_labels_to_samples(
         # a strategy mismatch. Inspect the *raw* (pre-normalisation) inputs
         # since normalised ids no longer carry separators.
         samples_have_separators = any("/" in s or "\\" in s for s in sample_ids)
-        labels_have_separators = any(
-            "/" in str(r) or "\\" in str(r) for r in raw_label_ids_list
-        )
+        labels_have_separators = any("/" in str(r) or "\\" in str(r) for r in raw_label_ids_list)
         hint = ""
         if strategy == "relative_path" and samples_have_separators and not labels_have_separators:
             hint = (

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -583,13 +583,20 @@ def _align_labels_to_samples(
             "/" in str(r) or "\\" in str(r) for r in raw_label_ids.tolist()
         )
         hint = ""
-        if strategy == "stem" and (samples_have_separators or labels_have_separators):
+        # Asymmetric separator presence is a strong signal of strategy
+        # mismatch: only one side carries directory components, so stem-mode
+        # normalisation will line up neither across samples nor against labels.
+        # When both sides have (or both lack) separators, stem stripping is
+        # consistent and any missing rows are a genuine data/label gap, not a
+        # strategy issue — suppress the hint there.
+        if strategy == "stem" and samples_have_separators != labels_have_separators:
             hint = (
-                " Hint: raw ids include path separators but id_strategy='stem' "
-                "strips directory components, so different files with the same "
-                "filename normalise to the same key. Set "
-                "data.labels.id_strategy=relative_path (or =auto, the default) "
-                "to match by relative path."
+                " Hint: raw ids on one side carry path separators while the "
+                "other side doesn't, so stem-mode normalisation drops the "
+                "directory components asymmetrically and the keys never line "
+                "up. Set data.labels.id_strategy=relative_path "
+                "(or =auto, the default) to match by relative path on both "
+                "sides."
             )
         elif strategy == "relative_path" and samples_have_separators and not labels_have_separators:
             hint = (

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -575,20 +575,36 @@ def _align_labels_to_samples(
     if missing_ids:
         preview = ", ".join(missing_ids[:5])
         more = "..." if len(missing_ids) > 5 else ""
+        # Inspect the *raw* (pre-normalisation) inputs to diagnose strategy
+        # mismatch. Normalised ids no longer carry separators in stem mode,
+        # so we have to look at what the user actually supplied.
+        samples_have_separators = any("/" in s or "\\" in s for s in sample_ids)
+        labels_have_separators = any(
+            "/" in str(r) or "\\" in str(r) for r in raw_label_ids.tolist()
+        )
         hint = ""
-        looks_like_path = any("/" in sid or "\\" in sid for sid in missing_ids)
-        if strategy == "stem" and looks_like_path:
+        if strategy == "stem" and (samples_have_separators or labels_have_separators):
             hint = (
-                " Hint: sample ids include path separators but id_strategy='stem' "
-                "strips directory components. Set data.labels.id_strategy=relative_path "
-                "(or =auto, the default)."
+                " Hint: raw ids include path separators but id_strategy='stem' "
+                "strips directory components, so different files with the same "
+                "filename normalise to the same key. Set "
+                "data.labels.id_strategy=relative_path (or =auto, the default) "
+                "to match by relative path."
             )
-        elif strategy == "relative_path" and not looks_like_path:
+        elif strategy == "relative_path" and samples_have_separators and not labels_have_separators:
             hint = (
-                " Hint: under id_strategy='relative_path', label ids must include "
-                "directory components matching data.source's subdir layout "
-                "(e.g. 'NORMAL/IM-0001.jpeg'). For flat-dir layouts, use "
-                "id_strategy=stem (or =auto, the default)."
+                " Hint: data.source has a nested layout (sample ids contain "
+                "path separators) but label ids don't — under "
+                "id_strategy='relative_path' both sides must use the same "
+                "relative-path form (e.g. 'NORMAL/IM-0001.jpeg'). Either add "
+                "the directory prefix to your label ids, or use "
+                "id_strategy=stem to match by basename only."
+            )
+        elif strategy == "relative_path" and labels_have_separators and not samples_have_separators:
+            hint = (
+                " Hint: label ids contain path separators but data.source is "
+                "flat (sample ids don't). Drop the directory prefix from the "
+                "label ids, or use id_strategy=stem to match by basename only."
             )
         raise ValueError(
             f"Missing labels for some sample IDs ({preview}{more}) under "

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -554,8 +554,17 @@ def _align_labels_to_samples(
     )
     if duplicates:
         preview = ", ".join(duplicates[:5])
+        more = "..." if len(duplicates) > 5 else ""
+        hint = ""
+        if strategy == "stem":
+            hint = (
+                " Hint: stem-only matching collapses ids that share a filename "
+                "across subdirs (e.g. NORMAL/IM-0001.jpeg vs PNEUMONIA/IM-0001.jpeg). "
+                "Set data.labels.id_strategy=relative_path (or =auto, the default) "
+                "and use posix-style relative paths in the id column."
+            )
         raise ValueError(
-            f"Duplicate label IDs detected ({preview}{'...' if len(duplicates) > 5 else ''})."
+            f"Duplicate label IDs detected ({preview}{more}) under id_strategy={strategy!r}.{hint}"
         )
 
     label_by_id = {
@@ -565,9 +574,25 @@ def _align_labels_to_samples(
     missing_ids = [sid for sid in normalised_sample_ids if sid not in label_by_id]
     if missing_ids:
         preview = ", ".join(missing_ids[:5])
+        more = "..." if len(missing_ids) > 5 else ""
+        hint = ""
+        looks_like_path = any("/" in sid or "\\" in sid for sid in missing_ids)
+        if strategy == "stem" and looks_like_path:
+            hint = (
+                " Hint: sample ids include path separators but id_strategy='stem' "
+                "strips directory components. Set data.labels.id_strategy=relative_path "
+                "(or =auto, the default)."
+            )
+        elif strategy == "relative_path" and not looks_like_path:
+            hint = (
+                " Hint: under id_strategy='relative_path', label ids must include "
+                "directory components matching data.source's subdir layout "
+                "(e.g. 'NORMAL/IM-0001.jpeg'). For flat-dir layouts, use "
+                "id_strategy=stem (or =auto, the default)."
+            )
         raise ValueError(
-            "Missing labels for some sample IDs "
-            f"({preview}{'...' if len(missing_ids) > 5 else ''})."
+            f"Missing labels for some sample IDs ({preview}{more}) under "
+            f"id_strategy={strategy!r}.{hint}"
         )
     return [label_by_id[sid] for sid in normalised_sample_ids]
 

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -545,9 +545,10 @@ def _align_labels_to_samples(
     encoded_labels: list[int],
     strategy: str = "stem",
 ) -> list[int]:
+    raw_label_ids_list = raw_label_ids.tolist()
     normalised_sample_ids = [_normalise_sample_id(sid, strategy) for sid in sample_ids]
     normalised_label_ids = [
-        _normalise_sample_id(raw_id, strategy) for raw_id in raw_label_ids.tolist()
+        _normalise_sample_id(raw_id, strategy) for raw_id in raw_label_ids_list
     ]
     duplicates = sorted(
         [row_id for row_id, count in Counter(normalised_label_ids).items() if count > 1]
@@ -582,7 +583,7 @@ def _align_labels_to_samples(
         # since normalised ids no longer carry separators.
         samples_have_separators = any("/" in s or "\\" in s for s in sample_ids)
         labels_have_separators = any(
-            "/" in str(r) or "\\" in str(r) for r in raw_label_ids.tolist()
+            "/" in str(r) or "\\" in str(r) for r in raw_label_ids_list
         )
         hint = ""
         if strategy == "relative_path" and samples_have_separators and not labels_have_separators:

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -575,30 +575,17 @@ def _align_labels_to_samples(
     if missing_ids:
         preview = ", ".join(missing_ids[:5])
         more = "..." if len(missing_ids) > 5 else ""
-        # Inspect the *raw* (pre-normalisation) inputs to diagnose strategy
-        # mismatch. Normalised ids no longer carry separators in stem mode,
-        # so we have to look at what the user actually supplied.
+        # Strategy hints only fire under ``relative_path`` — stem mode strips
+        # directory components from both sides symmetrically, so a missing
+        # match means basenames don't line up (genuine data/label gap), not
+        # a strategy mismatch. Inspect the *raw* (pre-normalisation) inputs
+        # since normalised ids no longer carry separators.
         samples_have_separators = any("/" in s or "\\" in s for s in sample_ids)
         labels_have_separators = any(
             "/" in str(r) or "\\" in str(r) for r in raw_label_ids.tolist()
         )
         hint = ""
-        # Asymmetric separator presence is a strong signal of strategy
-        # mismatch: only one side carries directory components, so stem-mode
-        # normalisation will line up neither across samples nor against labels.
-        # When both sides have (or both lack) separators, stem stripping is
-        # consistent and any missing rows are a genuine data/label gap, not a
-        # strategy issue — suppress the hint there.
-        if strategy == "stem" and samples_have_separators != labels_have_separators:
-            hint = (
-                " Hint: raw ids on one side carry path separators while the "
-                "other side doesn't, so stem-mode normalisation drops the "
-                "directory components asymmetrically and the keys never line "
-                "up. Set data.labels.id_strategy=relative_path "
-                "(or =auto, the default) to match by relative path on both "
-                "sides."
-            )
-        elif strategy == "relative_path" and samples_have_separators and not labels_have_separators:
+        if strategy == "relative_path" and samples_have_separators and not labels_have_separators:
             hint = (
                 " Hint: data.source has a nested layout (sample ids contain "
                 "path separators) but label ids don't — under "

--- a/src/raitap/data/tests/test_data_class.py
+++ b/src/raitap/data/tests/test_data_class.py
@@ -276,17 +276,16 @@ class TestDataConstructor:
         # Hint pins the specific direction: nested data, flat labels.
         assert any("Missing labels" in m and "nested layout" in m for m in msgs)
 
-    def test_data_missing_label_hint_for_flat_labels_under_relative_path(
+    def test_data_missing_label_hint_for_nested_labels_flat_samples(
         self, tmp_path: Path
     ) -> None:
-        # Mirror of the nested-samples test, expressed as a separate scenario
-        # to exercise the second relative_path hint branch (label-side flat
-        # ids, sample-side path ids).
+        # Inverse direction: flat data dir + label ids carrying directory
+        # prefixes. Exercises the second relative_path hint branch.
         data_dir = tmp_path / "images"
-        (data_dir / "PNEUMONIA").mkdir(parents=True)
-        _write_image(data_dir / "PNEUMONIA" / "Y.jpeg")
+        data_dir.mkdir()
+        _write_image(data_dir / "Y.jpeg")
         labels_file = tmp_path / "labels.csv"
-        labels_file.write_text("image,label\nY.jpeg,0\n")
+        labels_file.write_text("image,label\nPNEUMONIA/Y.jpeg,0\n")
         config = _make_config(
             str(data_dir),
             labels_source=str(labels_file),
@@ -300,7 +299,10 @@ class TestDataConstructor:
             data = Data(config)
         assert data.labels is None
         msgs = [str(w.message) for w in record]
-        assert any("Missing labels" in m and "nested layout" in m for m in msgs)
+        assert any(
+            "Missing labels" in m and "label ids contain path separators" in m
+            for m in msgs
+        )
 
     def test_data_missing_label_no_hint_under_stem_mode(self, tmp_path: Path) -> None:
         # Stem mode strips dirs symmetrically, so a missing match is a real

--- a/src/raitap/data/tests/test_data_class.py
+++ b/src/raitap/data/tests/test_data_class.py
@@ -276,9 +276,7 @@ class TestDataConstructor:
         # Hint pins the specific direction: nested data, flat labels.
         assert any("Missing labels" in m and "nested layout" in m for m in msgs)
 
-    def test_data_missing_label_hint_for_nested_labels_flat_samples(
-        self, tmp_path: Path
-    ) -> None:
+    def test_data_missing_label_hint_for_nested_labels_flat_samples(self, tmp_path: Path) -> None:
         # Inverse direction: flat data dir + label ids carrying directory
         # prefixes. Exercises the second relative_path hint branch.
         data_dir = tmp_path / "images"
@@ -299,10 +297,7 @@ class TestDataConstructor:
             data = Data(config)
         assert data.labels is None
         msgs = [str(w.message) for w in record]
-        assert any(
-            "Missing labels" in m and "label ids contain path separators" in m
-            for m in msgs
-        )
+        assert any("Missing labels" in m and "label ids contain path separators" in m for m in msgs)
 
     def test_data_missing_label_no_hint_under_stem_mode(self, tmp_path: Path) -> None:
         # Stem mode strips dirs symmetrically, so a missing match is a real

--- a/src/raitap/data/tests/test_data_class.py
+++ b/src/raitap/data/tests/test_data_class.py
@@ -299,8 +299,42 @@ class TestDataConstructor:
             data = Data(config)
         assert data.labels is None
         msgs = [str(w.message) for w in record]
-        # Hint pins stem-mode + relative_path remediation.
-        assert any("Missing labels" in m and "id_strategy=relative_path" in m for m in msgs)
+        # Hint pins stem-mode + relative_path remediation, plus the
+        # asymmetric-separator wording that distinguishes strategy mismatch
+        # from a generic data gap.
+        assert any(
+            "Missing labels" in m and "id_strategy=relative_path" in m and "asymmetrically" in m
+            for m in msgs
+        )
+
+    def test_data_missing_label_no_strategy_hint_when_separators_match(
+        self, tmp_path: Path
+    ) -> None:
+        # Genuine data gap (sample exists on disk but no matching label row),
+        # not a strategy mismatch — both sides use the same separator style.
+        # Hint should NOT fire to avoid misleading the user.
+        data_dir = tmp_path / "images"
+        data_dir.mkdir()
+        _write_image(data_dir / "X.jpeg")
+        _write_image(data_dir / "Y.jpeg")
+        labels_file = tmp_path / "labels.csv"
+        labels_file.write_text("image,label\nX.jpeg,0\n")  # Y missing entirely
+        config = _make_config(
+            str(data_dir),
+            labels_source=str(labels_file),
+            labels_id_column="image",
+            labels_column="label",
+            labels_encoding="index",
+            labels_id_strategy="stem",
+        )
+
+        with pytest.warns(UserWarning) as record:
+            data = Data(config)
+        assert data.labels is None
+        msgs = [str(w.message) for w in record]
+        assert any("Missing labels" in m for m in msgs)
+        # No strategy hint — neither side carries separators.
+        assert not any("id_strategy=relative_path" in m for m in msgs)
 
     def test_data_raises_for_unsupported_id_strategy(self, tmp_path: Path) -> None:
         data_dir = tmp_path / "images"

--- a/src/raitap/data/tests/test_data_class.py
+++ b/src/raitap/data/tests/test_data_class.py
@@ -243,9 +243,37 @@ class TestDataConstructor:
         )
 
         # Forcing stem mode collapses both rows to the same key → duplicate.
-        with pytest.warns(UserWarning, match="Duplicate label IDs"):
+        with pytest.warns(UserWarning) as record:
             data = Data(config)
         assert data.labels is None
+        # Error message hints at id_strategy + suggests relative_path.
+        msgs = [str(w.message) for w in record]
+        assert any("Duplicate label IDs" in m for m in msgs)
+        assert any("id_strategy" in m and "relative_path" in m for m in msgs)
+
+    def test_data_missing_label_error_hints_at_id_strategy(self, tmp_path: Path) -> None:
+        # Nested data + flat label ids + forced relative_path → mismatch.
+        # Sample ids come back as 'NORMAL/IM-0001' (with subdir) but labels
+        # only carry 'IM-0001' (no subdir) → missing under strict path matching.
+        data_dir = tmp_path / "images"
+        (data_dir / "NORMAL").mkdir(parents=True)
+        _write_image(data_dir / "NORMAL" / "IM-0001.jpeg")
+        labels_file = tmp_path / "labels.csv"
+        labels_file.write_text("image,label\nIM-0001.jpeg,0\n")
+        config = _make_config(
+            str(data_dir),
+            labels_source=str(labels_file),
+            labels_id_column="image",
+            labels_column="label",
+            labels_encoding="index",
+            labels_id_strategy="relative_path",
+        )
+
+        with pytest.warns(UserWarning) as record:
+            data = Data(config)
+        assert data.labels is None
+        msgs = [str(w.message) for w in record]
+        assert any("Missing labels" in m and "id_strategy" in m for m in msgs)
 
     def test_data_raises_for_unsupported_id_strategy(self, tmp_path: Path) -> None:
         data_dir = tmp_path / "images"

--- a/src/raitap/data/tests/test_data_class.py
+++ b/src/raitap/data/tests/test_data_class.py
@@ -246,15 +246,15 @@ class TestDataConstructor:
         with pytest.warns(UserWarning) as record:
             data = Data(config)
         assert data.labels is None
-        # Error message hints at id_strategy + suggests relative_path.
         msgs = [str(w.message) for w in record]
         assert any("Duplicate label IDs" in m for m in msgs)
-        assert any("id_strategy" in m and "relative_path" in m for m in msgs)
+        # Hint pins the specific guidance: switch strategy + use relative paths.
+        assert any(
+            "id_strategy=relative_path" in m and "stem-only matching collapses" in m for m in msgs
+        )
 
-    def test_data_missing_label_error_hints_at_id_strategy(self, tmp_path: Path) -> None:
-        # Nested data + flat label ids + forced relative_path → mismatch.
-        # Sample ids come back as 'NORMAL/IM-0001' (with subdir) but labels
-        # only carry 'IM-0001' (no subdir) → missing under strict path matching.
+    def test_data_missing_label_hint_for_nested_samples_flat_labels(self, tmp_path: Path) -> None:
+        # Nested data + flat label ids under relative_path → strategy mismatch.
         data_dir = tmp_path / "images"
         (data_dir / "NORMAL").mkdir(parents=True)
         _write_image(data_dir / "NORMAL" / "IM-0001.jpeg")
@@ -273,7 +273,34 @@ class TestDataConstructor:
             data = Data(config)
         assert data.labels is None
         msgs = [str(w.message) for w in record]
-        assert any("Missing labels" in m and "id_strategy" in m for m in msgs)
+        # Hint pins the specific direction: nested data, flat labels.
+        assert any("Missing labels" in m and "nested layout" in m for m in msgs)
+
+    def test_data_missing_label_hint_for_stem_mode_with_path_labels(self, tmp_path: Path) -> None:
+        # Flat data dir + path-shaped label ids (with unique stems so the
+        # duplicate-ID guard doesn't fire first) + forced stem mode → label
+        # ids carry path separators that stem-mode strips, so sample stems
+        # never line up. The raw-input check catches the strategy mismatch.
+        data_dir = tmp_path / "images"
+        data_dir.mkdir()
+        _write_image(data_dir / "X.jpeg")
+        labels_file = tmp_path / "labels.csv"
+        labels_file.write_text("image,label\nNORMAL/Y.jpeg,0\nPNEUMONIA/Z.jpeg,1\n")
+        config = _make_config(
+            str(data_dir),
+            labels_source=str(labels_file),
+            labels_id_column="image",
+            labels_column="label",
+            labels_encoding="index",
+            labels_id_strategy="stem",
+        )
+
+        with pytest.warns(UserWarning) as record:
+            data = Data(config)
+        assert data.labels is None
+        msgs = [str(w.message) for w in record]
+        # Hint pins stem-mode + relative_path remediation.
+        assert any("Missing labels" in m and "id_strategy=relative_path" in m for m in msgs)
 
     def test_data_raises_for_unsupported_id_strategy(self, tmp_path: Path) -> None:
         data_dir = tmp_path / "images"

--- a/src/raitap/data/tests/test_data_class.py
+++ b/src/raitap/data/tests/test_data_class.py
@@ -276,11 +276,37 @@ class TestDataConstructor:
         # Hint pins the specific direction: nested data, flat labels.
         assert any("Missing labels" in m and "nested layout" in m for m in msgs)
 
-    def test_data_missing_label_hint_for_stem_mode_with_path_labels(self, tmp_path: Path) -> None:
-        # Flat data dir + path-shaped label ids (with unique stems so the
-        # duplicate-ID guard doesn't fire first) + forced stem mode → label
-        # ids carry path separators that stem-mode strips, so sample stems
-        # never line up. The raw-input check catches the strategy mismatch.
+    def test_data_missing_label_hint_for_flat_labels_under_relative_path(
+        self, tmp_path: Path
+    ) -> None:
+        # Mirror of the nested-samples test, expressed as a separate scenario
+        # to exercise the second relative_path hint branch (label-side flat
+        # ids, sample-side path ids).
+        data_dir = tmp_path / "images"
+        (data_dir / "PNEUMONIA").mkdir(parents=True)
+        _write_image(data_dir / "PNEUMONIA" / "Y.jpeg")
+        labels_file = tmp_path / "labels.csv"
+        labels_file.write_text("image,label\nY.jpeg,0\n")
+        config = _make_config(
+            str(data_dir),
+            labels_source=str(labels_file),
+            labels_id_column="image",
+            labels_column="label",
+            labels_encoding="index",
+            labels_id_strategy="relative_path",
+        )
+
+        with pytest.warns(UserWarning) as record:
+            data = Data(config)
+        assert data.labels is None
+        msgs = [str(w.message) for w in record]
+        assert any("Missing labels" in m and "nested layout" in m for m in msgs)
+
+    def test_data_missing_label_no_hint_under_stem_mode(self, tmp_path: Path) -> None:
+        # Stem mode strips dirs symmetrically, so a missing match is a real
+        # basename gap — not a strategy issue. Hint must not fire for any
+        # combination of separators (incl. asymmetric), since switching to
+        # relative_path won't fix the gap either.
         data_dir = tmp_path / "images"
         data_dir.mkdir()
         _write_image(data_dir / "X.jpeg")
@@ -299,42 +325,10 @@ class TestDataConstructor:
             data = Data(config)
         assert data.labels is None
         msgs = [str(w.message) for w in record]
-        # Hint pins stem-mode + relative_path remediation, plus the
-        # asymmetric-separator wording that distinguishes strategy mismatch
-        # from a generic data gap.
-        assert any(
-            "Missing labels" in m and "id_strategy=relative_path" in m and "asymmetrically" in m
-            for m in msgs
-        )
-
-    def test_data_missing_label_no_strategy_hint_when_separators_match(
-        self, tmp_path: Path
-    ) -> None:
-        # Genuine data gap (sample exists on disk but no matching label row),
-        # not a strategy mismatch — both sides use the same separator style.
-        # Hint should NOT fire to avoid misleading the user.
-        data_dir = tmp_path / "images"
-        data_dir.mkdir()
-        _write_image(data_dir / "X.jpeg")
-        _write_image(data_dir / "Y.jpeg")
-        labels_file = tmp_path / "labels.csv"
-        labels_file.write_text("image,label\nX.jpeg,0\n")  # Y missing entirely
-        config = _make_config(
-            str(data_dir),
-            labels_source=str(labels_file),
-            labels_id_column="image",
-            labels_column="label",
-            labels_encoding="index",
-            labels_id_strategy="stem",
-        )
-
-        with pytest.warns(UserWarning) as record:
-            data = Data(config)
-        assert data.labels is None
-        msgs = [str(w.message) for w in record]
         assert any("Missing labels" in m for m in msgs)
-        # No strategy hint — neither side carries separators.
+        # No strategy hint — switching strategies wouldn't make X match Y/Z.
         assert not any("id_strategy=relative_path" in m for m in msgs)
+        assert not any("id_strategy=stem" in m and "Hint:" in m for m in msgs)
 
     def test_data_raises_for_unsupported_id_strategy(self, tmp_path: Path) -> None:
         data_dir = tmp_path / "images"


### PR DESCRIPTION
Follow-up to #103 / #95.

## Summary

When label-alignment fails under `_align_labels_to_samples`, the error messages now name the active `id_strategy` and suggest the likely fix.

Two failure modes covered:

1. **Duplicate label IDs** under `id_strategy=stem` — typically means colliding stems across class subdirs (e.g. `NORMAL/IM-0001.jpeg` + `PNEUMONIA/IM-0001.jpeg`). Hint: switch to `relative_path` (or `auto`).
2. **Missing labels** when sample ids carry path separators but `id_strategy=stem` strips them — or the inverse, `id_strategy=relative_path` against flat label ids. Each direction gets its own hint.

Before:

> `ValueError: Duplicate label IDs detected (IM-0001).`

After:

> `ValueError: Duplicate label IDs detected (IM-0001) under id_strategy='stem'. Hint: stem-only matching collapses ids that share a filename across subdirs (e.g. NORMAL/IM-0001.jpeg vs PNEUMONIA/IM-0001.jpeg). Set data.labels.id_strategy=relative_path (or =auto, the default) and use posix-style relative paths in the id column.`

## Changes

- `src/raitap/data/data.py` — `_align_labels_to_samples` builds a strategy-aware hint for both error paths.
- `src/raitap/data/tests/test_data_class.py` — existing duplicate-collision test now asserts the hint mentions `id_strategy` + `relative_path`. New test covers the missing-id path.

## Test plan

- [x] `uv run pytest src/raitap/data/tests/ -q` — 69 passed.
- [x] `uv run ruff check . && uv run ruff format --check .`