### PR TITLE
feat(infra): error-rethrow layer for wrapped third-party libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ mlruns/
 .claude/
 conductor/
 .gitnexus
+
+# Git worktrees
+.worktrees/

--- a/docs/contributor/logging.md
+++ b/docs/contributor/logging.md
@@ -74,7 +74,9 @@ warning anyway.
 
 ## Raising errors
 
-Don't do it through `raitap_log`. Use plain `raise`:
+Don't do it through `raitap_log`. Use plain `raise` for raitap-originated
+errors, and use the `rethrow` context manager when wrapping a third-party
+library that throws confusing messages:
 
 ```python
 raise ValueError(
@@ -83,10 +85,44 @@ raise ValueError(
 )
 ```
 
-Issue #22 introduces raitap exception classes that carry a
-`Diagnostic` payload (subsystem, file, line, third-party lib) so the rich
-handler can frame raised exceptions the same way it frames warnings. Until
-then, plain `raise` with a helpful message is the right tool.
+For wrapped third-party calls (captum / shap / foolbox / torchattacks), use
+`raitap.utils.errors.rethrow` to rewrap matched error messages into a
+user-actionable `AdapterError` carrying a `Diagnostic`. The rich handler
+renders raised `RaitapError` subclasses with the same `Subsystem · via <lib>
+· View docs` chips as warnings, and the top-level `print_failure_panel`
+suppresses the raw traceback so the user sees the actionable copy first.
+
+```python
+# src/raitap/transparency/explainers/shap_explainer.py
+import re
+from raitap.utils.diagnostics import Subsystem
+from raitap.utils.errors import rethrow
+
+class ShapExplainer:
+    # Curated patterns: original message regex → replacement copy.
+    # Matched against ``str(exc)``; first hit wins. Unmatched errors propagate
+    # unchanged so real bugs don't get masked.
+    error_messages = {
+        re.compile(r"BackwardHookFunctionBackward is a view"): (
+            "DeepExplainer can fail on PyTorch models that use SiLU "
+            "activations (for example EfficientNet variants). Use "
+            "alternatives like GradientExplainer."
+        ),
+    }
+
+    def compute_attributions(self, model, inputs, ...):
+        ...
+        with rethrow(
+            subsystem=Subsystem.transparency,
+            third_party_lib="shap",
+            message_map=type(self).error_messages,
+        ):
+            shap_values = explainer.shap_values(inputs)
+```
+
+The original exception is preserved on `__cause__`, so the raw library
+traceback stays available for debugging — only the user-facing top is
+rewritten.
 
 ## Subsystem attribution
 
@@ -161,11 +197,20 @@ mental models. Use `raitap_log`.
 - `src/raitap/utils/diagnostics.py` — `Subsystem` enum, frame-walking
   classifier, third-party library detection (libs declared in each
   subsystem's `__init__.py` as `THIRD_PARTY_LIBS`).
+- `src/raitap/utils/errors.py` — `RaitapError`, `AdapterError`,
+  traceback-walking diagnostic resolver, and the `rethrow` context manager
+  that adapters use to rewrap confusing third-party errors.
+- `src/raitap/utils/colour.py` — two-shade colour palette (`<hue>_base` /
+  `<hue>_light`) plus the Rich `Theme`. Edit here when adding or
+  rebalancing colours; renderers reference tokens, not raw ANSI names.
 - `src/raitap/utils/console.py` — the rich `RichHandler` subclass that
-  formats warning records into panels with subsystem chips. Calls
-  `logging.captureWarnings(True)` so external log sinks (MLflow, Airflow)
-  see warnings too.
+  formats WARNING+ records into panels with subsystem / via-lib / docs
+  chips. Calls `logging.captureWarnings(True)` so external log sinks
+  (MLflow, Airflow) see warnings too. `print_failure_panel` mirrors the
+  same chip composition for top-level crashes.
 
 If you're touching that code, expect to also update
-`src/raitap/utils/tests/test_log.py` and
-`src/raitap/utils/tests/test_diagnostics.py`.
+`src/raitap/utils/tests/test_log.py`,
+`src/raitap/utils/tests/test_diagnostics.py`,
+`src/raitap/utils/tests/test_errors.py`, and
+`src/raitap/utils/tests/test_console_errors.py`.

--- a/src/raitap/configs/model/efficientnet_b0.yaml
+++ b/src/raitap/configs/model/efficientnet_b0.yaml
@@ -1,0 +1,4 @@
+# EfficientNet-B0 — uses SiLU activations, which trigger the
+# DeepExplainer ``BackwardHookFunctionBackward`` view+inplace error.
+# Pair with ``transparency: shap_deep_silu_bug`` to exercise the rethrow.
+source: efficientnet_b0

--- a/src/raitap/configs/transparency/shap_deep_silu_bug.yaml
+++ b/src/raitap/configs/transparency/shap_deep_silu_bug.yaml
@@ -1,0 +1,17 @@
+# Reproducer for issue #22: SHAP DeepExplainer + SiLU activations.
+# Combined with ``model: efficientnet_b0`` this triggers the
+# ``BackwardHookFunctionBackward view+inplace`` RuntimeError, which the
+# rethrow layer rewraps into a user-actionable message pointing at
+# GradientExplainer.
+shap_deep_silu:
+  _target_: ShapExplainer
+  algorithm: DeepExplainer
+  call:
+    target: 0
+  raitap:
+    batch_size: 1
+    progress_desc: "SHAP batches"
+  visualisers:
+    - _target_: ShapImageVisualiser
+      constructor:
+        max_samples: 1

--- a/src/raitap/robustness/assessors/foolbox_assessor.py
+++ b/src/raitap/robustness/assessors/foolbox_assessor.py
@@ -6,12 +6,16 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import torch
 
+from raitap.utils.diagnostics import Subsystem
+from raitap.utils.errors import rethrow
+
 from ..contracts import MethodKind, Objective, PerturbationNorm, ThreatModel
 from ..exceptions import AssessorBackendIncompatibilityError
 from ..semantics import AssessorSemanticsHints
 from .base_assessor import EmpiricalAttackAssessor, _prepare_inputs_for_forward
 
 if TYPE_CHECKING:
+    import re
     from collections.abc import Mapping
 
     from torch import nn
@@ -84,6 +88,10 @@ class FoolboxAssessor(EmpiricalAttackAssessor):
         ),
     }
     budget_kwarg_source = "call_kwargs"
+
+    # Curated patterns for confusing foolbox errors. Seed empty; extend as we
+    # observe confusing errors in practice. See :func:`raitap.utils.errors.rethrow`.
+    error_messages: ClassVar[Mapping[re.Pattern[str], str]] = {}
 
     def __init__(
         self,
@@ -158,7 +166,12 @@ class FoolboxAssessor(EmpiricalAttackAssessor):
             preprocessing=self.preprocessing,
         )
 
-        raw, clipped, success = attack(fmodel, inputs_dev, targets_dev, epsilons=eps)
+        with rethrow(
+            subsystem=Subsystem.robustness,
+            third_party_lib="foolbox",
+            message_map=type(self).error_messages,
+        ):
+            raw, clipped, success = attack(fmodel, inputs_dev, targets_dev, epsilons=eps)
         del raw  # unclipped — we keep the clipped tensor only
         if isinstance(clipped, list):
             raise TypeError(

--- a/src/raitap/robustness/assessors/torchattacks_assessor.py
+++ b/src/raitap/robustness/assessors/torchattacks_assessor.py
@@ -6,12 +6,16 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import torch
 
+from raitap.utils.diagnostics import Subsystem
+from raitap.utils.errors import rethrow
+
 from ..contracts import MethodKind, Objective, PerturbationNorm, ThreatModel
 from ..exceptions import AssessorBackendIncompatibilityError
 from ..semantics import AssessorSemanticsHints
 from .base_assessor import EmpiricalAttackAssessor, _prepare_inputs_for_forward
 
 if TYPE_CHECKING:
+    import re
     from collections.abc import Mapping
 
     from torch import nn
@@ -96,6 +100,10 @@ class TorchattacksAssessor(EmpiricalAttackAssessor):
         ),
     }
 
+    # Curated patterns for confusing torchattacks errors. Seed empty; extend as
+    # we observe confusing errors in practice. See :func:`raitap.utils.errors.rethrow`.
+    error_messages: ClassVar[Mapping[re.Pattern[str], str]] = {}
+
     def __init__(self, algorithm: str, **init_kwargs: Any) -> None:
         self.algorithm = algorithm
         self.init_kwargs = dict(init_kwargs)
@@ -155,15 +163,20 @@ class TorchattacksAssessor(EmpiricalAttackAssessor):
             targets, model=model, backend=backend
         ).contiguous()
 
-        if target_kwargs is not None:
-            adversarial = attack(
-                inputs_dev,
-                _prepare_inputs_for_forward(
-                    target_kwargs, model=model, backend=backend
-                ).contiguous(),
-            )
-        else:
-            adversarial = attack(inputs_dev, targets_dev)
+        with rethrow(
+            subsystem=Subsystem.robustness,
+            third_party_lib="torchattacks",
+            message_map=type(self).error_messages,
+        ):
+            if target_kwargs is not None:
+                adversarial = attack(
+                    inputs_dev,
+                    _prepare_inputs_for_forward(
+                        target_kwargs, model=model, backend=backend
+                    ).contiguous(),
+                )
+            else:
+                adversarial = attack(inputs_dev, targets_dev)
         return adversarial.detach()
 
     def _maybe_set_targeted(

--- a/src/raitap/run/__main__.py
+++ b/src/raitap/run/__main__.py
@@ -21,6 +21,7 @@ from raitap.utils.console import (
     print_failure_panel,
     setup_logging,
 )
+from raitap.utils.errors import RaitapError
 
 if TYPE_CHECKING:
     from raitap.configs.schema import AppConfig
@@ -76,6 +77,12 @@ def _hydra_main(config: AppConfig) -> None:
     except Exception as exc:
         duration = _format_duration(time.perf_counter() - start_time)
         print_failure_panel(exc, duration)
+        # RaitapError already carries a user-actionable message + diagnostic
+        # chips in the failure panel; the raw traceback is noise on top of
+        # that, so exit cleanly. Non-raitap exceptions keep propagating so
+        # Hydra/rich_traceback can still surface the full stack for triage.
+        if isinstance(exc, RaitapError):
+            sys.exit(1)
         raise
     duration = _format_duration(time.perf_counter() - start_time)
     print_complete_panel(duration)

--- a/src/raitap/transparency/explainers/captum_explainer.py
+++ b/src/raitap/transparency/explainers/captum_explainer.py
@@ -8,6 +8,8 @@ from raitap import raitap_log
 from raitap.transparency.algorithm_allowlist import ensure_algorithm_in_allowlist
 from raitap.transparency.contracts import ExplanationPayloadKind, MethodFamily
 from raitap.transparency.exceptions import ExplainerBackendIncompatibilityError
+from raitap.utils.diagnostics import Subsystem
+from raitap.utils.errors import rethrow
 
 from .base_explainer import AttributionOnlyExplainer
 
@@ -22,6 +24,7 @@ raitap_log.suppress(
 )
 
 if TYPE_CHECKING:
+    import re
     from collections.abc import Mapping
 
     import torch
@@ -66,6 +69,10 @@ class CaptumExplainer(AttributionOnlyExplainer):
             "Lime",
         }
     )
+
+    # Curated patterns for confusing Captum errors. Seed empty; extend as we
+    # observe confusing errors in practice. See :func:`raitap.utils.errors.rethrow`.
+    error_messages: ClassVar[Mapping[re.Pattern[str], str]] = {}
 
     def __init__(self, algorithm: str, **init_kwargs):
         """
@@ -145,17 +152,22 @@ class CaptumExplainer(AttributionOnlyExplainer):
         if self.algorithm == "Occlusion":
             attr_kwargs = _normalise_occlusion_kwargs(attr_kwargs)
 
-        # Instantiate method with model and constructor args
-        method = method_class(model, **init_kwargs)
+        with rethrow(
+            subsystem=Subsystem.transparency,
+            third_party_lib="captum",
+            message_map=type(self).error_messages,
+        ):
+            # Instantiate method with model and constructor args
+            method = method_class(model, **init_kwargs)
 
-        # Compute attributions using unified Captum API
-        # Only pass baselines if provided (some methods don't support it)
-        if baselines is not None:
-            attributions = method.attribute(
-                inputs, target=target, baselines=baselines, **attr_kwargs
-            )
-        else:
-            attributions = method.attribute(inputs, target=target, **attr_kwargs)
+            # Compute attributions using unified Captum API
+            # Only pass baselines if provided (some methods don't support it)
+            if baselines is not None:
+                attributions = method.attribute(
+                    inputs, target=target, baselines=baselines, **attr_kwargs
+                )
+            else:
+                attributions = method.attribute(inputs, target=target, **attr_kwargs)
 
         # Captum already returns torch.Tensor, so just return
         return attributions

--- a/src/raitap/transparency/explainers/shap_explainer.py
+++ b/src/raitap/transparency/explainers/shap_explainer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import torch
@@ -11,6 +12,8 @@ from raitap import raitap_log
 from raitap.transparency.algorithm_allowlist import ensure_algorithm_in_allowlist
 from raitap.transparency.contracts import ExplanationPayloadKind, MethodFamily
 from raitap.transparency.exceptions import ExplainerBackendIncompatibilityError
+from raitap.utils.diagnostics import Subsystem
+from raitap.utils.errors import rethrow
 
 from .base_explainer import AttributionOnlyExplainer
 
@@ -82,6 +85,19 @@ class ShapExplainer(AttributionOnlyExplainer):
     }
 
     ONNX_COMPATIBLE_ALGORITHMS: frozenset[str] = frozenset({"KernelExplainer"})
+
+    # Curated patterns for confusing SHAP errors. Matched against ``str(exc)``;
+    # first hit wins. See :func:`raitap.utils.errors.rethrow`.
+    error_messages: ClassVar[Mapping[re.Pattern[str], str]] = {
+        re.compile(
+            r"Output \d+ of BackwardHookFunctionBackward is a view "
+            r"and is being modified inplace",
+        ): (
+            "DeepExplainer can fail on PyTorch models that use SiLU activations "
+            "(for example EfficientNet variants) due to autograd/in-place "
+            "limitations. Use alternatives like GradientExplainer."
+        ),
+    }
 
     def __init__(self, algorithm: str, **init_kwargs):
         """
@@ -191,13 +207,18 @@ class ShapExplainer(AttributionOnlyExplainer):
         # Compute SHAP values using unified SHAP API
         # GradientExplainer and DeepExplainer expect torch tensors
         # KernelExplainer and TreeExplainer expect numpy arrays
-        if self.algorithm in ("GradientExplainer", "DeepExplainer"):
-            # Keep as tensor for PyTorch-based explainers
-            shap_values = explainer.shap_values(inputs, **shap_kwargs)
-        else:
-            # Convert to numpy for model-agnostic explainers
-            inputs_np = inputs.cpu().numpy() if isinstance(inputs, torch.Tensor) else inputs
-            shap_values = explainer.shap_values(inputs_np, **shap_kwargs)
+        with rethrow(
+            subsystem=Subsystem.transparency,
+            third_party_lib="shap",
+            message_map=type(self).error_messages,
+        ):
+            if self.algorithm in ("GradientExplainer", "DeepExplainer"):
+                # Keep as tensor for PyTorch-based explainers
+                shap_values = explainer.shap_values(inputs, **shap_kwargs)
+            else:
+                # Convert to numpy for model-agnostic explainers
+                inputs_np = inputs.cpu().numpy() if isinstance(inputs, torch.Tensor) else inputs
+                shap_values = explainer.shap_values(inputs_np, **shap_kwargs)
 
         # Handle multi-class outputs: SHAP returns list of arrays for each class
         # or a single array with shape (*input_shape, num_classes)

--- a/src/raitap/transparency/explainers/tests/test_shap_explainer_errors.py
+++ b/src/raitap/transparency/explainers/tests/test_shap_explainer_errors.py
@@ -1,0 +1,53 @@
+"""Adapter-level rethrow coverage for :class:`ShapExplainer`."""
+
+from __future__ import annotations
+
+import pytest
+
+from raitap.transparency.explainers import ShapExplainer
+from raitap.utils.diagnostics import Subsystem
+from raitap.utils.errors import AdapterError, rethrow
+
+
+def test_error_messages_contains_silu_entry() -> None:
+    """The seed pattern from issue #22 must match the original SHAP error text."""
+    original = (
+        "Output 0 of BackwardHookFunctionBackward is a view and is being modified "
+        "inplace. This view was created inside a custom Function (or because an "
+        "input was returned as-is) and the autograd logic to handle view+inplace "
+        "would override the custom backward associated with the custom Function, "
+        "leading to incorrect gradients. This behavior is forbidden."
+    )
+    hits = [
+        replacement
+        for pattern, replacement in ShapExplainer.error_messages.items()
+        if pattern.search(original)
+    ]
+    assert hits, "Expected the SiLU/DeepExplainer pattern to match the issue's example error."
+    assert "GradientExplainer" in hits[0]
+
+
+def test_silu_runtime_error_is_rewrapped() -> None:
+    """End-to-end: rethrow context using ShapExplainer.error_messages rewraps the
+    canonical SiLU :class:`RuntimeError` into an :class:`AdapterError`.
+
+    Exercising the dict via :func:`rethrow` directly avoids needing the optional
+    ``shap`` dependency, while still proving the dict + wrapper compose correctly.
+    """
+    with (
+        pytest.raises(AdapterError) as info,
+        rethrow(
+            subsystem=Subsystem.transparency,
+            third_party_lib="shap",
+            message_map=ShapExplainer.error_messages,
+        ),
+    ):
+        raise RuntimeError(
+            "Output 0 of BackwardHookFunctionBackward is a view and is being modified inplace."
+        )
+    exc = info.value
+    assert "GradientExplainer" in str(exc)
+    assert isinstance(exc.__cause__, RuntimeError)
+    assert exc.diagnostic is not None
+    assert exc.diagnostic.subsystem == Subsystem.transparency
+    assert exc.diagnostic.third_party_lib == "shap"

--- a/src/raitap/utils/__init__.py
+++ b/src/raitap/utils/__init__.py
@@ -3,7 +3,15 @@
 from __future__ import annotations
 
 from raitap.utils.diagnostics import Diagnostic
+from raitap.utils.errors import AdapterError, RaitapError, rethrow
 from raitap.utils.log import raitap_log
 from raitap.utils.serialization import to_json_serialisable
 
-__all__ = ["Diagnostic", "raitap_log", "to_json_serialisable"]
+__all__ = [
+    "AdapterError",
+    "Diagnostic",
+    "RaitapError",
+    "raitap_log",
+    "rethrow",
+    "to_json_serialisable",
+]

--- a/src/raitap/utils/colour.py
+++ b/src/raitap/utils/colour.py
@@ -1,0 +1,69 @@
+"""Raitap colour palette + Rich theme.
+
+Two layers:
+
+- :data:`BASE_TOKENS` — the raw palette. Each hue exposes a ``_base`` shade
+  (used for borders / primary text) and a ``_light`` shade (used for
+  secondary chips and dimmed accents). Adding or rebalancing a colour means
+  editing one row here; nothing downstream hard-codes ANSI names.
+- :data:`SEMANTIC_TOKENS` — semantic names (``logging.level.warning``,
+  ``log.time``, …) that reference base tokens. Renderers should refer to
+  these where the *meaning* is what matters; base tokens are for places where
+  a hue choice is intentional (a warning panel using ``yellow_base``).
+
+:data:`THEME` is the Rich :class:`~rich.theme.Theme` consumed by the console
+factories — it merges both layers (with semantic tokens dereferenced to raw
+ANSI colours, since Rich can't chase references inside theme values).
+
+Naming convention: ``<hue>_<shade>``. Underscores rather than dots because
+Rich's style parser can't carry dots through ``[name]`` markup lookups.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from rich.theme import Theme
+
+# Raw palette. Two shades per hue keeps the visual hierarchy explicit:
+# ``_base`` for the dominant element of a region (border, headline),
+# ``_light`` for chips / metadata that should recede slightly.
+BASE_TOKENS: Final[dict[str, str]] = {
+    "red_base": "red",
+    "red_light": "bright_red",
+    "yellow_base": "yellow",
+    "yellow_light": "bright_yellow",
+    "green_base": "green",
+    "green_light": "bright_green",
+    "cyan_base": "cyan",
+    "cyan_light": "bright_cyan",
+}
+
+# Semantic aliases. Values are base-token *names*; the resolver below maps
+# them to raw ANSI colours when constructing the Rich theme. Renderers can
+# still reference base tokens directly when the hue choice is intentional.
+SEMANTIC_TOKENS: Final[dict[str, str]] = {
+    "log.time": "cyan_base",
+    "log.message": "default",  # passthrough: keep the terminal's foreground.
+    "logging.level.info": "cyan_base",
+    "logging.level.warning": "yellow_light",
+    "logging.level.error": "red_base",
+}
+
+
+def _resolve(token: str) -> str:
+    """Return the raw ANSI colour for a token (base token or ``default``)."""
+    if token == "default":
+        return token
+    return BASE_TOKENS[token]
+
+
+THEME: Final[Theme] = Theme(
+    {
+        **BASE_TOKENS,
+        **{name: _resolve(ref) for name, ref in SEMANTIC_TOKENS.items()},
+    }
+)
+
+
+__all__ = ["BASE_TOKENS", "SEMANTIC_TOKENS", "THEME"]

--- a/src/raitap/utils/colour.py
+++ b/src/raitap/utils/colour.py
@@ -1,69 +1,87 @@
-"""Raitap colour palette + Rich theme.
+"""Raitap colour palette.
 
 Two layers:
 
-- :data:`BASE_TOKENS` — the raw palette. Each hue exposes a ``_base`` shade
-  (used for borders / primary text) and a ``_light`` shade (used for
-  secondary chips and dimmed accents). Adding or rebalancing a colour means
-  editing one row here; nothing downstream hard-codes ANSI names.
-- :data:`SEMANTIC_TOKENS` — semantic names (``logging.level.warning``,
-  ``log.time``, …) that reference base tokens. Renderers should refer to
-  these where the *meaning* is what matters; base tokens are for places where
-  a hue choice is intentional (a warning panel using ``yellow_base``).
+- :class:`Status` — the semantic axis. ``WARNING``, ``ERROR``, ``SUCCESS``,
+  ``INFO``. Each carries a hue plus the conventional icon/label used in
+  framed status output. Renderers should talk in terms of ``Status``, not
+  ANSI colour names.
+- :func:`colour` — resolves a :class:`Status` to a :class:`Shades` pair of
+  Rich :class:`~rich.style.Style` instances (``base`` for the dominant
+  region, ``light`` for secondary chips). :class:`Style` composes via ``+``,
+  which is what makes ``colour(Status.ERROR).light + Style(link=url)``
+  build cleanly without string concatenation.
 
-:data:`THEME` is the Rich :class:`~rich.theme.Theme` consumed by the console
-factories — it merges both layers (with semantic tokens dereferenced to raw
-ANSI colours, since Rich can't chase references inside theme values).
-
-Naming convention: ``<hue>_<shade>``. Underscores rather than dots because
-Rich's style parser can't carry dots through ``[name]`` markup lookups.
+:data:`THEME` keeps a tiny set of ``logging.level.*`` aliases so the Rich
+log formatter colours the level prefix consistently with the Status axis.
+Most rendering should hold :class:`Style` instances directly rather than
+referencing theme names.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
 from typing import Final
 
+from rich.style import Style
 from rich.theme import Theme
 
-# Raw palette. Two shades per hue keeps the visual hierarchy explicit:
-# ``_base`` for the dominant element of a region (border, headline),
-# ``_light`` for chips / metadata that should recede slightly.
-BASE_TOKENS: Final[dict[str, str]] = {
-    "red_base": "red",
-    "red_light": "bright_red",
-    "yellow_base": "yellow",
-    "yellow_light": "bright_yellow",
-    "green_base": "green",
-    "green_light": "bright_green",
-    "cyan_base": "cyan",
-    "cyan_light": "bright_cyan",
-}
 
-# Semantic aliases. Values are base-token *names*; the resolver below maps
-# them to raw ANSI colours when constructing the Rich theme. Renderers can
-# still reference base tokens directly when the hue choice is intentional.
-SEMANTIC_TOKENS: Final[dict[str, str]] = {
-    "log.time": "cyan_base",
-    "log.message": "default",  # passthrough: keep the terminal's foreground.
-    "logging.level.info": "cyan_base",
-    "logging.level.warning": "yellow_light",
-    "logging.level.error": "red_base",
-}
+class Status(Enum):
+    """Semantic axis for status output.
+
+    Each member binds a hue, a leading glyph, and the canonical label that
+    appears in framed status output. Callers override ``default_label`` per
+    site when the wording needs to differ (e.g. ``"Failure"`` for the
+    top-level crash panel even though it's an :attr:`ERROR` underneath).
+    """
+
+    WARNING = ("yellow", "⚠︎  ", "Warning")
+    ERROR = ("red", "✗ ", "Error")
+    SUCCESS = ("green", "✓ ", "Complete")
+    INFO = ("cyan", "▸ ", "Info")
+
+    def __init__(self, hue: str, icon: str, default_label: str) -> None:
+        self.hue: str = hue
+        self.icon: str = icon
+        self.default_label: str = default_label
 
 
-def _resolve(token: str) -> str:
-    """Return the raw ANSI colour for a token (base token or ``default``)."""
-    if token == "default":
-        return token
-    return BASE_TOKENS[token]
+@dataclass(frozen=True)
+class Shades:
+    """Two Rich :class:`~rich.style.Style` shades for a :class:`Status`.
+
+    ``base`` for borders / headlines / dominant text, ``light`` for
+    secondary chips and metadata that should recede slightly.
+    """
+
+    base: Style
+    light: Style
 
 
+def colour(status: Status) -> Shades:
+    """Resolve a :class:`Status` to a :class:`Shades` pair."""
+    return Shades(
+        base=Style.parse(status.hue),
+        light=Style.parse(f"bright_{status.hue}"),
+    )
+
+
+# Rich theme: only ``logging.level.*`` aliases so the default level prefix
+# rendering matches the Status axis. Inline styling goes through
+# :func:`colour` (Style objects), not theme names — Rich's parser doesn't
+# resolve theme names inside compound style strings, so keeping the theme
+# small avoids a class of bugs.
 THEME: Final[Theme] = Theme(
     {
-        **BASE_TOKENS,
-        **{name: _resolve(ref) for name, ref in SEMANTIC_TOKENS.items()},
+        "log.time": Status.INFO.hue,
+        "log.message": "default",
+        "logging.level.info": Status.INFO.hue,
+        "logging.level.warning": f"bright_{Status.WARNING.hue}",
+        "logging.level.error": Status.ERROR.hue,
     }
 )
 
 
-__all__ = ["BASE_TOKENS", "SEMANTIC_TOKENS", "THEME"]
+__all__ = ["THEME", "Shades", "Status", "colour"]

--- a/src/raitap/utils/colour.py
+++ b/src/raitap/utils/colour.py
@@ -37,10 +37,10 @@ class Status(Enum):
     top-level crash panel even though it's an :attr:`ERROR` underneath).
     """
 
-    WARNING = ("yellow", "⚠︎  ", "Warning")
-    ERROR = ("red", "✗ ", "Error")
+    WARNING = ("yellow", "△ ", "Warning")
+    ERROR = ("red", "✕ ", "Error")
     SUCCESS = ("green", "✓ ", "Complete")
-    INFO = ("cyan", "▸ ", "Info")
+    INFO = ("cyan", "▷ ", "Info")
 
     def __init__(self, hue: str, icon: str, default_label: str) -> None:
         self.hue: str = hue

--- a/src/raitap/utils/console.py
+++ b/src/raitap/utils/console.py
@@ -12,7 +12,6 @@ import logging
 import re
 import sys
 import warnings
-from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -26,11 +25,12 @@ from rich.progress import (
     SpinnerColumn,
     TextColumn,
 )
+from rich.style import Style
 from rich.table import Table
 from rich.text import Text
 from rich.traceback import install as install_rich_traceback
 
-from raitap.utils.colour import THEME
+from raitap.utils.colour import THEME, Status, colour
 from raitap.utils.diagnostics import (
     Diagnostic,
     docs_url,
@@ -40,28 +40,7 @@ from raitap.utils.diagnostics import (
 )
 from raitap.utils.errors import RaitapError
 from raitap.utils.log import _pop_diagnostic, _push_diagnostic, _take_diagnostic_override
-
-
-@dataclass(frozen=True)
-class _PanelKind:
-    """Visual identity of a panel (warning / error / failure / completion).
-
-    Two colour tokens — ``base`` for the dominant element (border, headline)
-    and ``light`` for secondary chips — plus the leading icon/label pair.
-    Centralising these lets the warning and error renderers share one code
-    path; they differ only in this tuple.
-    """
-
-    base: str
-    light: str
-    icon: str
-    label: str
-
-
-_WARNING_KIND = _PanelKind(base="yellow_base", light="yellow_light", icon="⚠︎  ", label="Warning")
-_ERROR_KIND = _PanelKind(base="red_base", light="red_light", icon="✗ ", label="Error")
-_FAILURE_KIND = _PanelKind(base="red_base", light="red_light", icon="✗ ", label="Failure")
-_COMPLETE_KIND = _PanelKind(base="green_base", light="green_light", icon="✓ ", label="Complete")
+from raitap.utils.status_frame import StatusFrame, chip
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -102,7 +81,7 @@ def _src_to_uri(src: str) -> str:
 
 def _linkify_message(message: str) -> Text:
     """Style backtick-quoted code spans magenta and wrap path-like substrings in
-    a ``cyan_base`` OSC 8 hyperlink."""
+    a cyan (Status.INFO) OSC 8 hyperlink."""
     from pathlib import Path
 
     rendered = Text()
@@ -118,7 +97,7 @@ def _linkify_message(message: str) -> Text:
             # Non-absolute or invalid path — fall back to manual file:// URI.
             normalized = trimmed.replace("\\", "/")
             uri = f"file:///{normalized.lstrip('/')}"
-        rendered.append(trimmed, style=f"cyan_base link {uri}")
+        rendered.append(trimmed, style=colour(Status.INFO).base + Style(link=uri))
         if trailing:
             rendered.append(trailing)
         last = match.end()
@@ -165,12 +144,12 @@ def get_stderr_console() -> Console:
     return _stderr_console
 
 
-_LEVEL_ICONS: dict[int, tuple[str, str]] = {
-    logging.DEBUG: ("·", "dim"),
-    logging.INFO: ("▸", "cyan_base"),
-    logging.WARNING: ("⚠︎ ", "yellow_light"),
-    logging.ERROR: ("✗", "red_base"),
-    logging.CRITICAL: ("✗", "bold red_base"),
+_LEVEL_ICONS: dict[int, tuple[str, Style]] = {
+    logging.DEBUG: ("·", Style(dim=True)),
+    logging.INFO: ("▸", colour(Status.INFO).base),
+    logging.WARNING: ("⚠︎ ", colour(Status.WARNING).light),
+    logging.ERROR: ("✗", colour(Status.ERROR).base),
+    logging.CRITICAL: ("✗", colour(Status.ERROR).base + Style(bold=True)),
 }
 
 
@@ -201,17 +180,17 @@ class RaitapRichHandler(RichHandler):
         self._last_was_panel = False
 
     def _emit_panel(self, record: logging.LogRecord, message: str) -> None:
-        kind = _ERROR_KIND if record.levelno >= logging.ERROR else _WARNING_KIND
-
-        body = message
-        header_parts = [f"[{kind.base}]{kind.icon}{kind.label}[/]"]
+        status = Status.ERROR if record.levelno >= logging.ERROR else Status.WARNING
+        body: Text = _linkify_message(message)
+        chips: list[Text] = []
+        label: str | None = None
 
         # RaitapError carries an explicit Diagnostic on the exception object,
         # which beats any heuristics we could apply to the formatted message.
         raitap_exc = _extract_raitap_error(record)
         if raitap_exc is not None and raitap_exc.diagnostic is not None:
-            self._render_diagnostic_header(
-                header_parts,
+            chips = diagnostic_chips(
+                status,
                 scope=(
                     raitap_exc.diagnostic.subsystem.capitalize()
                     if raitap_exc.diagnostic.subsystem
@@ -223,9 +202,8 @@ class RaitapRichHandler(RichHandler):
                     else ""
                 ),
                 diagnostic=raitap_exc.diagnostic,
-                kind=kind,
             )
-            self._render_panel(header_parts, body, kind.base, record=record)
+            self._print_frame(record, StatusFrame(status, body, label=label, chips=chips))
             return
         # Only treat the "<path>:<line>: <Category>: msg" shape as a warnings.warn
         # payload when it actually came from logging.captureWarnings (logger name
@@ -240,19 +218,14 @@ class RaitapRichHandler(RichHandler):
             diagnostic = _pop_diagnostic()
             sub = diagnostic.subsystem if diagnostic else None
             scope = sub.capitalize() if sub else cat
-            self._render_diagnostic_header(
-                header_parts,
-                scope=scope,
-                src=src,
-                diagnostic=diagnostic,
-                kind=kind,
-            )
-            body = warn_match.group("msg").strip()
+            chips = diagnostic_chips(status, scope=scope, src=src, diagnostic=diagnostic)
+            body = _linkify_message(warn_match.group("msg").strip())
         else:
             head_match = _LOGGER_HEADER_RE.match(message.strip())
             if head_match:
                 head = head_match.group("head")
-                header_parts.append(f"[{kind.light}]· {head}[/]")
+                shades = colour(status)
+                chips = [chip(head, style=shades.light)]
                 # logger.warning("Subsystem: …") records have no Diagnostic
                 # stashed (no frame walk happened), so synthesise one from the
                 # header text to drive the same View-docs affordance.
@@ -265,34 +238,17 @@ class RaitapRichHandler(RichHandler):
                 if not is_dev_install():
                     url = docs_url(synth)
                     if url is not None:
-                        header_parts.append(
-                            f"[{kind.light}]· [/][{kind.light} underline link={url}]View docs[/]"
+                        chips.append(
+                            chip("View docs", style=shades.light, link=url, underline=True)
                         )
                 stripped = head_match.group("msg").strip()
-                body = stripped[:1].upper() + stripped[1:] if stripped else stripped
+                body = _linkify_message(
+                    stripped[:1].upper() + stripped[1:] if stripped else stripped
+                )
 
-        self._render_panel(header_parts, body, kind.base, record=record)
+        self._print_frame(record, StatusFrame(status, body, label=label, chips=chips))
 
-    def _render_panel(
-        self,
-        header_parts: list[str],
-        body: str,
-        border: str,
-        *,
-        record: logging.LogRecord,
-    ) -> None:
-        # Build a non-wrapping ``Text`` with overflow="ellipsis" so a narrow
-        # terminal trims chips with ``…`` instead of hard-cutting mid-word.
-        title_text = Text.from_markup(" ".join(header_parts))
-        title_text.overflow = "ellipsis"
-        title_text.no_wrap = True
-        panel = Panel(
-            _linkify_message(body),
-            title=title_text,
-            title_align="left",
-            border_style=border,
-            padding=(1, 2),
-        )
+    def _print_frame(self, record: logging.LogRecord, frame: StatusFrame) -> None:
         try:
             # Two blank lines so the panel doesn't visually collide with a
             # progress bar or other Rich output that didn't leave trailing
@@ -301,37 +257,12 @@ class RaitapRichHandler(RichHandler):
             if not self._last_was_panel:
                 self.console.print()
                 self.console.print()
-            self.console.print(panel)
+            self.console.print(frame.render())
             self.console.print()
             self._last_was_panel = True
         except Exception:
             # Never let logging crash the run — fall back to plain RichHandler.
             super().emit(record)
-
-    def _render_diagnostic_header(
-        self,
-        header_parts: list[str],
-        *,
-        scope: str,
-        src: str,
-        diagnostic: Diagnostic | None,
-        kind: _PanelKind,
-    ) -> None:
-        """Append subsystem / path / docs-link chips to a panel header.
-
-        All sub-chips render in ``kind.light`` so the main label keeps the
-        visual lead. Layout depends on the audience:
-
-        - **Dev install** (cloned repo): ``· <scope> · via <lib> · <path:line>``
-          (``via <lib>`` only when a wrapped library is involved). ``path``
-          is clickable.
-        - **Installed wheel, raitap-emitted**: ``· <scope> · View docs``,
-          ``View docs`` linking to the subsystem documentation page.
-        - **Installed wheel, third-party**: ``· <scope> · via <lib> · View docs``,
-          link points to the frameworks-and-libraries doc page.
-        - **Installed wheel, unclassified**: no subheader at all.
-        """
-        _append_chips(header_parts, scope=scope, src=src, diagnostic=diagnostic, kind=kind)
 
 
 def setup_logging(level: int = logging.INFO) -> None:
@@ -394,59 +325,66 @@ def _format_warning_compact(
     return f"{diagnostic.file}:{diagnostic.line}: {category.__name__}: {message}"
 
 
-def _append_chips(
-    header_parts: list[str],
+def diagnostic_chips(
+    status: Status,
     *,
     scope: str,
     src: str,
     diagnostic: Diagnostic | None,
-    kind: _PanelKind,
-) -> None:
-    """Append diagnostic chips to a panel header, shared by handler + failure panel.
+) -> list[Text]:
+    """Return the chip sequence that decorates a status frame title.
 
-    See :meth:`RaitapRichHandler._render_diagnostic_header` for the layout
-    rules — pulled out as a free function so the top-level failure panel can
-    reuse the exact same composition without needing a handler instance.
+    Layout depends on the audience:
+
+    - **Dev install** (cloned repo): ``· <scope> · via <lib> · <path:line>``
+      (``via <lib>`` only when a wrapped library is involved). ``path`` is
+      clickable; all chips render in ``colour(status).light`` so the main
+      label keeps the visual lead.
+    - **Installed wheel, raitap-emitted**: ``· <scope> · View docs``,
+      ``View docs`` linking to the subsystem documentation page.
+    - **Installed wheel, third-party**: ``· <scope> · via <lib> · View docs``,
+      link points to the frameworks-and-libraries doc page.
+    - **Installed wheel, unclassified**: empty list.
     """
+    shades = colour(status)
     sub = diagnostic.subsystem if diagnostic else None
     third_party = diagnostic.third_party_lib if diagnostic else None
+    chips: list[Text] = []
 
     if is_dev_install():
-        header_parts.append(f"[{kind.light}]· {scope}[/]")
+        chips.append(chip(scope, style=shades.light))
         if third_party is not None:
-            header_parts.append(f"[{kind.light}]· via {third_party.capitalize()}[/]")
+            chips.append(chip(f"via {third_party.capitalize()}", style=shades.light))
         if src:
-            header_parts.append(
-                f"[{kind.light}]· [/][{kind.light} link={_src_to_uri(src)}]{src}[/]"
-            )
-        return
+            chips.append(chip(src, style=shades.light, link=_src_to_uri(src)))
+        return chips
 
     if sub is None:
-        return
-    header_parts.append(f"[{kind.light}]· {scope}[/]")
+        return chips
+    chips.append(chip(scope, style=shades.light))
     if third_party is not None:
-        header_parts.append(f"[{kind.light}]· via {third_party.capitalize()}[/]")
+        chips.append(chip(f"via {third_party.capitalize()}", style=shades.light))
     url = docs_url(diagnostic) if diagnostic is not None else None
     if url is not None:
-        # Explicit ``View docs`` chip — clearer affordance than relying on
-        # OSC 8 styling on the subsystem text alone (some terminals don't
-        # visually mark hyperlinks by default). Link wraps only the label so
-        # the leading separator stays plain.
-        header_parts.append(f"[{kind.light}]· [/][{kind.light} underline link={url}]View docs[/]")
+        chips.append(chip("View docs", style=shades.light, link=url, underline=True))
+    return chips
 
 
-def _format_value(value: Any, *, dot: bool = False, dot_style: str = "green_base") -> Text:
+def _format_value(value: Any, *, dot: bool = False, dot_style: Style | str | None = None) -> Text:
     """Render an arbitrary config value, gracefully handling ``None``/empty.
 
     ``dot=True`` prepends a colored ``●`` glyph (used for status fields).
     """
+    success_style = colour(Status.SUCCESS).base
+    if dot_style is None:
+        dot_style = success_style
     if value is None or value == "" or value == [] or value == {}:
         return Text("—", style="dim")
     if isinstance(value, bool):
         if value:
             if dot:
-                return Text.assemble(("● ", dot_style), ("on", "green_base"))
-            return Text("on", style="green_base")
+                return Text.assemble(("● ", dot_style), ("on", success_style))
+            return Text("on", style=success_style)
         return Text("off", style="dim")
     if isinstance(value, list | tuple):
         return Text(", ".join(str(item) for item in value))
@@ -489,16 +427,18 @@ def print_summary_panel(config: AppConfig, model: Model) -> None:
         # surface that with the same yellow used for warnings.
         hw_label = str(hardware)
         is_cpu = "cpu" in hw_label.lower()
-        hw_color = "yellow_base" if is_cpu else "green_base"
+        hw_style = colour(Status.WARNING).base if is_cpu else colour(Status.SUCCESS).base
         hw_symbol = "⚠︎  " if is_cpu else "✓ "
         if is_cpu:
             cpu_install_docs = "https://caiivs.github.io/raitap/using-raitap/installation.html#execution-dependencies"
-            hw_text = Text.from_markup(
-                f"[{hw_color}]{hw_symbol}{hw_label}[/]  "
-                f"[{hw_color} underline link={cpu_install_docs}]Use GPU[/]"
+            hw_text = Text.assemble(
+                (hw_symbol, hw_style),
+                (hw_label, hw_style),
+                ("  ", ""),
+                ("Use GPU", hw_style + Style(underline=True, link=cpu_install_docs)),
             )
         else:
-            hw_text = Text.assemble((hw_symbol, hw_color), (hw_label, hw_color))
+            hw_text = Text.assemble((hw_symbol, hw_style), (hw_label, hw_style))
     else:
         hw_text = Text("—", style="dim")
     table.add_row("hardware", hw_text)
@@ -513,17 +453,22 @@ def print_summary_panel(config: AppConfig, model: Model) -> None:
 
         run_dir = str(resolve_run_dir(config))
         run_uri = Path(run_dir).resolve().as_uri()
-        output_text = Text(run_dir, style=f"cyan_base link {run_uri}")
+        output_text = Text(run_dir, style=colour(Status.INFO).base + Style(link=run_uri))
     except Exception:
         # Banner must never crash the run — fall back to em-dash placeholder.
         output_text = Text("—", style="dim")
     table.add_row("output", output_text)
 
+    info_style = colour(Status.INFO).base
+    title = Text.assemble(
+        ("RAITAP", info_style + Style(bold=True)),
+        (" · assessment", info_style),
+    )
     panel = Panel(
         table,
-        title="[bold cyan_base]RAITAP[/] [cyan_base]· assessment[/]",
+        title=title,
         title_align="left",
-        border_style="cyan_base",
+        border_style=info_style,
         padding=(1, 2),
     )
     get_console().print()
@@ -532,85 +477,64 @@ def print_summary_panel(config: AppConfig, model: Model) -> None:
 
 
 def print_complete_panel(duration: str) -> None:
-    kind = _COMPLETE_KIND
+    shades = colour(Status.SUCCESS)
     body = Text.assemble(
-        (f"{kind.icon} ", kind.base),
-        ("Assessment complete", f"bold {kind.base}"),
-        ("    duration ", "dim"),
-        (duration, "white"),
+        (f"{Status.SUCCESS.icon} ", shades.base),
+        ("Assessment complete", shades.base + Style(bold=True)),
+        ("    duration ", Style(dim=True)),
+        (duration, Style(color="white")),
     )
-    panel = Panel(
-        body,
-        border_style=kind.base,
-        padding=(1, 2),
-    )
+    frame = StatusFrame(Status.SUCCESS, body)
+    panel = frame.render()
+    # Override default title (we already render icon+label in the body).
+    panel.title = None
     get_console().print()
     get_console().print(panel)
     get_console().print()
 
 
 def print_failure_panel(exc: BaseException, duration: str) -> None:
-    kind = _FAILURE_KIND
-    body_pieces: list[tuple[str, str]] = [
-        (f"{kind.icon} ", kind.base),
-        ("Assessment failed", f"bold {kind.base}"),
-        ("    after ", "dim"),
-        (duration, "white"),
+    shades = colour(Status.ERROR)
+    body_pieces: list[tuple[str, Style] | tuple[str, str]] = [
+        (f"{Status.ERROR.icon} ", shades.base),
+        ("Assessment failed", shades.base + Style(bold=True)),
+        ("    after ", Style(dim=True)),
+        (duration, Style(color="white")),
     ]
-    title: Text | str | None = None
+    chips: list[Text] = []
+    label: str | None = None
 
     # Surface diagnostic chips when the failure carries a Diagnostic — same
     # affordance the rich handler renders for inline error records, but
     # printed at top-level by the Hydra entrypoint.
     if isinstance(exc, RaitapError) and exc.diagnostic is not None:
-        header_parts: list[str] = [f"[{kind.base}]{kind.icon}{kind.label}[/]"]
+        label = "Failure"
         scope = (
             exc.diagnostic.subsystem.capitalize()
             if exc.diagnostic.subsystem
             else type(exc).__name__
         )
         src = f"{exc.diagnostic.file}:{exc.diagnostic.line}" if exc.diagnostic.file else ""
-        _append_chips(
-            header_parts,
-            scope=scope,
-            src=src,
-            diagnostic=exc.diagnostic,
-            kind=kind,
-        )
-        title_text = Text.from_markup(" ".join(header_parts))
-        title_text.overflow = "ellipsis"
-        title_text.no_wrap = True
-        title = title_text
-        body_pieces.extend(
-            [
-                ("\n\n", ""),
-                (str(exc), kind.base),
-            ]
-        )
+        chips = diagnostic_chips(Status.ERROR, scope=scope, src=src, diagnostic=exc.diagnostic)
+        body_pieces.extend([("\n\n", ""), (str(exc), shades.base)])
         cause = exc.__cause__
         if cause is not None:
             body_pieces.extend(
                 [
                     ("\n\n", ""),
-                    (f"caused by {type(cause).__name__}: {cause}", "dim"),
+                    (f"caused by {type(cause).__name__}: {cause}", Style(dim=True)),
                 ]
             )
     else:
-        body_pieces.extend(
-            [
-                ("\n\n", ""),
-                (f"{type(exc).__name__}: {exc}", kind.base),
-            ]
-        )
+        body_pieces.extend([("\n\n", ""), (f"{type(exc).__name__}: {exc}", shades.base)])
 
     body = Text.assemble(*body_pieces)
-    panel = Panel(
-        body,
-        title=title,
-        title_align="left" if title is not None else "center",
-        border_style=kind.base,
-        padding=(1, 2),
-    )
+    frame = StatusFrame(Status.ERROR, body, label=label, chips=chips)
+    panel = frame.render()
+    if label is None:
+        # No diagnostic title — drop the auto-generated icon+label since the
+        # body already opens with them.
+        panel.title = None
     # Two blank lines so the panel separates cleanly from a progress bar
     # whose final repaint may eat the first newline.
     get_stderr_console().print()
@@ -621,24 +545,26 @@ def print_failure_panel(exc: BaseException, duration: str) -> None:
 
 class _PercentColumn(ProgressColumn):
     def render(self, task: Any) -> Text:
-        style = "green_base" if task.finished else "cyan_base"
+        style = colour(Status.SUCCESS).base if task.finished else colour(Status.INFO).base
         pct = 0.0 if task.percentage is None else task.percentage
         return Text(f"{pct:>3.0f}%", style=style)
 
 
 class _ElapsedColumn(ProgressColumn):
     def render(self, task: Any) -> Text:
-        style = "green_base" if task.finished else "cyan_base"
+        style = colour(Status.SUCCESS).base if task.finished else colour(Status.INFO).base
         elapsed = task.finished_time if task.finished else task.elapsed
         text = "-:--:--" if elapsed is None else str(timedelta(seconds=int(elapsed)))
         return Text(text, style=style)
 
 
 def _make_progress() -> Progress:
+    info = colour(Status.INFO).base
+    success = colour(Status.SUCCESS).base
     return Progress(
-        SpinnerColumn(style="cyan_base"),
-        TextColumn("[cyan_base]{task.description}"),
-        BarColumn(complete_style="cyan_base", finished_style="green_base"),
+        SpinnerColumn(style=info),
+        TextColumn("{task.description}", style=info),
+        BarColumn(complete_style=info, finished_style=success),
         _PercentColumn(),
         _ElapsedColumn(),
         console=get_console(),

--- a/src/raitap/utils/console.py
+++ b/src/raitap/utils/console.py
@@ -37,6 +37,7 @@ from raitap.utils.diagnostics import (
     resolve_diagnostic_from_frames,
     subsystem_from_str,
 )
+from raitap.utils.errors import RaitapError
 from raitap.utils.log import _pop_diagnostic, _push_diagnostic, _take_diagnostic_override
 
 _THEME = Theme(
@@ -200,6 +201,29 @@ class RaitapRichHandler(RichHandler):
 
         body = message
         header_parts = [f"[{main_style}]{icon}{label}[/]"]
+
+        # RaitapError carries an explicit Diagnostic on the exception object,
+        # which beats any heuristics we could apply to the formatted message.
+        raitap_exc = _extract_raitap_error(record)
+        if raitap_exc is not None and raitap_exc.diagnostic is not None:
+            self._render_diagnostic_header(
+                header_parts,
+                scope=(
+                    raitap_exc.diagnostic.subsystem.capitalize()
+                    if raitap_exc.diagnostic.subsystem
+                    else type(raitap_exc).__name__
+                ),
+                src=(
+                    f"{raitap_exc.diagnostic.file}:{raitap_exc.diagnostic.line}"
+                    if raitap_exc.diagnostic.file
+                    else ""
+                ),
+                diagnostic=raitap_exc.diagnostic,
+                main_style=main_style,
+                sub_style=sub_style,
+            )
+            self._render_panel(header_parts, body, border)
+            return
         # Only treat the "<path>:<line>: <Category>: msg" shape as a warnings.warn
         # payload when it actually came from logging.captureWarnings (logger name
         # ``py.warnings``). Otherwise an unrelated WARNING that happens to match
@@ -211,10 +235,12 @@ class RaitapRichHandler(RichHandler):
             cat = warn_match.group("cat")
             src = warn_match.group("src")
             diagnostic = _pop_diagnostic()
-            self._render_warning_header(
+            sub = diagnostic.subsystem if diagnostic else None
+            scope = sub.capitalize() if sub else cat
+            self._render_diagnostic_header(
                 header_parts,
+                scope=scope,
                 src=src,
-                category=cat,
                 diagnostic=diagnostic,
                 main_style=main_style,
                 sub_style=sub_style,
@@ -243,6 +269,16 @@ class RaitapRichHandler(RichHandler):
                 stripped = head_match.group("msg").strip()
                 body = stripped[:1].upper() + stripped[1:] if stripped else stripped
 
+        self._render_panel(header_parts, body, border, record=record)
+
+    def _render_panel(
+        self,
+        header_parts: list[str],
+        body: str,
+        border: str,
+        *,
+        record: logging.LogRecord | None = None,
+    ) -> None:
         # Build a non-wrapping ``Text`` with overflow="ellipsis" so a narrow
         # terminal trims chips with ``…`` instead of hard-cutting mid-word.
         title_text = Text.from_markup(" ".join(header_parts))
@@ -263,39 +299,41 @@ class RaitapRichHandler(RichHandler):
             self._last_was_panel = True
         except Exception:
             # Never let logging crash the run — fall back to plain RichHandler.
-            super().emit(record)
+            if record is not None:
+                super().emit(record)
 
-    def _render_warning_header(
+    def _render_diagnostic_header(
         self,
         header_parts: list[str],
         *,
+        scope: str,
         src: str,
-        category: str,
         diagnostic: Diagnostic | None,
         main_style: str,
         sub_style: str,
     ) -> None:
-        """Append subsystem / path / docs-link chips to the warning panel header.
+        """Append subsystem / path / docs-link chips to a warning or error panel header.
 
         Layout depends on the audience:
 
-        - **Dev install** (cloned repo): ``· <Subsystem> · <path:line>``,
-          ``path`` clickable. Falls back to category if no subsystem matched.
-        - **Installed wheel, raitap-emitted**: ``· <Subsystem>`` only,
+        - **Dev install** (cloned repo): ``· <scope> · <path:line>``,
+          ``path`` clickable. ``scope`` is the subsystem name when classified,
+          otherwise a caller-provided fallback (warning category / exception class).
+        - **Installed wheel, raitap-emitted**: ``· <scope>`` only,
           subsystem text linked to the docs page.
-        - **Installed wheel, third-party**: ``· <Subsystem> · via <lib>``,
+        - **Installed wheel, third-party**: ``· <scope> · via <lib>``,
           subsystem linked to the frameworks-and-libraries doc page.
         - **Installed wheel, unclassified**: no subheader at all.
         """
         sub = diagnostic.subsystem if diagnostic else None
         third_party = diagnostic.third_party_lib if diagnostic else None
-        scope = sub.capitalize() if sub else category
 
         if is_dev_install():
             header_parts.append(f"[{sub_style}]· {scope}[/]")
-            header_parts.append(
-                f"[{main_style}]· [/][{main_style} link={_src_to_uri(src)}]{src}[/]"
-            )
+            if src:
+                header_parts.append(
+                    f"[{main_style}]· [/][{main_style} link={_src_to_uri(src)}]{src}[/]"
+                )
             if third_party is not None:
                 header_parts.append(f"[{sub_style}]· via {third_party.capitalize()}[/]")
             return
@@ -340,6 +378,17 @@ def setup_logging(level: int = logging.INFO) -> None:
     # handler then unpacks it back into a Panel with subtitle = source.
     warnings.formatwarning = _format_warning_compact  # type: ignore[assignment]
     install_rich_traceback(console=get_stderr_console(), show_locals=False, width=None)
+
+
+def _extract_raitap_error(record: logging.LogRecord) -> RaitapError | None:
+    """Return the :class:`RaitapError` attached to ``record.exc_info``, if any."""
+    exc_info = record.exc_info
+    if not exc_info:
+        return None
+    exc = exc_info[1] if isinstance(exc_info, tuple) else None
+    if isinstance(exc, RaitapError):
+        return exc
+    return None
 
 
 def _format_warning_compact(
@@ -478,22 +527,98 @@ def print_complete_panel(duration: str) -> None:
 
 
 def print_failure_panel(exc: BaseException, duration: str) -> None:
-    body = Text.assemble(
+    # Default crash-panel body for plain exceptions.
+    body_pieces: list[tuple[str, str]] = [
         ("✗  ", "bold red"),
         ("Assessment failed", "bold"),
         ("    after ", "dim"),
         (duration, "white"),
         ("\n", ""),
         (f"{type(exc).__name__}: {exc}", "red"),
-    )
+    ]
+    title: Text | str | None = None
+
+    # Surface diagnostic chips when the failure carries a Diagnostic — same
+    # affordance the rich handler renders for inline error records, but
+    # printed at top-level by the Hydra entrypoint.
+    if isinstance(exc, RaitapError) and exc.diagnostic is not None:
+        header_parts: list[str] = ["[red]✗ Failure[/]"]
+        scope = (
+            exc.diagnostic.subsystem.capitalize()
+            if exc.diagnostic.subsystem
+            else type(exc).__name__
+        )
+        src = f"{exc.diagnostic.file}:{exc.diagnostic.line}" if exc.diagnostic.file else ""
+        _append_failure_chips(
+            header_parts,
+            scope=scope,
+            src=src,
+            diagnostic=exc.diagnostic,
+            main_style="red",
+            sub_style="yellow",
+        )
+        title_text = Text.from_markup(" ".join(header_parts))
+        title_text.overflow = "ellipsis"
+        title_text.no_wrap = True
+        title = title_text
+        body_pieces = [
+            ("✗  ", "bold red"),
+            ("Assessment failed", "bold"),
+            ("    after ", "dim"),
+            (duration, "white"),
+            ("\n", ""),
+            (str(exc), "red"),
+        ]
+        cause = exc.__cause__
+        if cause is not None:
+            body_pieces.extend(
+                [
+                    ("\n", ""),
+                    (f"caused by {type(cause).__name__}: {cause}", "dim"),
+                ]
+            )
+
+    body = Text.assemble(*body_pieces)
     panel = Panel(
         body,
+        title=title,
+        title_align="left" if title is not None else "center",
         border_style="bold red",
         padding=(0, 2),
     )
     get_stderr_console().print()
     get_stderr_console().print(panel)
     get_stderr_console().print()
+
+
+def _append_failure_chips(
+    header_parts: list[str],
+    *,
+    scope: str,
+    src: str,
+    diagnostic: Diagnostic,
+    main_style: str,
+    sub_style: str,
+) -> None:
+    """Module-level mirror of :meth:`RaitapRichHandler._render_diagnostic_header`
+    so :func:`print_failure_panel` doesn't need a handler instance."""
+    if is_dev_install():
+        header_parts.append(f"[{sub_style}]· {scope}[/]")
+        if src:
+            header_parts.append(
+                f"[{main_style}]· [/][{main_style} link={_src_to_uri(src)}]{src}[/]"
+            )
+        if diagnostic.third_party_lib is not None:
+            header_parts.append(f"[{sub_style}]· via {diagnostic.third_party_lib.capitalize()}[/]")
+        return
+    if diagnostic.subsystem is None:
+        return
+    header_parts.append(f"[{sub_style}]· {scope}[/]")
+    if diagnostic.third_party_lib is not None:
+        header_parts.append(f"[{sub_style}]· via {diagnostic.third_party_lib.capitalize()}[/]")
+    url = docs_url(diagnostic)
+    if url is not None:
+        header_parts.append(f"[{sub_style}]· [/][{sub_style} underline link={url}]View docs[/]")
 
 
 class _PercentColumn(ProgressColumn):

--- a/src/raitap/utils/console.py
+++ b/src/raitap/utils/console.py
@@ -144,12 +144,14 @@ def get_stderr_console() -> Console:
     return _stderr_console
 
 
-_LEVEL_ICONS: dict[int, tuple[str, Style]] = {
-    logging.DEBUG: ("·", Style(dim=True)),
-    logging.INFO: ("▸", colour(Status.INFO).base),
-    logging.WARNING: ("⚠︎ ", colour(Status.WARNING).light),
-    logging.ERROR: ("✗", colour(Status.ERROR).base),
-    logging.CRITICAL: ("✗", colour(Status.ERROR).base + Style(bold=True)),
+# Map logging levels onto :class:`Status`. The level-prefix renderer pulls
+# icon + colour from the Status so glyphs live in exactly one place (the
+# enum). DEBUG isn't a Status — we render it as a dim ``·`` separately.
+_LEVEL_STATUS: dict[int, Status] = {
+    logging.INFO: Status.INFO,
+    logging.WARNING: Status.WARNING,
+    logging.ERROR: Status.ERROR,
+    logging.CRITICAL: Status.ERROR,
 }
 
 
@@ -159,8 +161,20 @@ class RaitapRichHandler(RichHandler):
     _last_was_panel: bool = False
 
     def get_level_text(self, record: logging.LogRecord) -> Text:
-        icon, style = _LEVEL_ICONS.get(record.levelno, ("·", "white"))
-        return Text(icon, style=style)
+        if record.levelno < logging.INFO:
+            return Text("·", style=Style(dim=True))
+        status = _LEVEL_STATUS.get(record.levelno, Status.INFO)
+        shades = colour(status)
+        # WARNING level-prefix uses ``light`` for legibility (ANSI 33 yellow
+        # is brownish on a single glyph); other levels stay on ``base``.
+        # CRITICAL adds bold on top of the ERROR base.
+        if status is Status.WARNING:
+            style = shades.light
+        elif record.levelno >= logging.CRITICAL:
+            style = shades.base + Style(bold=True)
+        else:
+            style = shades.base
+        return Text(status.icon.rstrip(), style=style)
 
     def render_message(self, record: logging.LogRecord, message: str) -> Any:
         return _linkify_message(message)
@@ -427,8 +441,9 @@ def print_summary_panel(config: AppConfig, model: Model) -> None:
         # surface that with the same yellow used for warnings.
         hw_label = str(hardware)
         is_cpu = "cpu" in hw_label.lower()
-        hw_style = colour(Status.WARNING).base if is_cpu else colour(Status.SUCCESS).base
-        hw_symbol = "⚠︎  " if is_cpu else "✓ "
+        hw_status = Status.WARNING if is_cpu else Status.SUCCESS
+        hw_style = colour(hw_status).base
+        hw_symbol = hw_status.icon
         if is_cpu:
             cpu_install_docs = "https://caiivs.github.io/raitap/using-raitap/installation.html#execution-dependencies"
             hw_text = Text.assemble(
@@ -479,7 +494,7 @@ def print_summary_panel(config: AppConfig, model: Model) -> None:
 def print_complete_panel(duration: str) -> None:
     shades = colour(Status.SUCCESS)
     body = Text.assemble(
-        (f"{Status.SUCCESS.icon} ", shades.base),
+        (Status.SUCCESS.icon, shades.base),
         ("Assessment complete", shades.base + Style(bold=True)),
         ("    duration ", Style(dim=True)),
         (duration, Style(color="white")),
@@ -496,7 +511,7 @@ def print_complete_panel(duration: str) -> None:
 def print_failure_panel(exc: BaseException, duration: str) -> None:
     shades = colour(Status.ERROR)
     body_pieces: list[tuple[str, Style] | tuple[str, str]] = [
-        (f"{Status.ERROR.icon} ", shades.base),
+        (Status.ERROR.icon, shades.base),
         ("Assessment failed", shades.base + Style(bold=True)),
         ("    after ", Style(dim=True)),
         (duration, Style(color="white")),

--- a/src/raitap/utils/console.py
+++ b/src/raitap/utils/console.py
@@ -12,6 +12,7 @@ import logging
 import re
 import sys
 import warnings
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -27,9 +28,9 @@ from rich.progress import (
 )
 from rich.table import Table
 from rich.text import Text
-from rich.theme import Theme
 from rich.traceback import install as install_rich_traceback
 
+from raitap.utils.colour import THEME
 from raitap.utils.diagnostics import (
     Diagnostic,
     docs_url,
@@ -40,15 +41,27 @@ from raitap.utils.diagnostics import (
 from raitap.utils.errors import RaitapError
 from raitap.utils.log import _pop_diagnostic, _push_diagnostic, _take_diagnostic_override
 
-_THEME = Theme(
-    {
-        "log.time": "cyan",
-        "log.message": "default",
-        "logging.level.info": "cyan",
-        "logging.level.warning": "bright_yellow",
-        "logging.level.error": "red",
-    }
-)
+
+@dataclass(frozen=True)
+class _PanelKind:
+    """Visual identity of a panel (warning / error / failure / completion).
+
+    Two colour tokens — ``base`` for the dominant element (border, headline)
+    and ``light`` for secondary chips — plus the leading icon/label pair.
+    Centralising these lets the warning and error renderers share one code
+    path; they differ only in this tuple.
+    """
+
+    base: str
+    light: str
+    icon: str
+    label: str
+
+
+_WARNING_KIND = _PanelKind(base="yellow_base", light="yellow_light", icon="⚠︎  ", label="Warning")
+_ERROR_KIND = _PanelKind(base="red_base", light="red_light", icon="✗ ", label="Error")
+_FAILURE_KIND = _PanelKind(base="red_base", light="red_light", icon="✗ ", label="Failure")
+_COMPLETE_KIND = _PanelKind(base="green_base", light="green.light", icon="✓ ", label="Complete")
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -89,7 +102,7 @@ def _src_to_uri(src: str) -> str:
 
 def _linkify_message(message: str) -> Text:
     """Style backtick-quoted code spans magenta and wrap path-like substrings in
-    a cyan OSC 8 hyperlink."""
+    a ``cyan_base`` OSC 8 hyperlink."""
     from pathlib import Path
 
     rendered = Text()
@@ -105,7 +118,7 @@ def _linkify_message(message: str) -> Text:
             # Non-absolute or invalid path — fall back to manual file:// URI.
             normalized = trimmed.replace("\\", "/")
             uri = f"file:///{normalized.lstrip('/')}"
-        rendered.append(trimmed, style=f"cyan link {uri}")
+        rendered.append(trimmed, style=f"cyan_base link {uri}")
         if trailing:
             rendered.append(trailing)
         last = match.end()
@@ -140,7 +153,7 @@ def get_console() -> Console:
     global _console
     if _console is None:
         _reconfigure_utf8(sys.stdout)
-        _console = Console(soft_wrap=False, highlight=False, theme=_THEME)
+        _console = Console(soft_wrap=False, highlight=False, theme=THEME)
     return _console
 
 
@@ -148,16 +161,16 @@ def get_stderr_console() -> Console:
     global _stderr_console
     if _stderr_console is None:
         _reconfigure_utf8(sys.stderr)
-        _stderr_console = Console(stderr=True, soft_wrap=False, highlight=False, theme=_THEME)
+        _stderr_console = Console(stderr=True, soft_wrap=False, highlight=False, theme=THEME)
     return _stderr_console
 
 
 _LEVEL_ICONS: dict[int, tuple[str, str]] = {
     logging.DEBUG: ("·", "dim"),
-    logging.INFO: ("▸", "cyan"),
-    logging.WARNING: ("⚠︎ ", "bright_yellow"),
-    logging.ERROR: ("✗", "red"),
-    logging.CRITICAL: ("✗", "bold red"),
+    logging.INFO: ("▸", "cyan_base"),
+    logging.WARNING: ("⚠︎ ", "yellow_light"),
+    logging.ERROR: ("✗", "red_base"),
+    logging.CRITICAL: ("✗", "bold red_base"),
 }
 
 
@@ -188,25 +201,10 @@ class RaitapRichHandler(RichHandler):
         self._last_was_panel = False
 
     def _emit_panel(self, record: logging.LogRecord, message: str) -> None:
-        if record.levelno >= logging.ERROR:
-            border, main_style, sub_style, icon, label = (
-                "red",
-                "red",
-                "red dim",
-                "✗ ",
-                "Error",
-            )
-        else:
-            border, main_style, sub_style, icon, label = (
-                "yellow",
-                "yellow",
-                "bright_yellow",
-                "⚠︎  ",
-                "Warning",
-            )
+        kind = _ERROR_KIND if record.levelno >= logging.ERROR else _WARNING_KIND
 
         body = message
-        header_parts = [f"[{main_style}]{icon}{label}[/]"]
+        header_parts = [f"[{kind.base}]{kind.icon}{kind.label}[/]"]
 
         # RaitapError carries an explicit Diagnostic on the exception object,
         # which beats any heuristics we could apply to the formatted message.
@@ -225,10 +223,9 @@ class RaitapRichHandler(RichHandler):
                     else ""
                 ),
                 diagnostic=raitap_exc.diagnostic,
-                main_style=main_style,
-                sub_style=sub_style,
+                kind=kind,
             )
-            self._render_panel(header_parts, body, border, record=record)
+            self._render_panel(header_parts, body, kind.base, record=record)
             return
         # Only treat the "<path>:<line>: <Category>: msg" shape as a warnings.warn
         # payload when it actually came from logging.captureWarnings (logger name
@@ -248,15 +245,14 @@ class RaitapRichHandler(RichHandler):
                 scope=scope,
                 src=src,
                 diagnostic=diagnostic,
-                main_style=main_style,
-                sub_style=sub_style,
+                kind=kind,
             )
             body = warn_match.group("msg").strip()
         else:
             head_match = _LOGGER_HEADER_RE.match(message.strip())
             if head_match:
                 head = head_match.group("head")
-                header_parts.append(f"[{sub_style}]· {head}[/]")
+                header_parts.append(f"[{kind.light}]· {head}[/]")
                 # logger.warning("Subsystem: …") records have no Diagnostic
                 # stashed (no frame walk happened), so synthesise one from the
                 # header text to drive the same View-docs affordance.
@@ -270,12 +266,12 @@ class RaitapRichHandler(RichHandler):
                     url = docs_url(synth)
                     if url is not None:
                         header_parts.append(
-                            f"[{sub_style}]· [/][{sub_style} underline link={url}]View docs[/]"
+                            f"[{kind.light}]· [/][{kind.light} underline link={url}]View docs[/]"
                         )
                 stripped = head_match.group("msg").strip()
                 body = stripped[:1].upper() + stripped[1:] if stripped else stripped
 
-        self._render_panel(header_parts, body, border, record=record)
+        self._render_panel(header_parts, body, kind.base, record=record)
 
     def _render_panel(
         self,
@@ -319,48 +315,23 @@ class RaitapRichHandler(RichHandler):
         scope: str,
         src: str,
         diagnostic: Diagnostic | None,
-        main_style: str,
-        sub_style: str,
+        kind: _PanelKind,
     ) -> None:
-        """Append subsystem / path / docs-link chips to a warning or error panel header.
+        """Append subsystem / path / docs-link chips to a panel header.
 
-        Layout depends on the audience:
+        All sub-chips render in ``kind.light`` so the main label keeps the
+        visual lead. Layout depends on the audience:
 
-        - **Dev install** (cloned repo): ``· <scope> · <path:line>``,
-          ``path`` clickable. ``scope`` is the subsystem name when classified,
-          otherwise a caller-provided fallback (warning category / exception class).
+        - **Dev install** (cloned repo): ``· <scope> · via <lib> · <path:line>``
+          (``via <lib>`` only when a wrapped library is involved). ``path``
+          is clickable.
         - **Installed wheel, raitap-emitted**: ``· <scope> · View docs``,
           ``View docs`` linking to the subsystem documentation page.
         - **Installed wheel, third-party**: ``· <scope> · via <lib> · View docs``,
           link points to the frameworks-and-libraries doc page.
         - **Installed wheel, unclassified**: no subheader at all.
         """
-        sub = diagnostic.subsystem if diagnostic else None
-        third_party = diagnostic.third_party_lib if diagnostic else None
-
-        if is_dev_install():
-            header_parts.append(f"[{sub_style}]· {scope}[/]")
-            if src:
-                header_parts.append(
-                    f"[{main_style}]· [/][{main_style} link={_src_to_uri(src)}]{src}[/]"
-                )
-            if third_party is not None:
-                header_parts.append(f"[{sub_style}]· via {third_party.capitalize()}[/]")
-            return
-
-        # Installed: hide raw paths the user can't act on. Surface docs links instead.
-        if sub is None:
-            return
-        header_parts.append(f"[{sub_style}]· {scope}[/]")
-        if third_party is not None:
-            header_parts.append(f"[{sub_style}]· via {third_party.capitalize()}[/]")
-        url = docs_url(diagnostic) if diagnostic is not None else None
-        if url is not None:
-            # Explicit ``View docs`` chip — clearer affordance than relying on
-            # OSC 8 styling on the subsystem text alone (Windows Terminal /
-            # other terminals don't visually mark hyperlinks by default).
-            # Link wraps only the label so the leading separator stays plain.
-            header_parts.append(f"[{sub_style}]· [/][{sub_style} underline link={url}]View docs[/]")
+        _append_chips(header_parts, scope=scope, src=src, diagnostic=diagnostic, kind=kind)
 
 
 def setup_logging(level: int = logging.INFO) -> None:
@@ -423,7 +394,48 @@ def _format_warning_compact(
     return f"{diagnostic.file}:{diagnostic.line}: {category.__name__}: {message}"
 
 
-def _format_value(value: Any, *, dot: bool = False, dot_style: str = "green") -> Text:
+def _append_chips(
+    header_parts: list[str],
+    *,
+    scope: str,
+    src: str,
+    diagnostic: Diagnostic | None,
+    kind: _PanelKind,
+) -> None:
+    """Append diagnostic chips to a panel header, shared by handler + failure panel.
+
+    See :meth:`RaitapRichHandler._render_diagnostic_header` for the layout
+    rules — pulled out as a free function so the top-level failure panel can
+    reuse the exact same composition without needing a handler instance.
+    """
+    sub = diagnostic.subsystem if diagnostic else None
+    third_party = diagnostic.third_party_lib if diagnostic else None
+
+    if is_dev_install():
+        header_parts.append(f"[{kind.light}]· {scope}[/]")
+        if third_party is not None:
+            header_parts.append(f"[{kind.light}]· via {third_party.capitalize()}[/]")
+        if src:
+            header_parts.append(
+                f"[{kind.light}]· [/][{kind.light} link={_src_to_uri(src)}]{src}[/]"
+            )
+        return
+
+    if sub is None:
+        return
+    header_parts.append(f"[{kind.light}]· {scope}[/]")
+    if third_party is not None:
+        header_parts.append(f"[{kind.light}]· via {third_party.capitalize()}[/]")
+    url = docs_url(diagnostic) if diagnostic is not None else None
+    if url is not None:
+        # Explicit ``View docs`` chip — clearer affordance than relying on
+        # OSC 8 styling on the subsystem text alone (some terminals don't
+        # visually mark hyperlinks by default). Link wraps only the label so
+        # the leading separator stays plain.
+        header_parts.append(f"[{kind.light}]· [/][{kind.light} underline link={url}]View docs[/]")
+
+
+def _format_value(value: Any, *, dot: bool = False, dot_style: str = "green_base") -> Text:
     """Render an arbitrary config value, gracefully handling ``None``/empty.
 
     ``dot=True`` prepends a colored ``●`` glyph (used for status fields).
@@ -433,8 +445,8 @@ def _format_value(value: Any, *, dot: bool = False, dot_style: str = "green") ->
     if isinstance(value, bool):
         if value:
             if dot:
-                return Text.assemble(("● ", dot_style), ("on", "green"))
-            return Text("on", style="green")
+                return Text.assemble(("● ", dot_style), ("on", "green_base"))
+            return Text("on", style="green_base")
         return Text("off", style="dim")
     if isinstance(value, list | tuple):
         return Text(", ".join(str(item) for item in value))
@@ -477,7 +489,7 @@ def print_summary_panel(config: AppConfig, model: Model) -> None:
         # surface that with the same yellow used for warnings.
         hw_label = str(hardware)
         is_cpu = "cpu" in hw_label.lower()
-        hw_color = "yellow" if is_cpu else "green"
+        hw_color = "yellow_base" if is_cpu else "green_base"
         hw_symbol = "⚠︎  " if is_cpu else "✓ "
         if is_cpu:
             cpu_install_docs = "https://caiivs.github.io/raitap/using-raitap/installation.html#execution-dependencies"
@@ -501,7 +513,7 @@ def print_summary_panel(config: AppConfig, model: Model) -> None:
 
         run_dir = str(resolve_run_dir(config))
         run_uri = Path(run_dir).resolve().as_uri()
-        output_text = Text(run_dir, style=f"cyan link {run_uri}")
+        output_text = Text(run_dir, style=f"cyan_base link {run_uri}")
     except Exception:
         # Banner must never crash the run — fall back to em-dash placeholder.
         output_text = Text("—", style="dim")
@@ -509,9 +521,9 @@ def print_summary_panel(config: AppConfig, model: Model) -> None:
 
     panel = Panel(
         table,
-        title="[bold cyan]RAITAP[/] [cyan]· assessment[/]",
+        title="[bold cyan_base]RAITAP[/] [cyan_base]· assessment[/]",
         title_align="left",
-        border_style="cyan",
+        border_style="cyan_base",
         padding=(1, 2),
     )
     get_console().print()
@@ -520,15 +532,16 @@ def print_summary_panel(config: AppConfig, model: Model) -> None:
 
 
 def print_complete_panel(duration: str) -> None:
+    kind = _COMPLETE_KIND
     body = Text.assemble(
-        ("✓  ", "bold green"),
-        ("Assessment complete", "bold"),
+        (f"{kind.icon} ", kind.base),
+        ("Assessment complete", f"bold {kind.base}"),
         ("    duration ", "dim"),
         (duration, "white"),
     )
     panel = Panel(
         body,
-        border_style="bold green",
+        border_style=kind.base,
         padding=(1, 2),
     )
     get_console().print()
@@ -537,14 +550,12 @@ def print_complete_panel(duration: str) -> None:
 
 
 def print_failure_panel(exc: BaseException, duration: str) -> None:
-    # Default crash-panel body for plain exceptions.
+    kind = _FAILURE_KIND
     body_pieces: list[tuple[str, str]] = [
-        ("✗  ", "bold red"),
-        ("Assessment failed", "bold"),
+        (f"{kind.icon} ", kind.base),
+        ("Assessment failed", f"bold {kind.base}"),
         ("    after ", "dim"),
         (duration, "white"),
-        ("\n", ""),
-        (f"{type(exc).__name__}: {exc}", "red"),
     ]
     title: Text | str | None = None
 
@@ -552,48 +563,52 @@ def print_failure_panel(exc: BaseException, duration: str) -> None:
     # affordance the rich handler renders for inline error records, but
     # printed at top-level by the Hydra entrypoint.
     if isinstance(exc, RaitapError) and exc.diagnostic is not None:
-        header_parts: list[str] = ["[red]✗ Failure[/]"]
+        header_parts: list[str] = [f"[{kind.base}]{kind.icon}{kind.label}[/]"]
         scope = (
             exc.diagnostic.subsystem.capitalize()
             if exc.diagnostic.subsystem
             else type(exc).__name__
         )
         src = f"{exc.diagnostic.file}:{exc.diagnostic.line}" if exc.diagnostic.file else ""
-        _append_failure_chips(
+        _append_chips(
             header_parts,
             scope=scope,
             src=src,
             diagnostic=exc.diagnostic,
-            main_style="red",
-            sub_style="red dim",
+            kind=kind,
         )
         title_text = Text.from_markup(" ".join(header_parts))
         title_text.overflow = "ellipsis"
         title_text.no_wrap = True
         title = title_text
-        body_pieces = [
-            ("✗  ", "bold red"),
-            ("Assessment failed", "bold"),
-            ("    after ", "dim"),
-            (duration, "white"),
-            ("\n", ""),
-            (str(exc), "red"),
-        ]
+        body_pieces.extend(
+            [
+                ("\n\n", ""),
+                (str(exc), kind.base),
+            ]
+        )
         cause = exc.__cause__
         if cause is not None:
             body_pieces.extend(
                 [
-                    ("\n", ""),
+                    ("\n\n", ""),
                     (f"caused by {type(cause).__name__}: {cause}", "dim"),
                 ]
             )
+    else:
+        body_pieces.extend(
+            [
+                ("\n\n", ""),
+                (f"{type(exc).__name__}: {exc}", kind.base),
+            ]
+        )
 
     body = Text.assemble(*body_pieces)
     panel = Panel(
         body,
         title=title,
         title_align="left" if title is not None else "center",
-        border_style="bold red",
+        border_style=kind.base,
         padding=(1, 2),
     )
     # Two blank lines so the panel separates cleanly from a progress bar
@@ -604,46 +619,16 @@ def print_failure_panel(exc: BaseException, duration: str) -> None:
     get_stderr_console().print()
 
 
-def _append_failure_chips(
-    header_parts: list[str],
-    *,
-    scope: str,
-    src: str,
-    diagnostic: Diagnostic,
-    main_style: str,
-    sub_style: str,
-) -> None:
-    """Module-level mirror of :meth:`RaitapRichHandler._render_diagnostic_header`
-    so :func:`print_failure_panel` doesn't need a handler instance."""
-    if is_dev_install():
-        header_parts.append(f"[{sub_style}]· {scope}[/]")
-        if src:
-            header_parts.append(
-                f"[{main_style}]· [/][{main_style} link={_src_to_uri(src)}]{src}[/]"
-            )
-        if diagnostic.third_party_lib is not None:
-            header_parts.append(f"[{sub_style}]· via {diagnostic.third_party_lib.capitalize()}[/]")
-        return
-    if diagnostic.subsystem is None:
-        return
-    header_parts.append(f"[{sub_style}]· {scope}[/]")
-    if diagnostic.third_party_lib is not None:
-        header_parts.append(f"[{sub_style}]· via {diagnostic.third_party_lib.capitalize()}[/]")
-    url = docs_url(diagnostic)
-    if url is not None:
-        header_parts.append(f"[{sub_style}]· [/][{sub_style} underline link={url}]View docs[/]")
-
-
 class _PercentColumn(ProgressColumn):
     def render(self, task: Any) -> Text:
-        style = "green" if task.finished else "cyan"
+        style = "green_base" if task.finished else "cyan_base"
         pct = 0.0 if task.percentage is None else task.percentage
         return Text(f"{pct:>3.0f}%", style=style)
 
 
 class _ElapsedColumn(ProgressColumn):
     def render(self, task: Any) -> Text:
-        style = "green" if task.finished else "cyan"
+        style = "green_base" if task.finished else "cyan_base"
         elapsed = task.finished_time if task.finished else task.elapsed
         text = "-:--:--" if elapsed is None else str(timedelta(seconds=int(elapsed)))
         return Text(text, style=style)
@@ -651,9 +636,9 @@ class _ElapsedColumn(ProgressColumn):
 
 def _make_progress() -> Progress:
     return Progress(
-        SpinnerColumn(style="cyan"),
-        TextColumn("[cyan]{task.description}"),
-        BarColumn(complete_style="cyan", finished_style="green"),
+        SpinnerColumn(style="cyan_base"),
+        TextColumn("[cyan_base]{task.description}"),
+        BarColumn(complete_style="cyan_base", finished_style="green_base"),
         _PercentColumn(),
         _ElapsedColumn(),
         console=get_console(),

--- a/src/raitap/utils/console.py
+++ b/src/raitap/utils/console.py
@@ -222,7 +222,7 @@ class RaitapRichHandler(RichHandler):
                 main_style=main_style,
                 sub_style=sub_style,
             )
-            self._render_panel(header_parts, body, border)
+            self._render_panel(header_parts, body, border, record=record)
             return
         # Only treat the "<path>:<line>: <Category>: msg" shape as a warnings.warn
         # payload when it actually came from logging.captureWarnings (logger name
@@ -277,7 +277,7 @@ class RaitapRichHandler(RichHandler):
         body: str,
         border: str,
         *,
-        record: logging.LogRecord | None = None,
+        record: logging.LogRecord,
     ) -> None:
         # Build a non-wrapping ``Text`` with overflow="ellipsis" so a narrow
         # terminal trims chips with ``…`` instead of hard-cutting mid-word.
@@ -299,8 +299,7 @@ class RaitapRichHandler(RichHandler):
             self._last_was_panel = True
         except Exception:
             # Never let logging crash the run — fall back to plain RichHandler.
-            if record is not None:
-                super().emit(record)
+            super().emit(record)
 
     def _render_diagnostic_header(
         self,
@@ -319,10 +318,10 @@ class RaitapRichHandler(RichHandler):
         - **Dev install** (cloned repo): ``· <scope> · <path:line>``,
           ``path`` clickable. ``scope`` is the subsystem name when classified,
           otherwise a caller-provided fallback (warning category / exception class).
-        - **Installed wheel, raitap-emitted**: ``· <scope>`` only,
-          subsystem text linked to the docs page.
-        - **Installed wheel, third-party**: ``· <scope> · via <lib>``,
-          subsystem linked to the frameworks-and-libraries doc page.
+        - **Installed wheel, raitap-emitted**: ``· <scope> · View docs``,
+          ``View docs`` linking to the subsystem documentation page.
+        - **Installed wheel, third-party**: ``· <scope> · via <lib> · View docs``,
+          link points to the frameworks-and-libraries doc page.
         - **Installed wheel, unclassified**: no subheader at all.
         """
         sub = diagnostic.subsystem if diagnostic else None

--- a/src/raitap/utils/console.py
+++ b/src/raitap/utils/console.py
@@ -61,7 +61,7 @@ class _PanelKind:
 _WARNING_KIND = _PanelKind(base="yellow_base", light="yellow_light", icon="⚠︎  ", label="Warning")
 _ERROR_KIND = _PanelKind(base="red_base", light="red_light", icon="✗ ", label="Error")
 _FAILURE_KIND = _PanelKind(base="red_base", light="red_light", icon="✗ ", label="Failure")
-_COMPLETE_KIND = _PanelKind(base="green_base", light="green.light", icon="✓ ", label="Complete")
+_COMPLETE_KIND = _PanelKind(base="green_base", light="green_light", icon="✓ ", label="Complete")
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator

--- a/src/raitap/utils/console.py
+++ b/src/raitap/utils/console.py
@@ -189,7 +189,13 @@ class RaitapRichHandler(RichHandler):
 
     def _emit_panel(self, record: logging.LogRecord, message: str) -> None:
         if record.levelno >= logging.ERROR:
-            border, main_style, sub_style, icon, label = "red", "red", "yellow", "✗ ", "Error"
+            border, main_style, sub_style, icon, label = (
+                "red",
+                "red",
+                "red dim",
+                "✗ ",
+                "Error",
+            )
         else:
             border, main_style, sub_style, icon, label = (
                 "yellow",
@@ -289,10 +295,15 @@ class RaitapRichHandler(RichHandler):
             title=title_text,
             title_align="left",
             border_style=border,
-            padding=(0, 1),
+            padding=(1, 2),
         )
         try:
+            # Two blank lines so the panel doesn't visually collide with a
+            # progress bar or other Rich output that didn't leave trailing
+            # whitespace (one blank line is sometimes consumed by the
+            # progress renderer's final repaint).
             if not self._last_was_panel:
+                self.console.print()
                 self.console.print()
             self.console.print(panel)
             self.console.print()
@@ -518,7 +529,7 @@ def print_complete_panel(duration: str) -> None:
     panel = Panel(
         body,
         border_style="bold green",
-        padding=(0, 2),
+        padding=(1, 2),
     )
     get_console().print()
     get_console().print(panel)
@@ -554,7 +565,7 @@ def print_failure_panel(exc: BaseException, duration: str) -> None:
             src=src,
             diagnostic=exc.diagnostic,
             main_style="red",
-            sub_style="yellow",
+            sub_style="red dim",
         )
         title_text = Text.from_markup(" ".join(header_parts))
         title_text.overflow = "ellipsis"
@@ -583,8 +594,11 @@ def print_failure_panel(exc: BaseException, duration: str) -> None:
         title=title,
         title_align="left" if title is not None else "center",
         border_style="bold red",
-        padding=(0, 2),
+        padding=(1, 2),
     )
+    # Two blank lines so the panel separates cleanly from a progress bar
+    # whose final repaint may eat the first newline.
+    get_stderr_console().print()
     get_stderr_console().print()
     get_stderr_console().print(panel)
     get_stderr_console().print()

--- a/src/raitap/utils/errors.py
+++ b/src/raitap/utils/errors.py
@@ -1,0 +1,175 @@
+"""Error-rethrow layer for wrapped third-party libraries.
+
+Sits on top of :mod:`raitap.utils.diagnostics`. Adapter call sites wrap
+third-party library calls in :func:`rethrow`; when the library raises an
+exception whose message matches a curated pattern, the original is replaced
+with a user-actionable message and re-raised as :class:`AdapterError`, with
+the original exception preserved on ``__cause__`` so the raw traceback stays
+available for debugging.
+
+Unmatched exceptions propagate untouched — the rethrow layer only rewords
+known footguns, it never masks real bugs.
+
+Companion to :mod:`raitap.utils.log` (warnings side of the same plumbing).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from raitap.utils.diagnostics import (
+    Diagnostic,
+    Subsystem,
+    _classify_subsystem,
+    _detect_third_party,
+)
+
+if TYPE_CHECKING:
+    import re
+    from collections.abc import Iterator, Mapping
+    from types import TracebackType
+
+
+class RaitapError(Exception):
+    """Base raitap exception carrying a :class:`Diagnostic`.
+
+    The diagnostic powers audience-aware rendering in
+    :class:`raitap.utils.console.RaitapRichHandler` and
+    :func:`raitap.utils.console.print_failure_panel`.
+    """
+
+    diagnostic: Diagnostic | None
+
+    def __init__(self, message: str, *, diagnostic: Diagnostic | None = None) -> None:
+        super().__init__(message)
+        self.diagnostic = diagnostic
+
+
+class AdapterError(RaitapError):
+    """Raised by :func:`rethrow` when a wrapped library error is rewrapped.
+
+    The original exception is preserved on ``__cause__``.
+    """
+
+
+def resolve_diagnostic_from_traceback(
+    tb: TracebackType | None,
+    *,
+    default_file: str = "",
+    default_line: int = 0,
+) -> Diagnostic:
+    """Walk a traceback's ``tb_next`` chain to classify the diagnostic origin.
+
+    Mirrors :func:`raitap.utils.diagnostics.resolve_diagnostic_from_frames`
+    but consumes a frozen traceback rather than the live call stack — needed
+    because by the time the rethrow handler runs the exception has propagated
+    and the offending frames are no longer on ``sys._getframe``.
+
+    Returns a :class:`Diagnostic` with:
+
+    - ``file`` / ``line``: deepest frame inside ``raitap/<subsystem>/`` that
+      isn't ``raitap/utils/`` (so the user lands at the adapter, not the
+      rethrow helper), falling back to ``default_file:default_line``.
+    - ``subsystem``: the matching ``<subsystem>``, or ``None``.
+    - ``third_party_lib``: name of a known wrapped library if any traceback
+      frame lives inside it; otherwise ``None``.
+    """
+    rai_path: str | None = None
+    rai_line: int = default_line
+    rai_sub: Subsystem | None = None
+    third_party: str | None = None
+
+    cursor = tb
+    while cursor is not None:
+        frame = cursor.tb_frame
+        path = frame.f_code.co_filename
+        normalized = path.replace("\\", "/")
+        if third_party is None:
+            third_party = _detect_third_party(path)
+        if "/raitap/" in normalized and "/raitap/utils/" not in normalized:
+            sub = _classify_subsystem(path)
+            if sub is not None:
+                rai_path = path
+                rai_line = cursor.tb_lineno
+                rai_sub = sub
+        cursor = cursor.tb_next
+
+    if rai_path is None:
+        return Diagnostic(
+            subsystem=None,
+            file=default_file,
+            line=default_line,
+            third_party_lib=third_party,
+        )
+    return Diagnostic(
+        subsystem=rai_sub,
+        file=rai_path,
+        line=rai_line,
+        third_party_lib=third_party,
+    )
+
+
+@contextmanager
+def rethrow(
+    *,
+    subsystem: Subsystem,
+    third_party_lib: str | None,
+    message_map: Mapping[re.Pattern[str], str],
+    base_exc: type[BaseException] = Exception,
+) -> Iterator[None]:
+    """Rewrap third-party errors matching a curated pattern dict.
+
+    Adapter call sites wrap their third-party calls in::
+
+        with rethrow(
+            subsystem=Subsystem.transparency,
+            third_party_lib="shap",
+            message_map=type(self).error_messages,
+        ):
+            shap_values = explainer.shap_values(inputs)
+
+    On a matching exception, raises :class:`AdapterError` carrying the
+    replacement message and a :class:`Diagnostic` resolved from the traceback,
+    with ``__cause__`` set to the original. Unmatched exceptions and anything
+    outside ``base_exc`` (e.g. :class:`KeyboardInterrupt`) propagate as-is.
+    """
+    try:
+        yield
+    except base_exc as exc:
+        original_message = str(exc)
+        replacement: str | None = None
+        for pattern, new_message in message_map.items():
+            if pattern.search(original_message):
+                replacement = new_message
+                break
+        if replacement is None:
+            raise
+        diagnostic = resolve_diagnostic_from_traceback(
+            exc.__traceback__,
+            default_file="",
+            default_line=0,
+        )
+        if diagnostic.subsystem is None:
+            diagnostic = Diagnostic(
+                subsystem=subsystem,
+                file=diagnostic.file,
+                line=diagnostic.line,
+                third_party_lib=diagnostic.third_party_lib or third_party_lib,
+            )
+        elif diagnostic.third_party_lib is None and third_party_lib is not None:
+            diagnostic = Diagnostic(
+                subsystem=diagnostic.subsystem,
+                file=diagnostic.file,
+                line=diagnostic.line,
+                third_party_lib=third_party_lib,
+            )
+        raise AdapterError(replacement, diagnostic=diagnostic) from exc
+
+
+__all__ = [
+    "AdapterError",
+    "RaitapError",
+    "resolve_diagnostic_from_traceback",
+    "rethrow",
+]

--- a/src/raitap/utils/status_frame.py
+++ b/src/raitap/utils/status_frame.py
@@ -36,17 +36,19 @@ def chip(
 ) -> Text:
     """Build a ``· label`` chip with the given Rich :class:`Style`.
 
-    ``link`` adds an OSC 8 hyperlink without breaking the colour;
-    ``underline`` toggles the underline attribute (used for ``View docs``
-    affordances). The leading ``· `` separator is part of the chip so chips
-    compose by simple concatenation.
+    The leading ``· `` separator always renders in the plain chip ``style``;
+    ``link`` / ``underline`` only decorate the label so users don't see the
+    separator dot rendered as part of the clickable region.
     """
-    chip_style = style
+    label_style = style
     if underline:
-        chip_style = chip_style + Style(underline=True)
+        label_style = label_style + Style(underline=True)
     if link is not None:
-        chip_style = chip_style + Style(link=link)
-    return Text(f"· {label}", style=chip_style)
+        label_style = label_style + Style(link=link)
+    text = Text()
+    text.append("· ", style=style)
+    text.append(label, style=label_style)
+    return text
 
 
 @dataclass(frozen=True)

--- a/src/raitap/utils/status_frame.py
+++ b/src/raitap/utils/status_frame.py
@@ -1,0 +1,86 @@
+"""Single framed status panel — ``StatusFrame``.
+
+Wraps Rich's :class:`~rich.panel.Panel` with the raitap header convention:
+``icon label · chip · chip · …``. One class covers warning, error, failure
+(an :attr:`Status.ERROR` with a custom label), and completion panels —
+they differ only by :class:`Status`, label, and chip composition.
+
+Renderers compose chips via the :func:`chip` helper, which returns Rich
+:class:`~rich.text.Text` instances with pre-resolved :class:`~rich.style.Style`
+attributes (colour + link + underline). No theme-name strings cross this
+boundary, so Rich's "compound style strings bypass theme lookup" footgun
+can't bite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from rich.panel import Panel
+from rich.style import Style
+from rich.text import Text
+
+from raitap.utils.colour import Status, colour
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def chip(
+    label: str,
+    *,
+    style: Style,
+    link: str | None = None,
+    underline: bool = False,
+) -> Text:
+    """Build a ``· label`` chip with the given Rich :class:`Style`.
+
+    ``link`` adds an OSC 8 hyperlink without breaking the colour;
+    ``underline`` toggles the underline attribute (used for ``View docs``
+    affordances). The leading ``· `` separator is part of the chip so chips
+    compose by simple concatenation.
+    """
+    chip_style = style
+    if underline:
+        chip_style = chip_style + Style(underline=True)
+    if link is not None:
+        chip_style = chip_style + Style(link=link)
+    return Text(f"· {label}", style=chip_style)
+
+
+@dataclass(frozen=True)
+class StatusFrame:
+    """A framed status event: warning, error, completion, or similar.
+
+    Renderers pick a :class:`Status` and supply the body; the frame handles
+    icon, default label, border colour, and title composition. ``label``
+    overrides the status's default label (e.g. ``"Failure"`` for a
+    top-level :attr:`Status.ERROR`).
+    """
+
+    status: Status
+    body: Text
+    label: str | None = None
+    chips: Sequence[Text] = field(default_factory=tuple)
+    padding: tuple[int, int] = (1, 2)
+
+    def render(self) -> Panel:
+        shades = colour(self.status)
+        label = self.label or self.status.default_label
+        title = Text(f"{self.status.icon}{label}", style=shades.base)
+        for c in self.chips:
+            title.append(" ")
+            title.append_text(c)
+        title.overflow = "ellipsis"
+        title.no_wrap = True
+        return Panel(
+            self.body,
+            title=title,
+            title_align="left",
+            border_style=shades.base,
+            padding=self.padding,
+        )
+
+
+__all__ = ["StatusFrame", "chip"]

--- a/src/raitap/utils/status_frame.py
+++ b/src/raitap/utils/status_frame.py
@@ -68,7 +68,12 @@ class StatusFrame:
     def render(self) -> Panel:
         shades = colour(self.status)
         label = self.label or self.status.default_label
-        title = Text(f"{self.status.icon}{label}", style=shades.base)
+        # Don't set ``title.style`` on the Text: Panel.__rich_console__ calls
+        # ``text.stylize(text.style)`` over the entire title, which would push
+        # the base style over our chip spans and lose the lighter shade.
+        # Apply styles per-span instead.
+        title = Text()
+        title.append(f"{self.status.icon}{label}", style=shades.base)
         for c in self.chips:
             title.append(" ")
             title.append_text(c)

--- a/src/raitap/utils/tests/test_console_errors.py
+++ b/src/raitap/utils/tests/test_console_errors.py
@@ -16,9 +16,11 @@ import pytest
 from rich.console import Console
 
 import raitap.utils.console as console_module
+from raitap.utils.colour import THEME
 from raitap.utils.console import (
+    _FAILURE_KIND,
     RaitapRichHandler,
-    _append_failure_chips,
+    _append_chips,
     print_failure_panel,
 )
 from raitap.utils.diagnostics import Diagnostic, Subsystem
@@ -47,13 +49,12 @@ class TestAppendFailureChips:
         )
         parts: list[str] = ["[red]✗ Failure[/]"]
         with patch.object(console_module, "is_dev_install", return_value=True):
-            _append_failure_chips(
+            _append_chips(
                 parts,
                 scope="Transparency",
                 src=f"{diag.file}:{diag.line}",
                 diagnostic=diag,
-                main_style="red",
-                sub_style="yellow",
+                kind=_FAILURE_KIND,
             )
         joined = " ".join(parts)
         assert "Transparency" in joined
@@ -69,13 +70,12 @@ class TestAppendFailureChips:
         )
         parts: list[str] = ["[red]✗ Failure[/]"]
         with patch.object(console_module, "is_dev_install", return_value=False):
-            _append_failure_chips(
+            _append_chips(
                 parts,
                 scope="Transparency",
                 src="",
                 diagnostic=diag,
-                main_style="red",
-                sub_style="yellow",
+                kind=_FAILURE_KIND,
             )
         joined = " ".join(parts)
         assert "View docs" in joined
@@ -86,20 +86,19 @@ class TestAppendFailureChips:
         diag = Diagnostic(subsystem=None, file="", line=0, third_party_lib=None)
         parts: list[str] = ["[red]✗ Failure[/]"]
         with patch.object(console_module, "is_dev_install", return_value=False):
-            _append_failure_chips(
+            _append_chips(
                 parts,
                 scope="RaitapError",
                 src="",
                 diagnostic=diag,
-                main_style="red",
-                sub_style="yellow",
+                kind=_FAILURE_KIND,
             )
         assert parts == ["[red]✗ Failure[/]"]
 
 
 class TestPrintFailurePanel:
     def test_plain_exception_uses_default_title(self) -> None:
-        console = Console(file=io.StringIO(), force_terminal=False, width=120)
+        console = Console(file=io.StringIO(), force_terminal=False, width=120, theme=THEME)
         with patch.object(console_module, "get_stderr_console", return_value=console):
             print_failure_panel(RuntimeError("plain boom"), "0:00:01")
         output = console.file.getvalue()  # type: ignore[attr-defined]
@@ -122,7 +121,7 @@ class TestPrintFailurePanel:
         except AdapterError as exc:
             captured = exc
 
-        console = Console(file=io.StringIO(), force_terminal=False, width=160)
+        console = Console(file=io.StringIO(), force_terminal=False, width=160, theme=THEME)
         with (
             patch.object(console_module, "get_stderr_console", return_value=console),
             patch.object(console_module, "is_dev_install", return_value=True),
@@ -144,7 +143,7 @@ class TestRichHandlerErrorPanel:
         )
         err = RaitapError("rewrapped robustness failure", diagnostic=diag)
 
-        console = Console(file=io.StringIO(), force_terminal=False, width=160)
+        console = Console(file=io.StringIO(), force_terminal=False, width=160, theme=THEME)
         handler = RaitapRichHandler(console=console, show_time=False, show_level=False)
         handler.setLevel(logging.ERROR)
 

--- a/src/raitap/utils/tests/test_console_errors.py
+++ b/src/raitap/utils/tests/test_console_errors.py
@@ -16,11 +16,10 @@ import pytest
 from rich.console import Console
 
 import raitap.utils.console as console_module
-from raitap.utils.colour import THEME
+from raitap.utils.colour import THEME, Status
 from raitap.utils.console import (
-    _FAILURE_KIND,
     RaitapRichHandler,
-    _append_chips,
+    diagnostic_chips,
     print_failure_panel,
 )
 from raitap.utils.diagnostics import Diagnostic, Subsystem
@@ -39,7 +38,7 @@ def _reset_dev_install_cache() -> Iterator[None]:
     is_dev_install.cache_clear()
 
 
-class TestAppendFailureChips:
+class TestDiagnosticChips:
     def test_dev_install_includes_path_and_third_party(self) -> None:
         diag = Diagnostic(
             subsystem=Subsystem.transparency,
@@ -47,16 +46,14 @@ class TestAppendFailureChips:
             line=196,
             third_party_lib="shap",
         )
-        parts: list[str] = ["[red]✗ Failure[/]"]
         with patch.object(console_module, "is_dev_install", return_value=True):
-            _append_chips(
-                parts,
+            chips = diagnostic_chips(
+                Status.ERROR,
                 scope="Transparency",
                 src=f"{diag.file}:{diag.line}",
                 diagnostic=diag,
-                kind=_FAILURE_KIND,
             )
-        joined = " ".join(parts)
+        joined = " ".join(c.plain for c in chips)
         assert "Transparency" in joined
         assert "shap_explainer.py:196" in joined
         assert "via Shap" in joined
@@ -68,32 +65,27 @@ class TestAppendFailureChips:
             line=0,
             third_party_lib="shap",
         )
-        parts: list[str] = ["[red]✗ Failure[/]"]
         with patch.object(console_module, "is_dev_install", return_value=False):
-            _append_chips(
-                parts,
+            chips = diagnostic_chips(
+                Status.ERROR,
                 scope="Transparency",
                 src="",
                 diagnostic=diag,
-                kind=_FAILURE_KIND,
             )
-        joined = " ".join(parts)
+        joined = " ".join(c.plain for c in chips)
         assert "View docs" in joined
-        # No raw path chip in installed mode.
         assert "<frozen>" not in joined
 
     def test_unclassified_in_installed_mode_yields_no_chips(self) -> None:
         diag = Diagnostic(subsystem=None, file="", line=0, third_party_lib=None)
-        parts: list[str] = ["[red]✗ Failure[/]"]
         with patch.object(console_module, "is_dev_install", return_value=False):
-            _append_chips(
-                parts,
+            chips = diagnostic_chips(
+                Status.ERROR,
                 scope="RaitapError",
                 src="",
                 diagnostic=diag,
-                kind=_FAILURE_KIND,
             )
-        assert parts == ["[red]✗ Failure[/]"]
+        assert chips == []
 
 
 class TestPrintFailurePanel:

--- a/src/raitap/utils/tests/test_console_errors.py
+++ b/src/raitap/utils/tests/test_console_errors.py
@@ -1,0 +1,168 @@
+"""Console rendering of :class:`RaitapError` panels.
+
+Focuses on the chip-composition logic and the :func:`print_failure_panel`
+``RaitapError`` branch — both newly added for issue #22 to bring error panels
+to parity with the warning rendering shipped in PR #124.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+import raitap.utils.console as console_module
+from raitap.utils.console import (
+    RaitapRichHandler,
+    _append_failure_chips,
+    print_failure_panel,
+)
+from raitap.utils.diagnostics import Diagnostic, Subsystem
+from raitap.utils.errors import AdapterError, RaitapError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _reset_dev_install_cache() -> Iterator[None]:
+    from raitap.utils.diagnostics import is_dev_install
+
+    is_dev_install.cache_clear()
+    yield
+    is_dev_install.cache_clear()
+
+
+class TestAppendFailureChips:
+    def test_dev_install_includes_path_and_third_party(self) -> None:
+        diag = Diagnostic(
+            subsystem=Subsystem.transparency,
+            file="src/raitap/transparency/explainers/shap_explainer.py",
+            line=196,
+            third_party_lib="shap",
+        )
+        parts: list[str] = ["[red]✗ Failure[/]"]
+        with patch.object(console_module, "is_dev_install", return_value=True):
+            _append_failure_chips(
+                parts,
+                scope="Transparency",
+                src=f"{diag.file}:{diag.line}",
+                diagnostic=diag,
+                main_style="red",
+                sub_style="yellow",
+            )
+        joined = " ".join(parts)
+        assert "Transparency" in joined
+        assert "shap_explainer.py:196" in joined
+        assert "via Shap" in joined
+
+    def test_installed_wheel_includes_docs_link(self) -> None:
+        diag = Diagnostic(
+            subsystem=Subsystem.transparency,
+            file="<frozen>",
+            line=0,
+            third_party_lib="shap",
+        )
+        parts: list[str] = ["[red]✗ Failure[/]"]
+        with patch.object(console_module, "is_dev_install", return_value=False):
+            _append_failure_chips(
+                parts,
+                scope="Transparency",
+                src="",
+                diagnostic=diag,
+                main_style="red",
+                sub_style="yellow",
+            )
+        joined = " ".join(parts)
+        assert "View docs" in joined
+        # No raw path chip in installed mode.
+        assert "<frozen>" not in joined
+
+    def test_unclassified_in_installed_mode_yields_no_chips(self) -> None:
+        diag = Diagnostic(subsystem=None, file="", line=0, third_party_lib=None)
+        parts: list[str] = ["[red]✗ Failure[/]"]
+        with patch.object(console_module, "is_dev_install", return_value=False):
+            _append_failure_chips(
+                parts,
+                scope="RaitapError",
+                src="",
+                diagnostic=diag,
+                main_style="red",
+                sub_style="yellow",
+            )
+        assert parts == ["[red]✗ Failure[/]"]
+
+
+class TestPrintFailurePanel:
+    def test_plain_exception_uses_default_title(self) -> None:
+        console = Console(file=io.StringIO(), force_terminal=False, width=120)
+        with patch.object(console_module, "get_stderr_console", return_value=console):
+            print_failure_panel(RuntimeError("plain boom"), "0:00:01")
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "Assessment failed" in output
+        assert "RuntimeError" in output
+        assert "plain boom" in output
+
+    def test_raitap_error_renders_diagnostic_chips_and_cause(self) -> None:
+        diag = Diagnostic(
+            subsystem=Subsystem.transparency,
+            file="/x/raitap/transparency/explainers/shap_explainer.py",
+            line=196,
+            third_party_lib="shap",
+        )
+        try:
+            try:
+                raise RuntimeError("original library error")
+            except RuntimeError as exc:
+                raise AdapterError("user-facing replacement", diagnostic=diag) from exc
+        except AdapterError as exc:
+            captured = exc
+
+        console = Console(file=io.StringIO(), force_terminal=False, width=160)
+        with (
+            patch.object(console_module, "get_stderr_console", return_value=console),
+            patch.object(console_module, "is_dev_install", return_value=True),
+        ):
+            print_failure_panel(captured, "0:00:01")
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "user-facing replacement" in output
+        assert "Transparency" in output
+        assert "caused by RuntimeError" in output
+
+
+class TestRichHandlerErrorPanel:
+    def test_logger_error_with_raitap_exc_renders_diagnostic_header(self) -> None:
+        diag = Diagnostic(
+            subsystem=Subsystem.robustness,
+            file="/x/raitap/robustness/assessors/foolbox_assessor.py",
+            line=161,
+            third_party_lib="foolbox",
+        )
+        err = RaitapError("rewrapped robustness failure", diagnostic=diag)
+
+        console = Console(file=io.StringIO(), force_terminal=False, width=160)
+        handler = RaitapRichHandler(console=console, show_time=False, show_level=False)
+        handler.setLevel(logging.ERROR)
+
+        logger = logging.getLogger("raitap.tests.console_errors")
+        logger.handlers.clear()
+        logger.addHandler(handler)
+        logger.setLevel(logging.ERROR)
+        logger.propagate = False
+
+        try:
+            with patch.object(console_module, "is_dev_install", return_value=True):
+                try:
+                    raise err
+                except RaitapError:
+                    logger.error("rewrapped robustness failure", exc_info=True)
+        finally:
+            logger.removeHandler(handler)
+
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "Robustness" in output
+        assert "via Foolbox" in output

--- a/src/raitap/utils/tests/test_errors.py
+++ b/src/raitap/utils/tests/test_errors.py
@@ -31,7 +31,7 @@ class TestResolveDiagnosticFromTraceback:
             "/x/raitap/transparency/explainers/shap_explainer.py", 196, tb_inner_utils
         )
         tb_root = _make_tb("/other/site.py", 1, tb_transparency)
-        diag = resolve_diagnostic_from_traceback(tb_root)
+        diag = resolve_diagnostic_from_traceback(tb_root)  # pyright: ignore[reportArgumentType]
         assert diag.subsystem == Subsystem.transparency
         assert diag.line == 196
         assert "shap_explainer.py" in diag.file
@@ -39,7 +39,7 @@ class TestResolveDiagnosticFromTraceback:
     def test_detects_third_party_in_chain(self) -> None:
         tb_inner = _make_tb("/x/site-packages/shap/explainers/_deep.py", 42, None)
         tb_outer = _make_tb("/x/raitap/transparency/explainers/shap_explainer.py", 196, tb_inner)
-        diag = resolve_diagnostic_from_traceback(tb_outer)
+        diag = resolve_diagnostic_from_traceback(tb_outer)  # pyright: ignore[reportArgumentType]
         assert diag.third_party_lib == "shap"
         assert diag.subsystem == Subsystem.transparency
 

--- a/src/raitap/utils/tests/test_errors.py
+++ b/src/raitap/utils/tests/test_errors.py
@@ -1,0 +1,124 @@
+"""Tests for :mod:`raitap.utils.errors`."""
+
+from __future__ import annotations
+
+import re
+import types
+
+import pytest
+
+from raitap.utils.diagnostics import Diagnostic, Subsystem
+from raitap.utils.errors import (
+    AdapterError,
+    RaitapError,
+    resolve_diagnostic_from_traceback,
+    rethrow,
+)
+
+
+class TestResolveDiagnosticFromTraceback:
+    def test_returns_default_when_tb_is_none(self) -> None:
+        diag = resolve_diagnostic_from_traceback(None, default_file="x.py", default_line=7)
+        assert diag.file == "x.py"
+        assert diag.line == 7
+        assert diag.subsystem is None
+        assert diag.third_party_lib is None
+
+    def test_picks_deepest_raitap_subsystem_frame(self) -> None:
+        # Build a synthetic traceback chain: outer non-raitap → transparency → utils.
+        tb_inner_utils = _make_tb("/x/raitap/utils/log.py", 20, None)
+        tb_transparency = _make_tb(
+            "/x/raitap/transparency/explainers/shap_explainer.py", 196, tb_inner_utils
+        )
+        tb_root = _make_tb("/other/site.py", 1, tb_transparency)
+        diag = resolve_diagnostic_from_traceback(tb_root)
+        assert diag.subsystem == Subsystem.transparency
+        assert diag.line == 196
+        assert "shap_explainer.py" in diag.file
+
+    def test_detects_third_party_in_chain(self) -> None:
+        tb_inner = _make_tb("/x/site-packages/shap/explainers/_deep.py", 42, None)
+        tb_outer = _make_tb("/x/raitap/transparency/explainers/shap_explainer.py", 196, tb_inner)
+        diag = resolve_diagnostic_from_traceback(tb_outer)
+        assert diag.third_party_lib == "shap"
+        assert diag.subsystem == Subsystem.transparency
+
+
+class TestRethrow:
+    def test_passthrough_when_no_exception(self) -> None:
+        with rethrow(
+            subsystem=Subsystem.transparency,
+            third_party_lib="shap",
+            message_map={re.compile("never matches"): "replacement"},
+        ):
+            value = 1 + 1
+        assert value == 2
+
+    def test_matches_pattern_and_wraps(self) -> None:
+        message_map = {re.compile(r"view and is being modified inplace"): "Use GradientExplainer."}
+        with (
+            pytest.raises(AdapterError) as info,
+            rethrow(
+                subsystem=Subsystem.transparency,
+                third_party_lib="shap",
+                message_map=message_map,
+            ),
+        ):
+            raise RuntimeError(
+                "Output 0 of BackwardHookFunctionBackward is a view and is being modified inplace"
+            )
+        exc = info.value
+        assert "Use GradientExplainer" in str(exc)
+        assert isinstance(exc.__cause__, RuntimeError)
+        assert exc.diagnostic is not None
+        assert exc.diagnostic.subsystem == Subsystem.transparency
+        assert exc.diagnostic.third_party_lib == "shap"
+
+    def test_unmatched_message_propagates_unchanged(self) -> None:
+        with (
+            pytest.raises(RuntimeError) as info,
+            rethrow(
+                subsystem=Subsystem.transparency,
+                third_party_lib="shap",
+                message_map={re.compile("xyz"): "rewritten"},
+            ),
+        ):
+            raise RuntimeError("unrelated boom")
+        assert not isinstance(info.value, AdapterError)
+        assert str(info.value) == "unrelated boom"
+
+    def test_skips_exceptions_outside_base_exc(self) -> None:
+        with (
+            pytest.raises(KeyboardInterrupt),
+            rethrow(
+                subsystem=Subsystem.transparency,
+                third_party_lib="shap",
+                message_map={re.compile(".*"): "rewritten"},
+                base_exc=Exception,
+            ),
+        ):
+            raise KeyboardInterrupt()
+
+
+class TestRaitapError:
+    def test_carries_diagnostic(self) -> None:
+        diag = Diagnostic(
+            subsystem=Subsystem.robustness,
+            file="x.py",
+            line=1,
+            third_party_lib="foolbox",
+        )
+        err = RaitapError("boom", diagnostic=diag)
+        assert err.diagnostic is diag
+        assert str(err) == "boom"
+
+
+def _make_tb(filename: str, lineno: int, tb_next: object) -> object:
+    """Build a duck-typed traceback object good enough for our walker.
+
+    Real ``types.TracebackType`` cannot be instantiated directly; the walker
+    only reads ``tb_frame.f_code.co_filename``, ``tb_lineno``, and ``tb_next``.
+    """
+    code = types.SimpleNamespace(co_filename=filename)
+    frame = types.SimpleNamespace(f_code=code)
+    return types.SimpleNamespace(tb_frame=frame, tb_lineno=lineno, tb_next=tb_next)


### PR DESCRIPTION
## Summary

Closes #22. Adds error-rethrow plumbing on top of PR #124's diagnostic infrastructure so confusing third-party errors (SHAP, Captum, Foolbox, Torchattacks) get rewrapped with user-actionable copy and rendered with the same `Subsystem · View docs · via <lib>` chips already used for warnings.

- New `raitap.utils.errors`: `RaitapError`, `AdapterError`, `resolve_diagnostic_from_traceback`, `rethrow` context manager. Pattern-match `str(exc)` against a curated dict; matched errors become `AdapterError` with the original on `__cause__`. Unmatched + non-`base_exc` propagate untouched.
- Per-adapter `error_messages: ClassVar[Mapping[re.Pattern, str]]` on `ShapExplainer` (seeded with the SiLU/DeepExplainer entry from the issue), `CaptumExplainer`, `FoolboxAssessor`, `TorchattacksAssessor` (empty seed — extend as confusing errors surface in practice).
- Adapter call sites wrap `explainer.shap_values(...)`, captum `method_class(...) + method.attribute(...)`, foolbox `attack(...)`, torchattacks `attack(...)`.
- `console.py`: `_render_warning_header` generalised to `_render_diagnostic_header` (shared with the error path); `RaitapRichHandler` now reads `RaitapError.diagnostic` off `record.exc_info` and renders chips; `print_failure_panel` mirrors the affordance and shows a dim `caused by <Original>` line so the underlying library is still grep-able.

## Test plan

- [x] `uv run pytest src/raitap/utils src/raitap/transparency/explainers/tests src/raitap/robustness/assessors/tests` — 79 passed, 9 skipped
- [x] `uv run ruff format` + `uv run ruff check` clean on touched files
- [ ] CI green
- [ ] Manual smoke: SHAP DeepExplainer + EfficientNet (SiLU) → panel renders the new message instead of the raw `BackwardHookFunctionBackward` traceback