### PR TITLE
refactor(infra): extract shared adapter factory for transparency + robustness

### DIFF
--- a/src/raitap/_adapter_factory.py
+++ b/src/raitap/_adapter_factory.py
@@ -1,0 +1,400 @@
+"""Shared YAML-config parser for raitap adapter modules.
+
+Both :mod:`raitap.robustness` and :mod:`raitap.transparency` configure their
+adapters with the same YAML shape::
+
+    _target_: raitap.<module>.<Adapter>
+    algorithm: <name>
+    constructor: { ... }      # __init__ kwargs
+    call: { ... }              # per-call library kwargs
+    raitap: { ... }            # framework-owned options
+    visualisers: [ ... ]       # optional list of visualiser entries
+
+This module owns the mechanics of parsing, validating, and instantiating that
+shape so the two domain factories do not duplicate ~250 lines of identical
+plumbing. Per-domain logic (compat checks, run-method dispatch, result
+wrapping) stays in the domain factories.
+
+Design rules:
+
+* :class:`AdapterSchema` is data-only — no callbacks, no methods. The schema
+  describes the YAML shape; orchestration lives in the per-domain
+  entry-point class (``Explanation`` / ``RobustnessAssessment``).
+* :class:`ParsedAdapterConfig` is a frozen container; it never mutates after
+  ``parse_adapter_config`` returns it.
+* Functions accept the schema explicitly so callers can see the parametrisation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from hydra.utils import instantiate
+from omegaconf import DictConfig, OmegaConf
+
+from raitap import raitap_log
+from raitap.configs import cfg_to_dict, resolve_target
+from raitap.data import load_tensor_from_source
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+
+__all__ = [
+    "AdapterSchema",
+    "ParsedAdapterConfig",
+    "instantiate_adapter",
+    "instantiate_visualisers",
+    "parse_adapter_config",
+    "raw_config_dict",
+    "resolve_call_data_sources",
+]
+
+
+_DATA_SOURCE_KEYS = frozenset({"source", "n_samples"})
+_VISUALISER_ENTRY_KEYS = frozenset({"_target_", "constructor", "call"})
+
+
+@dataclass(frozen=True)
+class AdapterSchema:
+    """Describes a domain's adapter YAML shape.
+
+    Attributes:
+        domain: lowercase domain key used in user-facing messages, e.g.
+            ``"robustness"`` or ``"transparency"``.
+        entity: lowercase noun naming the configured object,
+            e.g. ``"assessor"`` or ``"explainer"``.
+        subdict_namespace: title-cased label used in subdict-type errors,
+            e.g. ``"Robustness"``.
+        target_prefix: prefix prepended to bare ``_target_`` values
+            (matching :func:`raitap.configs.resolve_target`).
+        visualiser_prefix: prefix for visualiser ``_target_`` values. Often
+            equals ``target_prefix`` (transparency) or differs (robustness
+            uses a separate ``visualisers.`` namespace).
+        top_level_keys: allowed keys directly under the adapter config block.
+        raitap_keys: allowed keys under the ``raitap:`` sub-block.
+        removed_raitap_keys: keys that were valid in older versions but now
+            raise ``ValueError`` with the supplied migration message.
+        top_level_error_hint: trailing sentence appended to the
+            "Unknown … config keys" error so users see domain-specific guidance.
+    """
+
+    domain: str
+    entity: str
+    subdict_namespace: str
+    target_prefix: str
+    visualiser_prefix: str
+    top_level_keys: frozenset[str]
+    raitap_keys: frozenset[str]
+    top_level_error_hint: str
+    removed_raitap_keys: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ParsedAdapterConfig:
+    """Result of :func:`parse_adapter_config` — fully normalised + validated."""
+
+    raw: dict[str, Any]
+    target_path: str
+    resolved_target: str
+    algorithm: Any
+    constructor: dict[str, Any]
+    call: dict[str, Any]
+    raitap: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Raw config helpers
+# ---------------------------------------------------------------------------
+
+
+def raw_config_dict(adapter_config: Any) -> dict[str, Any]:
+    """Convert an adapter ``DictConfig`` (or plain dict) to a plain ``dict``."""
+    return cfg_to_dict(adapter_config)
+
+
+def _subdict(value: Any, *, label: str, schema: AdapterSchema) -> dict[str, Any]:
+    """Normalise a ``constructor`` / ``call`` / ``raitap`` block to a ``dict``."""
+    if value is None:
+        return {}
+    if isinstance(value, dict) and not value:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, DictConfig):
+        container = OmegaConf.to_container(value, resolve=True)
+        if not isinstance(container, dict):
+            raise TypeError(
+                f"{schema.subdict_namespace} {label!r} must be a mapping, "
+                f"got {type(container).__name__}."
+            )
+        return cast("dict[str, Any]", dict(container))
+    raise TypeError(
+        f"{schema.subdict_namespace} {label!r} must be a dict or DictConfig, "
+        f"got {type(value).__name__}."
+    )
+
+
+def _visualiser_entry_to_dict(visualiser_config: Any) -> dict[str, Any]:
+    if isinstance(visualiser_config, dict):
+        return dict(visualiser_config)
+    if isinstance(visualiser_config, DictConfig):
+        container = OmegaConf.to_container(visualiser_config, resolve=True)
+        if not isinstance(container, dict):
+            raise TypeError(
+                f"Each visualisers list entry must be a mapping, got {type(container).__name__}."
+            )
+        return cast("dict[str, Any]", dict(container))
+    raise TypeError(
+        "Each visualisers list entry must be a dict or DictConfig, "
+        f"got {type(visualiser_config).__name__}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_top_level_keys(raw: dict[str, Any], schema: AdapterSchema) -> None:
+    unknown = set(raw) - schema.top_level_keys
+    if not unknown:
+        return
+    sorted_unknown = ", ".join(sorted(unknown))
+    raise ValueError(
+        f"Unknown {schema.domain} {schema.entity} config keys: {sorted_unknown}. "
+        f"{schema.top_level_error_hint}"
+    )
+
+
+def _validate_visualiser_entry_keys(entry: dict[str, Any], *, target_hint: str) -> None:
+    unknown = set(entry) - _VISUALISER_ENTRY_KEYS
+    if unknown:
+        sorted_unknown = ", ".join(sorted(unknown))
+        raise ValueError(
+            f"Unknown keys in visualiser config {target_hint!r}: {sorted_unknown}. "
+            "Use 'constructor' for __init__ kwargs and 'call' for visualise() kwargs."
+        )
+
+
+def _validate_raitap_keys(
+    raitap_cfg: dict[str, Any], *, entity_name: str, schema: AdapterSchema
+) -> None:
+    for key, message in schema.removed_raitap_keys.items():
+        if key in raitap_cfg:
+            raise ValueError(message)
+
+    unknown = set(raitap_cfg) - schema.raitap_keys
+    if not unknown:
+        return
+
+    sorted_unknown = ", ".join(sorted(unknown))
+    sorted_valid = ", ".join(sorted(schema.raitap_keys))
+    raitap_log.warn(
+        f"Unknown {schema.domain}.raitap keys for {schema.entity} {entity_name!r}: "
+        f"{sorted_unknown}. Supported RAITAP keys: {sorted_valid}.",
+    )
+
+
+def _warn_on_misplaced_raitap_call_keys(
+    call_cfg: dict[str, Any], *, entity_name: str, schema: AdapterSchema
+) -> None:
+    misplaced = sorted(set(call_cfg).intersection(schema.raitap_keys))
+    if not misplaced:
+        return
+    keys = ", ".join(misplaced)
+    raitap_log.warn(
+        f"{schema.entity.capitalize()} {entity_name!r} has RAITAP-owned keys "
+        f"under 'call:': {keys}. These keys belong under 'raitap:' while "
+        "'call:' is intended for library kwargs only.",
+    )
+
+
+def _migrate_misplaced_raitap_call_keys(
+    call_cfg: dict[str, Any], raitap_cfg: dict[str, Any], schema: AdapterSchema
+) -> None:
+    misplaced = sorted(set(call_cfg).intersection(schema.raitap_keys))
+    for key in misplaced:
+        value = call_cfg.pop(key)
+        raitap_cfg.setdefault(key, value)
+
+
+# ---------------------------------------------------------------------------
+# Top-level parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_adapter_config(adapter_config: Any, schema: AdapterSchema) -> ParsedAdapterConfig:
+    """Parse + validate an adapter config block. Returns a frozen container."""
+    raw = raw_config_dict(adapter_config)
+    _validate_top_level_keys(raw, schema)
+
+    target_path = str(raw.get("_target_", ""))
+    resolved_target = resolve_target(target_path, schema.target_prefix)
+    constructor_plain = _subdict(raw.get("constructor"), label="constructor", schema=schema)
+    call_plain = _subdict(raw.get("call"), label="call", schema=schema)
+    raitap_plain = _subdict(raw.get("raitap"), label="raitap", schema=schema)
+    entity_name = resolved_target or target_path or "?"
+    _validate_raitap_keys(raitap_plain, entity_name=entity_name, schema=schema)
+    _warn_on_misplaced_raitap_call_keys(call_plain, entity_name=entity_name, schema=schema)
+    _migrate_misplaced_raitap_call_keys(call_plain, raitap_plain, schema)
+
+    return ParsedAdapterConfig(
+        raw=raw,
+        target_path=target_path,
+        resolved_target=resolved_target,
+        algorithm=raw.get("algorithm"),
+        constructor=constructor_plain,
+        call=call_plain,
+        raitap=raitap_plain,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Instantiation
+# ---------------------------------------------------------------------------
+
+
+A = TypeVar("A")
+W = TypeVar("W")
+
+
+def instantiate_adapter(
+    parsed: ParsedAdapterConfig,
+    *,
+    protocol: type[A],
+    schema: AdapterSchema,
+    instantiate_error_hint: str,
+    type_error_hint: str,
+    instantiate_fn: Callable[[dict[str, Any]], Any] | None = None,
+) -> tuple[A, str]:
+    """Instantiate the adapter described by ``parsed`` and verify its protocol.
+
+    ``protocol`` is the runtime-checkable Protocol or ABC the adapter must
+    satisfy (e.g. ``ExplainerAdapter``, ``AssessorAdapter``).
+
+    ``instantiate_fn`` defaults to :func:`hydra.utils.instantiate` but can be
+    overridden so per-domain factories can wire in test doubles or monkey-
+    patchable module-level bindings.
+    """
+    instantiate_cfg: dict[str, Any] = {
+        **parsed.constructor,
+        "algorithm": parsed.algorithm,
+        "_target_": parsed.resolved_target,
+    }
+
+    fn = instantiate_fn if instantiate_fn is not None else instantiate
+    try:
+        adapter = fn(instantiate_cfg)
+    except Exception as error:
+        raitap_log.exception(
+            "%s instantiation failed for target %r",
+            schema.entity.capitalize(),
+            parsed.target_path,
+        )
+        raise ValueError(
+            f"Could not instantiate {schema.entity} {parsed.target_path!r}.\n"
+            f"{instantiate_error_hint}"
+        ) from error
+
+    if not isinstance(adapter, protocol):
+        raise ValueError(
+            f"Instantiated {schema.entity} {parsed.target_path!r} does not implement "
+            f"{protocol.__name__}. {type_error_hint}"
+        )
+
+    return cast("A", adapter), parsed.resolved_target
+
+
+def instantiate_visualisers(
+    adapter_config: Any,
+    *,
+    schema: AdapterSchema,
+    wrap: Callable[[Any, dict[str, Any]], W],
+    instantiate_fn: Callable[[dict[str, Any]], Any] | None = None,
+) -> list[W]:
+    """Instantiate the ``visualisers:`` list and wrap each with ``wrap(viz, call)``.
+
+    ``wrap`` produces the per-domain ``ConfiguredVisualiser`` flavour
+    (``ConfiguredVisualiser`` for transparency, ``ConfiguredRobustnessVisualiser``
+    for robustness). The shared module is agnostic to the wrapper type.
+    """
+    raw = raw_config_dict(adapter_config)
+    out: list[W] = []
+
+    for visualiser_config in raw.get("visualisers", []):
+        entry = _visualiser_entry_to_dict(visualiser_config)
+        visualiser_target = str(entry.get("_target_", ""))
+        _validate_visualiser_entry_keys(entry, target_hint=visualiser_target or "?")
+
+        constructor_plain = _subdict(
+            entry.get("constructor"),
+            label=f"visualiser constructor ({visualiser_target})",
+            schema=schema,
+        )
+        call_plain = _subdict(
+            entry.get("call"),
+            label=f"visualiser call ({visualiser_target})",
+            schema=schema,
+        )
+        resolved_target = resolve_target(visualiser_target, schema.visualiser_prefix)
+
+        instantiate_cfg: dict[str, Any] = {
+            **constructor_plain,
+            "_target_": resolved_target,
+        }
+
+        fn = instantiate_fn if instantiate_fn is not None else instantiate
+        try:
+            visualiser = fn(instantiate_cfg)
+        except Exception as error:
+            raitap_log.exception("Visualiser instantiation failed for target %r", visualiser_target)
+            raise ValueError(f"Could not instantiate visualiser {visualiser_target!r}.") from error
+
+        out.append(wrap(visualiser, call_plain))
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Call-kwarg data-source resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_call_data_sources(
+    call_kwargs: dict[str, Any], *, log_label: str = "call"
+) -> dict[str, Any]:
+    """Replace ``call:`` values matching ``{source, n_samples}`` with loaded tensors.
+
+    A value is treated as a data-source reference when it is a plain ``dict``
+    whose keys are a subset of ``{"source", "n_samples"}`` and ``"source"`` is
+    present.  Such values are replaced with the loaded tensor so the
+    downstream adapter receives a ``torch.Tensor`` instead of a raw config dict.
+
+    Example YAML under ``call:``::
+
+        background_data:
+          source: "imagenet_samples"
+          n_samples: 50
+    """
+    resolved: dict[str, Any] = {}
+    for key, value in call_kwargs.items():
+        if isinstance(value, dict) and set(value).issubset(_DATA_SOURCE_KEYS) and "source" in value:
+            source = value["source"]
+            n_samples = value.get("n_samples")
+            if n_samples is not None and not isinstance(n_samples, int):
+                raise TypeError(
+                    f"call.{key}.n_samples must be an int, got {type(n_samples).__name__}."
+                )
+            raitap_log.info(
+                "Resolving %s kwarg %r as data source %r (n_samples=%s)",
+                log_label,
+                key,
+                source,
+                n_samples,
+            )
+            resolved[key] = load_tensor_from_source(str(source), n_samples=n_samples)
+        else:
+            resolved[key] = value
+    return resolved

--- a/src/raitap/configs/adapter_factory.py
+++ b/src/raitap/configs/adapter_factory.py
@@ -27,19 +27,19 @@ Design rules:
 
 from __future__ import annotations
 
+from collections.abc import (  # noqa: TC003 — runtime import: typing.get_type_hints() resolves these
+    Callable,
+    Mapping,
+)
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 
 from raitap import raitap_log
-from raitap.configs import cfg_to_dict, resolve_target
+from raitap.configs.utils import cfg_to_dict, resolve_target
 from raitap.data import load_tensor_from_source
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
-
 
 __all__ = [
     "AdapterSchema",

--- a/src/raitap/robustness/factory.py
+++ b/src/raitap/robustness/factory.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from hydra.utils import instantiate
-from omegaconf import DictConfig, OmegaConf
 
-from raitap import raitap_log
-from raitap.configs import cfg_to_dict, resolve_run_dir, resolve_target
-from raitap.data import load_tensor_from_source
+from raitap._adapter_factory import (
+    AdapterSchema,
+    ParsedAdapterConfig,
+    instantiate_adapter,
+    instantiate_visualisers,
+    parse_adapter_config,
+    raw_config_dict,
+    resolve_call_data_sources,
+)
+from raitap.configs import resolve_run_dir
 from raitap.models.backend import ModelBackend
 
 from .contracts import AssessorAdapter
@@ -27,219 +33,39 @@ if TYPE_CHECKING:
 _ROBUSTNESS_PREFIX = "raitap.robustness.assessors."
 _VISUALISER_PREFIX = "raitap.robustness.visualisers."
 
-_ASSESSOR_TOP_LEVEL_KEYS = frozenset(
-    {"_target_", "algorithm", "constructor", "call", "raitap", "visualisers"}
+_SCHEMA = AdapterSchema(
+    domain="robustness",
+    entity="assessor",
+    subdict_namespace="Robustness",
+    target_prefix=_ROBUSTNESS_PREFIX,
+    visualiser_prefix=_VISUALISER_PREFIX,
+    top_level_keys=frozenset(
+        {"_target_", "algorithm", "constructor", "call", "raitap", "visualisers"}
+    ),
+    raitap_keys=frozenset(
+        {
+            "batch_size",
+            "input_metadata",
+            "show_progress",
+            "progress_desc",
+            "sample_ids",
+            "sample_names",
+            "show_sample_names",
+        }
+    ),
+    top_level_error_hint=(
+        "Put __init__ kwargs under 'constructor', per-call kwargs under 'call', "
+        "and RAITAP-owned options under 'raitap'. Where the attack hyperparameters "
+        "(eps / alpha / steps) live depends on the underlying library: torchattacks "
+        "treats them as constructor args, foolbox as call args."
+    ),
 )
-_VISUALISER_ENTRY_KEYS = frozenset({"_target_", "constructor", "call"})
-_RAITAP_KEYS = frozenset(
-    {
-        "batch_size",
-        "input_metadata",
-        "show_progress",
-        "progress_desc",
-        "sample_ids",
-        "sample_names",
-        "show_sample_names",
-    }
-)
-_MISPLACED_RAITAP_CALL_WARNING_KEYS = _RAITAP_KEYS
 
-_DATA_SOURCE_KEYS = frozenset({"source", "n_samples"})
-
-_PARSED_ASSESSOR_CONFIG_CACHE: dict[int, _ParsedAssessorConfig] = {}
+_PARSED_ASSESSOR_CONFIG_CACHE: dict[int, ParsedAdapterConfig] = {}
 
 
-class _ParsedAssessorConfig:
-    def __init__(
-        self,
-        *,
-        raw: dict[str, Any],
-        target_path: str,
-        resolved_target: str,
-        algorithm: Any,
-        constructor: dict[str, Any],
-        call: dict[str, Any],
-        raitap: dict[str, Any],
-    ) -> None:
-        self.raw = raw
-        self.target_path = target_path
-        self.resolved_target = resolved_target
-        self.algorithm = algorithm
-        self.constructor = constructor
-        self.call = call
-        self.raitap = raitap
-
-
-def _raw_assessor_config(assessor_config: Any) -> dict[str, Any]:
-    return cfg_to_dict(assessor_config)
-
-
-def _subdict(value: Any, *, label: str) -> dict[str, Any]:
-    if value is None:
-        return {}
-    if isinstance(value, dict) and not value:
-        return {}
-    if isinstance(value, dict):
-        return dict(value)
-    if isinstance(value, DictConfig):
-        container = OmegaConf.to_container(value, resolve=True)
-        if not isinstance(container, dict):
-            raise TypeError(
-                f"Robustness {label!r} must be a mapping, got {type(container).__name__}."
-            )
-        return cast("dict[str, Any]", dict(container))
-    raise TypeError(
-        f"Robustness {label!r} must be a dict or DictConfig, got {type(value).__name__}."
-    )
-
-
-def _visualiser_entry_to_dict(visualiser_config: Any) -> dict[str, Any]:
-    if isinstance(visualiser_config, dict):
-        return dict(visualiser_config)
-    if isinstance(visualiser_config, DictConfig):
-        container = OmegaConf.to_container(visualiser_config, resolve=True)
-        if not isinstance(container, dict):
-            raise TypeError(
-                f"Each visualisers list entry must be a mapping, got {type(container).__name__}."
-            )
-        return cast("dict[str, Any]", dict(container))
-    raise TypeError(
-        "Each visualisers list entry must be a dict or DictConfig, "
-        f"got {type(visualiser_config).__name__}."
-    )
-
-
-def _validate_assessor_top_level_keys(raw: dict[str, Any]) -> None:
-    unknown = set(raw) - _ASSESSOR_TOP_LEVEL_KEYS
-    if unknown:
-        sorted_unknown = ", ".join(sorted(unknown))
-        raise ValueError(
-            f"Unknown robustness assessor config keys: {sorted_unknown}. "
-            "Put __init__ kwargs under 'constructor', per-call kwargs under 'call', "
-            "and RAITAP-owned options under 'raitap'. Where the attack hyperparameters "
-            "(eps / alpha / steps) live depends on the underlying library: torchattacks "
-            "treats them as constructor args, foolbox as call args."
-        )
-
-
-def _validate_visualiser_entry_keys(entry: dict[str, Any], *, target_hint: str) -> None:
-    unknown = set(entry) - _VISUALISER_ENTRY_KEYS
-    if unknown:
-        sorted_unknown = ", ".join(sorted(unknown))
-        raise ValueError(
-            f"Unknown keys in visualiser config {target_hint!r}: {sorted_unknown}. "
-            "Use 'constructor' for __init__ kwargs and 'call' for visualise() kwargs."
-        )
-
-
-def _validate_raitap_keys(raitap_cfg: dict[str, Any], *, assessor_name: str) -> None:
-    unknown = set(raitap_cfg) - _RAITAP_KEYS
-    if not unknown:
-        return
-    sorted_unknown = ", ".join(sorted(unknown))
-    sorted_valid = ", ".join(sorted(_RAITAP_KEYS))
-    raitap_log.warn(
-        f"Unknown robustness.raitap keys for assessor {assessor_name!r}: "
-        f"{sorted_unknown}. Supported RAITAP keys: {sorted_valid}.",
-    )
-
-
-def _warn_on_misplaced_raitap_call_keys(call_cfg: dict[str, Any], *, assessor_name: str) -> None:
-    misplaced = sorted(set(call_cfg).intersection(_MISPLACED_RAITAP_CALL_WARNING_KEYS))
-    if not misplaced:
-        return
-    keys = ", ".join(misplaced)
-    raitap_log.warn(
-        f"Assessor {assessor_name!r} has RAITAP-owned keys under 'call:': {keys}. "
-        "These keys belong under 'raitap:' while 'call:' is intended for library "
-        "kwargs only.",
-    )
-
-
-def _migrate_misplaced_raitap_call_keys(
-    call_cfg: dict[str, Any],
-    raitap_cfg: dict[str, Any],
-) -> None:
-    misplaced = sorted(set(call_cfg).intersection(_MISPLACED_RAITAP_CALL_WARNING_KEYS))
-    for key in misplaced:
-        value = call_cfg.pop(key)
-        raitap_cfg.setdefault(key, value)
-
-
-def _parse_assessor_config(assessor_config: Any) -> _ParsedAssessorConfig:
-    raw = _raw_assessor_config(assessor_config)
-    _validate_assessor_top_level_keys(raw)
-
-    target_path = str(raw.get("_target_", ""))
-    resolved_target = resolve_target(target_path, _ROBUSTNESS_PREFIX)
-    constructor_plain = _subdict(raw.get("constructor"), label="constructor")
-    call_plain = _subdict(raw.get("call"), label="call")
-    raitap_plain = _subdict(raw.get("raitap"), label="raitap")
-    assessor_name = resolved_target or target_path or "?"
-    _validate_raitap_keys(raitap_plain, assessor_name=assessor_name)
-    _warn_on_misplaced_raitap_call_keys(call_plain, assessor_name=assessor_name)
-    _migrate_misplaced_raitap_call_keys(call_plain, raitap_plain)
-
-    return _ParsedAssessorConfig(
-        raw=raw,
-        target_path=target_path,
-        resolved_target=resolved_target,
-        algorithm=raw.get("algorithm"),
-        constructor=constructor_plain,
-        call=call_plain,
-        raitap=raitap_plain,
-    )
-
-
-def _resolve_call_data_sources(call_kwargs: dict[str, Any]) -> dict[str, Any]:
-    """Replace ``call:`` values matching ``{source, n_samples}`` with loaded tensors."""
-    resolved: dict[str, Any] = {}
-    for key, value in call_kwargs.items():
-        if isinstance(value, dict) and set(value).issubset(_DATA_SOURCE_KEYS) and "source" in value:
-            source = value["source"]
-            n_samples = value.get("n_samples")
-            if n_samples is not None and not isinstance(n_samples, int):
-                raise TypeError(
-                    f"call.{key}.n_samples must be an int, got {type(n_samples).__name__}."
-                )
-            raitap_log.info(
-                "Resolving robustness call kwarg %r as data source %r (n_samples=%s)",
-                key,
-                source,
-                n_samples,
-            )
-            resolved[key] = load_tensor_from_source(str(source), n_samples=n_samples)
-        else:
-            resolved[key] = value
-    return resolved
-
-
-def _instantiate_assessor_from_parsed(
-    parsed: _ParsedAssessorConfig,
-) -> tuple[AssessorAdapter, str]:
-    instantiate_cfg: dict[str, Any] = {
-        **parsed.constructor,
-        "algorithm": parsed.algorithm,
-        "_target_": parsed.resolved_target,
-    }
-    try:
-        assessor = instantiate(instantiate_cfg)
-    except Exception as error:
-        raitap_log.exception("Assessor instantiation failed for target %r", parsed.target_path)
-        raise ValueError(
-            f"Could not instantiate assessor {parsed.target_path!r}.\n"
-            "Check that _target_ points to a valid AssessorAdapter implementation "
-            "(e.g. EmpiricalAttackAssessor or FormalVerificationAssessor subclass)."
-        ) from error
-
-    if not isinstance(assessor, AssessorAdapter):
-        raise ValueError(
-            f"Instantiated assessor {parsed.target_path!r} does not implement AssessorAdapter. "
-            "Configured assessors must have callable assess() and check_backend_compat() methods, "
-            "and a ``method_kind`` attribute."
-        )
-
-    return cast("AssessorAdapter", assessor), parsed.resolved_target
+def _parse_assessor_config(assessor_config: Any) -> ParsedAdapterConfig:
+    return parse_adapter_config(assessor_config, _SCHEMA)
 
 
 def _require_model_backend(model: object) -> ModelBackend:
@@ -312,7 +138,9 @@ class RobustnessAssessment:
             if input_metadata is not None:
                 raitap_cfg["input_metadata"] = input_metadata
 
-            merged_kwargs = _resolve_call_data_sources({**call_from_config, **kwargs})
+            merged_kwargs = resolve_call_data_sources(
+                {**call_from_config, **kwargs}, log_label="robustness call"
+            )
             merged_kwargs = backend._prepare_kwargs(merged_kwargs)
 
             return assessor.assess(
@@ -336,40 +164,37 @@ def create_assessor(assessor_config: Any) -> tuple[AssessorAdapter, str]:
     parsed = _PARSED_ASSESSOR_CONFIG_CACHE.get(id(assessor_config))
     if parsed is None:
         parsed = _parse_assessor_config(assessor_config)
-    return _instantiate_assessor_from_parsed(parsed)
+    return instantiate_adapter(
+        parsed,
+        protocol=AssessorAdapter,
+        schema=_SCHEMA,
+        instantiate_error_hint=(
+            "Check that _target_ points to a valid AssessorAdapter implementation "
+            "(e.g. EmpiricalAttackAssessor or FormalVerificationAssessor subclass)."
+        ),
+        type_error_hint=(
+            "Configured assessors must have callable assess() and check_backend_compat() methods, "
+            "and a ``method_kind`` attribute."
+        ),
+        instantiate_fn=lambda cfg: instantiate(cfg),
+    )
 
 
 def create_robustness_visualisers(
     assessor_config: Any,
 ) -> list[ConfiguredRobustnessVisualiser]:
-    raw = _raw_assessor_config(assessor_config)
-    out: list[ConfiguredRobustnessVisualiser] = []
+    return instantiate_visualisers(
+        assessor_config,
+        schema=_SCHEMA,
+        wrap=lambda viz, call: ConfiguredRobustnessVisualiser(visualiser=viz, call_kwargs=call),
+        instantiate_fn=lambda cfg: instantiate(cfg),
+    )
 
-    for visualiser_config in raw.get("visualisers", []):
-        entry = _visualiser_entry_to_dict(visualiser_config)
-        visualiser_target = str(entry.get("_target_", ""))
-        _validate_visualiser_entry_keys(entry, target_hint=visualiser_target or "?")
 
-        constructor_plain = _subdict(
-            entry.get("constructor"),
-            label=f"visualiser constructor ({visualiser_target})",
-        )
-        call_plain = _subdict(
-            entry.get("call"),
-            label=f"visualiser call ({visualiser_target})",
-        )
-        resolved_target = resolve_target(visualiser_target, _VISUALISER_PREFIX)
+# Internal-test back-compat thin wrappers (keep the test surface stable).
+def _raw_assessor_config(assessor_config: Any) -> dict[str, Any]:
+    return raw_config_dict(assessor_config)
 
-        instantiate_cfg: dict[str, Any] = {
-            **constructor_plain,
-            "_target_": resolved_target,
-        }
-        try:
-            visualiser = instantiate(instantiate_cfg)
-        except Exception as error:
-            raitap_log.exception("Visualiser instantiation failed for target %r", visualiser_target)
-            raise ValueError(f"Could not instantiate visualiser {visualiser_target!r}.") from error
 
-        out.append(ConfiguredRobustnessVisualiser(visualiser=visualiser, call_kwargs=call_plain))
-
-    return out
+def _resolve_call_data_sources(call_kwargs: dict[str, Any]) -> dict[str, Any]:
+    return resolve_call_data_sources(call_kwargs, log_label="robustness call")

--- a/src/raitap/robustness/factory.py
+++ b/src/raitap/robustness/factory.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, Any
 
 from hydra.utils import instantiate
 
-from raitap._adapter_factory import (
+from raitap.configs import resolve_run_dir
+from raitap.configs.adapter_factory import (
     AdapterSchema,
     ParsedAdapterConfig,
     instantiate_adapter,
@@ -15,7 +16,6 @@ from raitap._adapter_factory import (
     raw_config_dict,
     resolve_call_data_sources,
 )
-from raitap.configs import resolve_run_dir
 from raitap.models.backend import ModelBackend
 
 from .contracts import AssessorAdapter

--- a/src/raitap/transparency/factory.py
+++ b/src/raitap/transparency/factory.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import torch
 from hydra.utils import instantiate
-from omegaconf import DictConfig, OmegaConf
 
 from raitap import raitap_log
-from raitap.configs import cfg_to_dict, resolve_run_dir, resolve_target
-from raitap.data import load_tensor_from_source
+from raitap._adapter_factory import (
+    AdapterSchema,
+    ParsedAdapterConfig,
+    instantiate_adapter,
+    instantiate_visualisers,
+    parse_adapter_config,
+    raw_config_dict,
+    resolve_call_data_sources,
+)
+from raitap.configs import resolve_run_dir
 from raitap.models.backend import ModelBackend
 
 from .algorithm_allowlist import ensure_algorithm_in_allowlist
@@ -34,261 +41,42 @@ if TYPE_CHECKING:
     from .results import ExplanationResult
 
 _TRANSPARENCY_PREFIX = "raitap.transparency."
-_PARSED_EXPLAINER_CONFIG_CACHE: dict[int, _ParsedExplainerConfig] = {}
 
-_EXPLAINER_TOP_LEVEL_KEYS = frozenset(
-    {"_target_", "algorithm", "visualisers", "constructor", "call", "raitap"},
+_SCHEMA = AdapterSchema(
+    domain="transparency",
+    entity="explainer",
+    subdict_namespace="Transparency",
+    target_prefix=_TRANSPARENCY_PREFIX,
+    visualiser_prefix=_TRANSPARENCY_PREFIX,
+    top_level_keys=frozenset(
+        {"_target_", "algorithm", "visualisers", "constructor", "call", "raitap"}
+    ),
+    raitap_keys=frozenset(
+        {
+            "batch_size",
+            "input_metadata",
+            "show_progress",
+            "progress_desc",
+            "sample_ids",
+            "sample_names",
+            "show_sample_names",
+        }
+    ),
+    top_level_error_hint=(
+        "Put constructor args under 'constructor', library kwargs "
+        "(e.g. target, baselines) under 'call', and RAITAP-owned options "
+        "under 'raitap'."
+    ),
+    removed_raitap_keys={
+        "max_batch_size": "raitap.max_batch_size has been removed; use raitap.batch_size instead."
+    },
 )
 
-_VISUALISER_ENTRY_KEYS = frozenset({"_target_", "constructor", "call"})
-_RAITAP_KEYS = frozenset(
-    {
-        "batch_size",
-        "input_metadata",
-        "show_progress",
-        "progress_desc",
-        "sample_ids",
-        "sample_names",
-        "show_sample_names",
-    }
-)
-_MISPLACED_RAITAP_CALL_WARNING_KEYS = frozenset(
-    {
-        "batch_size",
-        "input_metadata",
-        "show_progress",
-        "progress_desc",
-        "sample_ids",
-        "sample_names",
-        "show_sample_names",
-    }
-)
-_REMOVED_RAITAP_KEYS = {
-    "max_batch_size": "raitap.max_batch_size has been removed; use raitap.batch_size instead."
-}
-
-# Keys that identify a dict value in ``call:`` as a data-source reference.
-# A value matches when it is a plain dict containing at least ``source``.
-_DATA_SOURCE_KEYS = frozenset({"source", "n_samples"})
+_PARSED_EXPLAINER_CONFIG_CACHE: dict[int, ParsedAdapterConfig] = {}
 
 
-class _ParsedExplainerConfig:
-    def __init__(
-        self,
-        *,
-        raw: dict[str, Any],
-        target_path: str,
-        resolved_target: str,
-        algorithm: Any,
-        constructor: dict[str, Any],
-        call: dict[str, Any],
-        raitap: dict[str, Any],
-    ) -> None:
-        self.raw = raw
-        self.target_path = target_path
-        self.resolved_target = resolved_target
-        self.algorithm = algorithm
-        self.constructor = constructor
-        self.call = call
-        self.raitap = raitap
-
-
-def _raw_transparency_config(explainer_config: Any) -> dict[str, Any]:
-    return cfg_to_dict(explainer_config)
-
-
-def _transparency_subdict(value: Any, *, label: str) -> dict[str, Any]:
-    """Normalise ``constructor`` / ``call`` blocks to a plain ``dict``."""
-    if value is None:
-        return {}
-    if isinstance(value, dict) and not value:
-        return {}
-    if isinstance(value, dict):
-        return dict(value)
-    if isinstance(value, DictConfig):
-        container = OmegaConf.to_container(value, resolve=True)
-        if not isinstance(container, dict):
-            raise TypeError(
-                f"Transparency {label!r} must be a mapping, got {type(container).__name__}."
-            )
-        return cast("dict[str, Any]", dict(container))
-    raise TypeError(
-        f"Transparency {label!r} must be a dict or DictConfig, got {type(value).__name__}."
-    )
-
-
-def _visualiser_entry_to_dict(visualiser_config: Any) -> dict[str, Any]:
-    if isinstance(visualiser_config, dict):
-        return dict(visualiser_config)
-    if isinstance(visualiser_config, DictConfig):
-        container = OmegaConf.to_container(visualiser_config, resolve=True)
-        if not isinstance(container, dict):
-            raise TypeError(
-                f"Each visualisers list entry must be a mapping, got {type(container).__name__}."
-            )
-        return cast("dict[str, Any]", dict(container))
-    raise TypeError(
-        "Each visualisers list entry must be a dict or DictConfig, "
-        f"got {type(visualiser_config).__name__}."
-    )
-
-
-def _validate_explainer_top_level_keys(raw: dict[str, Any]) -> None:
-    unknown = set(raw) - _EXPLAINER_TOP_LEVEL_KEYS
-    if unknown:
-        sorted_unknown = ", ".join(sorted(unknown))
-        raise ValueError(
-            f"Unknown transparency explainer config keys: {sorted_unknown}. "
-            "Put constructor args under 'constructor', library kwargs "
-            "(e.g. target, baselines) under 'call', and RAITAP-owned options "
-            "under 'raitap'."
-        )
-
-
-def _validate_visualiser_entry_keys(entry: dict[str, Any], *, target_hint: str) -> None:
-    unknown = set(entry) - _VISUALISER_ENTRY_KEYS
-    if unknown:
-        sorted_unknown = ", ".join(sorted(unknown))
-        raise ValueError(
-            f"Unknown keys in visualiser config {target_hint!r}: {sorted_unknown}. "
-            "Use 'constructor' for __init__ kwargs and 'call' for visualise() kwargs."
-        )
-
-
-def _validate_raitap_keys(raitap_cfg: dict[str, Any], *, explainer_name: str) -> None:
-    for key, message in _REMOVED_RAITAP_KEYS.items():
-        if key in raitap_cfg:
-            raise ValueError(message)
-
-    unknown = set(raitap_cfg) - _RAITAP_KEYS
-    if not unknown:
-        return
-
-    sorted_unknown = ", ".join(sorted(unknown))
-    sorted_valid = ", ".join(sorted(_RAITAP_KEYS))
-
-    raitap_log.warn(
-        f"Unknown transparency.raitap keys for explainer {explainer_name!r}: "
-        f"{sorted_unknown}. Supported RAITAP keys: {sorted_valid}.",
-    )
-
-
-def _warn_on_misplaced_raitap_call_keys(call_cfg: dict[str, Any], *, explainer_name: str) -> None:
-    misplaced = sorted(set(call_cfg).intersection(_MISPLACED_RAITAP_CALL_WARNING_KEYS))
-    if not misplaced:
-        return
-
-    keys = ", ".join(misplaced)
-
-    raitap_log.warn(
-        f"Explainer {explainer_name!r} has RAITAP-owned keys under 'call:': {keys}. "
-        "These keys usually belong under 'raitap:' while 'call:' is intended for "
-        "library kwargs only.",
-    )
-
-
-def _migrate_misplaced_raitap_call_keys(
-    call_cfg: dict[str, Any],
-    raitap_cfg: dict[str, Any],
-) -> None:
-    misplaced = sorted(set(call_cfg).intersection(_MISPLACED_RAITAP_CALL_WARNING_KEYS))
-    for key in misplaced:
-        value = call_cfg.pop(key)
-        raitap_cfg.setdefault(key, value)
-
-
-def _parse_explainer_config(explainer_config: Any) -> _ParsedExplainerConfig:
-    raw_transparency_config = _raw_transparency_config(explainer_config)
-    _validate_explainer_top_level_keys(raw_transparency_config)
-
-    target_path = str(raw_transparency_config.get("_target_", ""))
-    resolved_target = resolve_target(target_path, _TRANSPARENCY_PREFIX)
-    constructor_plain = _transparency_subdict(
-        raw_transparency_config.get("constructor"), label="constructor"
-    )
-    call_plain = _transparency_subdict(raw_transparency_config.get("call"), label="call")
-    raitap_plain = _transparency_subdict(raw_transparency_config.get("raitap"), label="raitap")
-    explainer_name = resolved_target or target_path or "?"
-    _validate_raitap_keys(raitap_plain, explainer_name=explainer_name)
-    _warn_on_misplaced_raitap_call_keys(call_plain, explainer_name=explainer_name)
-    _migrate_misplaced_raitap_call_keys(call_plain, raitap_plain)
-
-    return _ParsedExplainerConfig(
-        raw=raw_transparency_config,
-        target_path=target_path,
-        resolved_target=resolved_target,
-        algorithm=raw_transparency_config.get("algorithm"),
-        constructor=constructor_plain,
-        call=call_plain,
-        raitap=raitap_plain,
-    )
-
-
-def _resolve_call_data_sources(call_kwargs: dict[str, Any]) -> dict[str, Any]:
-    """
-    Resolve any data-source references inside ``call:`` kwargs.
-
-    A value is treated as a data-source reference when it is a plain ``dict``
-    whose keys are a subset of ``{"source", "n_samples"}`` and ``"source"`` is
-    present.  Such values are replaced with the loaded tensor so the downstream
-    explainer receives a ``torch.Tensor`` instead of a raw config dict.
-
-    Example YAML under ``call:``::
-
-        background_data:
-          source: "imagenet_samples"   # required: named sample, URL, or local path
-          n_samples: 50                # optional: randomly subsample N rows
-
-    This is a generic mechanism — any ``call:`` parameter whose value matches
-    the pattern above will be resolved, regardless of explainer type.
-    """
-    resolved: dict[str, Any] = {}
-    for key, value in call_kwargs.items():
-        if isinstance(value, dict) and set(value).issubset(_DATA_SOURCE_KEYS) and "source" in value:
-            source = value["source"]
-            n_samples = value.get("n_samples")
-            if n_samples is not None and not isinstance(n_samples, int):
-                raise TypeError(
-                    f"call.{key}.n_samples must be an int, got {type(n_samples).__name__}."
-                )
-            raitap_log.info(
-                "Resolving call kwarg %r as data source %r (n_samples=%s)",
-                key,
-                source,
-                n_samples,
-            )
-            resolved[key] = load_tensor_from_source(str(source), n_samples=n_samples)
-        else:
-            resolved[key] = value
-    return resolved
-
-
-def _instantiate_explainer_from_parsed(
-    parsed: _ParsedExplainerConfig,
-) -> tuple[ExplainerAdapter, str]:
-    instantiate_cfg: dict[str, Any] = {
-        **parsed.constructor,
-        "algorithm": parsed.algorithm,
-        "_target_": parsed.resolved_target,
-    }
-
-    try:
-        explainer = instantiate(instantiate_cfg)
-    except Exception as error:
-        raitap_log.exception("Explainer instantiation failed for target %r", parsed.target_path)
-        raise ValueError(
-            f"Could not instantiate explainer {parsed.target_path!r}.\n"
-            "Check that _target_ points to a valid ExplainerAdapter implementation "
-            "(e.g. AttributionOnlyExplainer or FullExplainer subclass)."
-        ) from error
-
-    if not isinstance(explainer, ExplainerAdapter):
-        raise ValueError(
-            f"Instantiated explainer {parsed.target_path!r} does not implement ExplainerAdapter. "
-            "Configured explainers must have callable explain() and check_backend_compat() methods."
-        )
-
-    return cast("ExplainerAdapter", explainer), parsed.resolved_target
+def _parse_explainer_config(explainer_config: Any) -> ParsedAdapterConfig:
+    return parse_adapter_config(explainer_config, _SCHEMA)
 
 
 def _require_model_backend(model: object) -> ModelBackend:
@@ -410,7 +198,9 @@ class Explanation:
             if input_metadata is not None:
                 raitap_cfg["input_metadata"] = input_metadata
 
-            merged_kwargs = _resolve_call_data_sources({**call_from_config, **kwargs})
+            merged_kwargs = resolve_call_data_sources(
+                {**call_from_config, **kwargs}, log_label="call"
+            )
             merged_kwargs = backend._prepare_kwargs(merged_kwargs)
 
             return explainer.explain(
@@ -433,40 +223,28 @@ def create_explainer(explainer_config: Any) -> tuple[ExplainerAdapter, str]:
     parsed = _PARSED_EXPLAINER_CONFIG_CACHE.get(id(explainer_config))
     if parsed is None:
         parsed = _parse_explainer_config(explainer_config)
-    return _instantiate_explainer_from_parsed(parsed)
+    return instantiate_adapter(
+        parsed,
+        protocol=ExplainerAdapter,
+        schema=_SCHEMA,
+        instantiate_error_hint=(
+            "Check that _target_ points to a valid ExplainerAdapter implementation "
+            "(e.g. AttributionOnlyExplainer or FullExplainer subclass)."
+        ),
+        type_error_hint=(
+            "Configured explainers must have callable explain() and check_backend_compat() methods."
+        ),
+        instantiate_fn=lambda cfg: instantiate(cfg),
+    )
 
 
 def create_visualisers(explainer_config: Any) -> list[ConfiguredVisualiser]:
-    raw_transparency_config = _raw_transparency_config(explainer_config)
-    out: list[ConfiguredVisualiser] = []
-
-    for visualiser_config in raw_transparency_config.get("visualisers", []):
-        entry = _visualiser_entry_to_dict(visualiser_config)
-        visualiser_target = str(entry.get("_target_", ""))
-        _validate_visualiser_entry_keys(entry, target_hint=visualiser_target or "?")
-
-        constructor_plain = _transparency_subdict(
-            entry.get("constructor"), label=f"visualiser constructor ({visualiser_target})"
-        )
-        call_plain = _transparency_subdict(
-            entry.get("call"), label=f"visualiser call ({visualiser_target})"
-        )
-        resolved_target = resolve_target(visualiser_target, _TRANSPARENCY_PREFIX)
-
-        instantiate_cfg: dict[str, Any] = {
-            **constructor_plain,
-            "_target_": resolved_target,
-        }
-
-        try:
-            visualiser = instantiate(instantiate_cfg)
-        except Exception as error:
-            raitap_log.exception("Visualiser instantiation failed for target %r", visualiser_target)
-            raise ValueError(f"Could not instantiate visualiser {visualiser_target!r}.") from error
-
-        out.append(ConfiguredVisualiser(visualiser=visualiser, call_kwargs=call_plain))
-
-    return out
+    return instantiate_visualisers(
+        explainer_config,
+        schema=_SCHEMA,
+        wrap=lambda viz, call: ConfiguredVisualiser(visualiser=viz, call_kwargs=call),
+        instantiate_fn=lambda cfg: instantiate(cfg),
+    )
 
 
 def check_explainer_visualiser_compat(
@@ -516,3 +294,13 @@ def _enum_frozenset(value: object, enum_type: type[Any]) -> frozenset[Any]:
         else:
             out.append(enum_type(str(item)))
     return frozenset(out)
+
+
+# Internal-test back-compat: a couple of older tests touch these names. Keep
+# them as thin wrappers so the test surface is unchanged across the refactor.
+def _raw_transparency_config(explainer_config: Any) -> dict[str, Any]:
+    return raw_config_dict(explainer_config)
+
+
+def _resolve_call_data_sources(call_kwargs: dict[str, Any]) -> dict[str, Any]:
+    return resolve_call_data_sources(call_kwargs, log_label="call")

--- a/src/raitap/transparency/factory.py
+++ b/src/raitap/transparency/factory.py
@@ -6,7 +6,8 @@ import torch
 from hydra.utils import instantiate
 
 from raitap import raitap_log
-from raitap._adapter_factory import (
+from raitap.configs import resolve_run_dir
+from raitap.configs.adapter_factory import (
     AdapterSchema,
     ParsedAdapterConfig,
     instantiate_adapter,
@@ -15,7 +16,6 @@ from raitap._adapter_factory import (
     raw_config_dict,
     resolve_call_data_sources,
 )
-from raitap.configs import resolve_run_dir
 from raitap.models.backend import ModelBackend
 
 from .algorithm_allowlist import ensure_algorithm_in_allowlist


### PR DESCRIPTION
## Summary
- Extracts ~250 LOC of identical YAML-config plumbing from `transparency/factory.py` and `robustness/factory.py` into a new shared module `raitap/_adapter_factory.py`.
- Both domain factories now configure the shared parser via a data-only `AdapterSchema` and consume `parse_adapter_config`, `instantiate_adapter`, `instantiate_visualisers`, `resolve_call_data_sources`.
- Per-domain logic (compat checks, run-method dispatch, result wrapping, parsed-config caches) stays inside each domain factory — the shared module is plumbing only.

## Stack note
- This branch is **stacked on `129-implement-marabou-robustness-adapter`** because it depends on `SemanticallyDescribable` (introduced there). Once #134 lands, rebase with `git rebase --onto origin/main <last-marabou-commit>` — do not `git merge main` (would re-trigger the squash-merge conflict storm).

## Design rules locked in
- `AdapterSchema` is data-only (no callbacks, no methods). Adding hooks turns it into a god-object with the same surface area as the two factories combined.
- `ConfiguredVisualiser` vs `ConfiguredRobustnessVisualiser` stay per-domain; the shared module accepts a `wrap` callable.
- Parsed-config cache stays per-domain (two lines of dup ≪ confusion of a shared cross-domain cache).
- Compat checks stay in domain factories (their entry-point classes call them after the shared pipeline).
- `instantiate_fn` is plumbed through both `instantiate_adapter` and `instantiate_visualisers` so per-domain `monkeypatch.setattr("raitap.transparency.factory.instantiate", …)` test idioms keep working without test edits.

## Verification (Phase 1 gate)
- `uv run pytest -m "not e2e and not cuda"` — **580 passed, 18 skipped, 0 failed**
- `uv run ruff check src/raitap` — clean
- `uv run ruff format --check src/raitap` — clean
- `uv run pyright src/raitap/_adapter_factory.py src/raitap/{robustness,transparency}/factory.py` — clean
- `git diff --stat`: **net −387 LOC in factory files** (529 → 142), new shared module +400 LOC. Most of the savings come from collapsing two parallel `_subdict` / `_validate_*` / `_warn_*` / `_migrate_*` / `_parse_*` / `_instantiate_*` / `_resolve_call_data_sources` ladders into one schema-driven path.
- **Zero test files modified.**

## Out of scope (Phase 2+)
- Unifying `hints_for_assessor` + `explainer_capability` semantics resolvers under a shared `lookup_registry(adapter)` (Phase 2).
- Promoting `ConfiguredVisualiser` to a single shared type (Phase 3).
- Unifying `Explanation` / `RobustnessAssessment` entry-point classes (Phase 4 — only if Phases 1–3 feel natural).

## Test plan
- [x] Full non-e2e suite green
- [ ] Marabou e2e lane on CI
- [ ] Confirm ruff format / pyright clean on CI