### PR TITLE
fix(deps): pin triton-xpu>=3.0.0 to skip yanked 0.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,10 @@ torch-cuda = ["torch>=2.10.0", "torchvision>=0.20.0"]
 torch-intel = [
   "torch>=2.10.0; python_full_version < '3.14' and sys_platform != 'darwin'",
   "torchvision>=0.20.0; python_full_version < '3.14' and sys_platform != 'darwin'",
-  "triton-xpu; python_full_version < '3.14' and sys_platform != 'darwin'",
+  # Pin triton-xpu>=3.0.0 — its only PyPI release (0.0.2) is yanked. The
+  # 3.x wheels live on the pytorch-intel index (routed via [tool.uv.sources]
+  # below) and are pulled in transitively by torch==*+xpu. See #110.
+  "triton-xpu>=3.0.0; python_full_version < '3.14' and sys_platform != 'darwin'",
 ]
 # TODO remove bundled torch deps once ONNX no longer relies on torch tensors internally
 onnx-cpu = [
@@ -90,7 +93,7 @@ onnx-intel = [
   "openvino>=2025.1.0; sys_platform == 'win32'",
   "torch>=2.10.0; python_full_version < '3.14' and sys_platform != 'darwin'",
   "torchvision>=0.20.0; python_full_version < '3.14' and sys_platform != 'darwin'",
-  "triton-xpu; python_full_version < '3.14' and sys_platform != 'darwin'",
+  "triton-xpu>=3.0.0; python_full_version < '3.14' and sys_platform != 'darwin'",
 ]
 
 # Transparency module
@@ -197,6 +200,8 @@ torchvision = [
   { index = "pytorch-intel", extra = "torch-intel" },
   { index = "pytorch-intel", extra = "onnx-intel" },
 ]
+# Route triton-xpu at the pytorch-intel index where the 3.x wheels live;
+# PyPI only hosts the yanked 0.0.2. See #110.
 triton-xpu = [
   { index = "pytorch-intel", extra = "torch-intel" },
   { index = "pytorch-intel", extra = "onnx-intel" },

--- a/uv.lock
+++ b/uv.lock
@@ -2933,8 +2933,8 @@ requires-dist = [
     { name = "torchvision", marker = "extra == 'onnx-cuda'", specifier = ">=0.20.0", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "raitap", extra = "onnx-cuda" } },
     { name = "torchvision", marker = "extra == 'torch-cpu'", specifier = ">=0.20.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "raitap", extra = "torch-cpu" } },
     { name = "torchvision", marker = "extra == 'torch-cuda'", specifier = ">=0.20.0", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "raitap", extra = "torch-cuda" } },
-    { name = "triton-xpu", marker = "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'onnx-intel'", index = "https://download.pytorch.org/whl/xpu", conflict = { package = "raitap", extra = "onnx-intel" } },
-    { name = "triton-xpu", marker = "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'torch-intel'", index = "https://download.pytorch.org/whl/xpu", conflict = { package = "raitap", extra = "torch-intel" } },
+    { name = "triton-xpu", marker = "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'onnx-intel'", specifier = ">=3.0.0", index = "https://download.pytorch.org/whl/xpu", conflict = { package = "raitap", extra = "onnx-intel" } },
+    { name = "triton-xpu", marker = "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'torch-intel'", specifier = ">=3.0.0", index = "https://download.pytorch.org/whl/xpu", conflict = { package = "raitap", extra = "torch-intel" } },
 ]
 provides-extras = ["torch-cpu", "torch-cuda", "torch-intel", "onnx-cpu", "onnx-cuda", "onnx-intel", "shap", "captum", "transparency", "launcher", "mlflow", "tracking", "metrics", "reporting"]
 


### PR DESCRIPTION
## Summary

- Pin `triton-xpu>=3.0.0` in `torch-intel` and `onnx-intel` extras so the resolver skips the yanked `0.0.2` on default PyPI
- Annotate the existing `[tool.uv.sources]` mapping for `triton-xpu` so the routing-via-pytorch-intel intent is discoverable

## Why

`raitap[torch-intel]` (and `[onnx-intel]`) is unresolvable downstream:

```
× Because triton-xpu==0.0.2 was yanked (reason: Obsolete, use 3.0.0 instead)
  and only triton-xpu==0.0.2 is available, we can conclude that all
  versions of triton-xpu cannot be used.
```

The 3.x line is published on the pytorch-intel index (already routed) and is pulled in transitively by `torch==*+xpu`. The unconstrained pin let the resolver see the yanked PyPI 0.0.2 and bail. Pinning `>=3.0.0` excludes it.

Closes #110

## Test plan

- [x] `uv lock` resolves cleanly (246 packages)
- [ ] Downstream `uv add raitap[torch-intel]>=0.4.2` succeeds in a clean project (pending release)
- [ ] CI green