### PR TITLE
fix(data): nested ImageFolder layouts blocked input_metadata inference

### DIFF
--- a/src/raitap/data/metadata.py
+++ b/src/raitap/data/metadata.py
@@ -50,6 +50,11 @@ def infer_data_input_metadata(config: object, data: object) -> DataInputMetadata
     return DataInputMetadata(kind=None, shape=shape, layout=None)
 
 
+def _has_extension_recursive(path: Path, extensions: set[str]) -> bool:
+    """True if any file under ``path`` (recursively) has a matching extension."""
+    return any(child.is_file() and child.suffix.lower() in extensions for child in path.rglob("*"))
+
+
 def is_image_source(source: str) -> bool:
     if source in SAMPLE_SOURCES:
         return True
@@ -57,7 +62,7 @@ def is_image_source(source: str) -> bool:
     if path.suffix.lower() in _IMAGE_EXTENSIONS:
         return True
     if path.is_dir():
-        return any(child.suffix.lower() in _IMAGE_EXTENSIONS for child in path.iterdir())
+        return _has_extension_recursive(path, _IMAGE_EXTENSIONS)
     return False
 
 
@@ -66,7 +71,7 @@ def is_tabular_source(source: str) -> bool:
     if path.suffix.lower() in _TABULAR_EXTENSIONS:
         return True
     if path.is_dir():
-        return any(child.suffix.lower() in _TABULAR_EXTENSIONS for child in path.iterdir())
+        return _has_extension_recursive(path, _TABULAR_EXTENSIONS)
     return False
 
 

--- a/src/raitap/data/metadata.py
+++ b/src/raitap/data/metadata.py
@@ -51,8 +51,17 @@ def infer_data_input_metadata(config: object, data: object) -> DataInputMetadata
 
 
 def _has_extension_recursive(path: Path, extensions: set[str]) -> bool:
-    """True if any file under ``path`` (recursively) has a matching extension."""
-    return any(child.is_file() and child.suffix.lower() in extensions for child in path.rglob("*"))
+    """True if any file under ``path`` (recursively) has a matching extension.
+
+    Filesystem errors (unreadable subdirs, broken symlinks, etc.) are swallowed
+    — this helper is best-effort source detection, not data validation.
+    """
+    try:
+        return any(
+            child.is_file() and child.suffix.lower() in extensions for child in path.rglob("*")
+        )
+    except OSError:
+        return False
 
 
 def is_image_source(source: str) -> bool:

--- a/src/raitap/data/metadata.py
+++ b/src/raitap/data/metadata.py
@@ -53,15 +53,19 @@ def infer_data_input_metadata(config: object, data: object) -> DataInputMetadata
 def _has_extension_recursive(path: Path, extensions: set[str]) -> bool:
     """True if any file under ``path`` (recursively) has a matching extension.
 
-    Filesystem errors (unreadable subdirs, broken symlinks, etc.) are swallowed
-    — this helper is best-effort source detection, not data validation.
+    Iterates per-extension globs (``rglob('*<ext>')``) so the OS layer skips
+    non-matching dirents instead of yielding every file. Short-circuits on the
+    first match. Filesystem errors (unreadable subdirs, broken symlinks, etc.)
+    are swallowed — this helper is best-effort source detection, not data
+    validation.
     """
     try:
-        return any(
-            child.is_file() and child.suffix.lower() in extensions for child in path.rglob("*")
-        )
+        for ext in extensions:
+            if next(path.rglob(f"*{ext}"), None) is not None:
+                return True
     except OSError:
         return False
+    return False
 
 
 def is_image_source(source: str) -> bool:

--- a/src/raitap/data/metadata.py
+++ b/src/raitap/data/metadata.py
@@ -50,18 +50,24 @@ def infer_data_input_metadata(config: object, data: object) -> DataInputMetadata
     return DataInputMetadata(kind=None, shape=shape, layout=None)
 
 
+def _case_insensitive_glob(ext: str) -> str:
+    """Build a case-insensitive glob suffix for ``ext`` (e.g. ``.jpg`` →
+    ``*.[jJ][pP][gG]``)."""
+    return "*" + "".join(f"[{c.lower()}{c.upper()}]" if c.isalpha() else c for c in ext)
+
+
 def _has_extension_recursive(path: Path, extensions: set[str]) -> bool:
     """True if any file under ``path`` (recursively) has a matching extension.
 
-    Iterates per-extension globs (``rglob('*<ext>')``) so the OS layer skips
-    non-matching dirents instead of yielding every file. Short-circuits on the
-    first match. Filesystem errors (unreadable subdirs, broken symlinks, etc.)
-    are swallowed — this helper is best-effort source detection, not data
-    validation.
+    Case-insensitive: ``IMG_001.JPG`` matches ``.jpg``. Iterates per-extension
+    case-insensitive globs so the OS layer skips non-matching dirents instead
+    of yielding every file. Short-circuits on the first match. Filesystem
+    errors (unreadable subdirs, broken symlinks, etc.) are swallowed — this
+    helper is best-effort source detection, not data validation.
     """
     try:
         for ext in extensions:
-            if next(path.rglob(f"*{ext}"), None) is not None:
+            if next(path.rglob(_case_insensitive_glob(ext)), None) is not None:
                 return True
     except OSError:
         return False

--- a/src/raitap/data/metadata.py
+++ b/src/raitap/data/metadata.py
@@ -66,7 +66,7 @@ def _has_extension_recursive(path: Path, extensions: set[str]) -> bool:
     helper is best-effort source detection, not data validation.
     """
     try:
-        for ext in extensions:
+        for ext in sorted(extensions):
             if next(path.rglob(_case_insensitive_glob(ext)), None) is not None:
                 return True
     except OSError:

--- a/src/raitap/data/tests/test_metadata.py
+++ b/src/raitap/data/tests/test_metadata.py
@@ -100,6 +100,25 @@ def test_is_tabular_source_recurses_into_subdirs(tmp_path: Path) -> None:
     assert is_tabular_source(str(nested))
 
 
+def test_is_image_source_matches_uppercase_extensions(tmp_path: Path) -> None:
+    # Many real-world dumps use ``.JPG`` / ``.JPEG`` (e.g. camera exports).
+    # Detection must be case-insensitive on Linux too — ``Path.rglob`` is
+    # case-sensitive there, so the implementation needs an explicit fix.
+    image_dir = tmp_path / "uppercase_images"
+    image_dir.mkdir()
+    (image_dir / "IMG_001.JPG").write_bytes(b"not-an-image-for-this-test")
+
+    assert is_image_source(str(image_dir))
+
+
+def test_is_tabular_source_matches_uppercase_extensions(tmp_path: Path) -> None:
+    table_dir = tmp_path / "uppercase_tables"
+    table_dir.mkdir()
+    (table_dir / "DATA.CSV").write_text("a,b\n1,2\n")
+
+    assert is_tabular_source(str(table_dir))
+
+
 def test_shape_tuple_returns_none_for_invalid_shapes() -> None:
     assert shape_tuple(None) is None
     assert shape_tuple(object()) is None

--- a/src/raitap/data/tests/test_metadata.py
+++ b/src/raitap/data/tests/test_metadata.py
@@ -80,6 +80,26 @@ def test_source_helpers_detect_directory_contents(tmp_path: Path) -> None:
     assert is_tabular_source(str(table_dir))
 
 
+def test_is_image_source_recurses_into_class_subdirs(tmp_path: Path) -> None:
+    # Nested ``ImageFolder`` layout (post-#95): images live under per-class
+    # subdirs, not the root. is_image_source must still recognise the dir.
+    nested = tmp_path / "test"
+    (nested / "NORMAL").mkdir(parents=True)
+    (nested / "PNEUMONIA").mkdir(parents=True)
+    (nested / "NORMAL" / "IM-0001.jpeg").write_bytes(b"not-an-image-for-this-test")
+    (nested / "PNEUMONIA" / "IM-0002.jpeg").write_bytes(b"not-an-image-for-this-test")
+
+    assert is_image_source(str(nested))
+
+
+def test_is_tabular_source_recurses_into_subdirs(tmp_path: Path) -> None:
+    nested = tmp_path / "tabular"
+    (nested / "shard_a").mkdir(parents=True)
+    (nested / "shard_a" / "rows.csv").write_text("a,b\n1,2\n")
+
+    assert is_tabular_source(str(nested))
+
+
 def test_shape_tuple_returns_none_for_invalid_shapes() -> None:
     assert shape_tuple(None) is None
     assert shape_tuple(object()) is None

--- a/src/raitap/run/pipeline.py
+++ b/src/raitap/run/pipeline.py
@@ -209,7 +209,11 @@ def _resolve_explainer_runtime_kwargs(
     return {"target": predictions.detach()}
 
 
-def _input_metadata_for_data(config: AppConfig, data: Data) -> InputSpec:
+def _input_metadata_for_data(config: AppConfig, data: Data) -> InputSpec | None:
+    """Return runtime input metadata derived from the data object, or ``None``
+    if inference can't determine the input kind (in which case any
+    ``transparency.<explainer>.raitap.input_metadata`` from the explainer
+    config will be used unchanged)."""
     explicit = getattr(data, "input_metadata", None)
     if isinstance(explicit, InputSpec):
         return explicit
@@ -217,6 +221,10 @@ def _input_metadata_for_data(config: AppConfig, data: Data) -> InputSpec:
     if isinstance(config_explicit, InputSpec):
         return config_explicit
     metadata = infer_data_input_metadata(config, data)
+    if metadata.kind is None:
+        # Don't override yaml-provided ``raitap.input_metadata`` with an empty
+        # spec — the user must have set it deliberately.
+        return None
     return InputSpec(
         kind=metadata.kind,
         shape=metadata.shape,

--- a/src/raitap/run/pipeline.py
+++ b/src/raitap/run/pipeline.py
@@ -211,7 +211,7 @@ def _resolve_explainer_runtime_kwargs(
 
 def _input_metadata_for_data(config: AppConfig, data: Data) -> InputSpec | None:
     """Return runtime input metadata derived from the data object, or ``None``
-    if inference can't determine the input kind (in which case any
+    if neither ``kind`` nor ``layout`` can be determined (in which case any
     ``transparency.<explainer>.raitap.input_metadata`` from the explainer
     config will be used unchanged)."""
     explicit = getattr(data, "input_metadata", None)
@@ -221,9 +221,9 @@ def _input_metadata_for_data(config: AppConfig, data: Data) -> InputSpec | None:
     if isinstance(config_explicit, InputSpec):
         return config_explicit
     metadata = infer_data_input_metadata(config, data)
-    if metadata.kind is None:
+    if metadata.kind is None and metadata.layout is None:
         # Don't override yaml-provided ``raitap.input_metadata`` with an empty
-        # spec — the user must have set it deliberately.
+        # spec — let the explainer-level config drive output-space inference.
         return None
     return InputSpec(
         kind=metadata.kind,

--- a/src/raitap/tests/test_run_main.py
+++ b/src/raitap/tests/test_run_main.py
@@ -664,6 +664,48 @@ def test_run_without_tracking_passes_none_when_inference_cant_determine_kind(
     assert captured_kwargs["input_metadata"] is None
 
 
+def test_run_without_tracking_preserves_layout_only_input_metadata(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Source kind can't be inferred from disk, but data.input_metadata in yaml
+    # supplies a layout. The pipeline must surface that layout downstream
+    # rather than dropping it (output-space inference accepts layout alone).
+    model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
+    empty_dir = tmp_path / "unknown"
+    empty_dir.mkdir()
+    data = SimpleNamespace(
+        tensor=torch.randn(2, 4, 3),
+        sample_ids=None,
+        labels=None,
+        source=str(empty_dir),
+    )
+    explanation = _FakeExplainerResult("exp")
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_explanation(*_args: object, **kwargs: object) -> _FakeExplainerResult:
+        captured_kwargs.update(kwargs)
+        return explanation
+
+    config = SimpleNamespace(
+        data=SimpleNamespace(
+            source=str(empty_dir),
+            input_metadata={"layout": "(B,T,C)"},
+        ),
+        transparency={"one": {}},
+        metrics=SimpleNamespace(num_classes=None),
+    )
+    monkeypatch.setattr(run_pipeline, "metrics_run_enabled", lambda _cfg: False)
+    monkeypatch.setattr(run_pipeline, "Explanation", _fake_explanation)
+
+    run_pipeline._run_without_tracking(config, model, data)  # type: ignore[arg-type]
+
+    spec = captured_kwargs["input_metadata"]
+    assert spec is not None
+    assert getattr(spec, "kind", "missing") is None
+    assert str(getattr(spec, "layout", None)) == "(B,T,C)"
+
+
 def test_run_without_tracking_resolves_auto_pred_target(monkeypatch: MonkeyPatch) -> None:
     class _Net(torch.nn.Module):
         def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/src/raitap/tests/test_run_main.py
+++ b/src/raitap/tests/test_run_main.py
@@ -627,6 +627,43 @@ def test_run_without_tracking_threads_tabular_metadata_to_explanation(
     assert input_metadata.layout == "(B,F)"
 
 
+def test_run_without_tracking_passes_none_when_inference_cant_determine_kind(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # When data.source isn't an image / tabular file or directory, runtime
+    # inference returns kind=None. The pipeline must pass ``None`` so that
+    # any yaml-provided ``transparency.<explainer>.raitap.input_metadata``
+    # is left intact downstream (no silent overwrite with an empty spec).
+    model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
+    empty_dir = tmp_path / "unknown"
+    empty_dir.mkdir()
+    data = SimpleNamespace(
+        tensor=torch.randn(2, 3, 8, 8),
+        sample_ids=None,
+        labels=None,
+        source=str(empty_dir),
+    )
+    explanation = _FakeExplainerResult("exp")
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_explanation(*_args: object, **kwargs: object) -> _FakeExplainerResult:
+        captured_kwargs.update(kwargs)
+        return explanation
+
+    config = SimpleNamespace(
+        data=SimpleNamespace(source=str(empty_dir)),
+        transparency={"one": {}},
+        metrics=SimpleNamespace(num_classes=None),
+    )
+    monkeypatch.setattr(run_pipeline, "metrics_run_enabled", lambda _cfg: False)
+    monkeypatch.setattr(run_pipeline, "Explanation", _fake_explanation)
+
+    run_pipeline._run_without_tracking(config, model, data)  # type: ignore[arg-type]
+
+    assert captured_kwargs["input_metadata"] is None
+
+
 def test_run_without_tracking_resolves_auto_pred_target(monkeypatch: MonkeyPatch) -> None:
     class _Net(torch.nn.Module):
         def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Two related bugs that surfaced after #95 enabled nested \`ImageFolder\`-style layouts (\`data/test/<class>/<file>.jpg\`):

## Bug 1 — \`is_image_source\` / \`is_tabular_source\` are flat-only

\`raitap/data/metadata.py\` checks \`path.iterdir()\` (one level). For a nested layout the direct children are class subdirs (\`NORMAL/\`, \`PNEUMONIA/\`) — no image suffix → returns \`False\`. \`infer_data_input_metadata\` then falls through to \`kind=None\`.

## Bug 2 — runtime override silently clobbers yaml \`raitap.input_metadata\`

\`raitap/run/pipeline.py::_input_metadata_for_data\` always returns an \`InputSpec\`, even when inference yields \`kind=None\`. \`factory.py\` line 414 then unconditionally overrides any user-set \`transparency.<explainer>.raitap.input_metadata\` with the empty spec — so users hit the very \"shape alone is ambiguous\" error #105 documents, even when they configured the metadata correctly.

## Repro

Nested chest-xray layout:

\`\`\`
data/processed/clean/test/NORMAL/IM-0001.jpeg
data/processed/clean/test/PNEUMONIA/person100_bacteria_478.jpeg
\`\`\`

\`\`\`yaml
data:
  source: \"./data/processed/clean/test\"
transparency:
  captum_ig:
    _target_: CaptumExplainer
    algorithm: IntegratedGradients
    raitap:
      input_metadata: { kind: image, layout: NCHW }
\`\`\`

Without these fixes: \`ValueError: Output-space inference requires explicit input metadata; shape alone is ambiguous.\` even though \`raitap.input_metadata\` is set.

## Changes

- \`src/raitap/data/metadata.py\` — \`_has_extension_recursive\` helper; \`is_image_source\` / \`is_tabular_source\` now use \`Path.rglob\` instead of \`iterdir\`.
- \`src/raitap/run/pipeline.py\` — \`_input_metadata_for_data\` returns \`None\` when inference can't determine \`kind\`, so factory leaves the yaml-provided \`raitap.input_metadata\` alone. Type signature changed to \`InputSpec | None\`.
- \`src/raitap/data/tests/test_metadata.py\` — 2 new tests for nested image + nested tabular layouts.
- \`src/raitap/tests/test_run_main.py\` — new test asserts pipeline passes \`input_metadata=None\` when source is an empty/unknown dir.

## Test plan

- [x] \`uv run pytest src/raitap/data/tests/ src/raitap/tests/test_run_main.py -q\` — 94 passed.
- [x] \`uv run ruff check . && uv run ruff format --check .\`