### PR TITLE
feat(infra): chips for every panel-producing log (#149)

### DIFF
--- a/src/raitap/utils/console.py
+++ b/src/raitap/utils/console.py
@@ -36,6 +36,8 @@ from raitap.utils.diagnostics import (
     docs_url,
     is_dev_install,
     resolve_diagnostic_from_frames,
+    resolve_diagnostic_from_path,
+    resolve_diagnostic_from_traceback,
     subsystem_from_str,
 )
 from raitap.utils.errors import RaitapError
@@ -239,26 +241,41 @@ class RaitapRichHandler(RichHandler):
             if head_match:
                 head = head_match.group("head")
                 shades = colour(status)
-                chips = [chip(head, style=shades.light)]
-                # logger.warning("Subsystem: …") records have no Diagnostic
-                # stashed (no frame walk happened), so synthesise one from the
-                # header text to drive the same View-docs affordance.
-                synth = Diagnostic(
-                    subsystem=subsystem_from_str(head.lower()),
-                    file="",
-                    line=0,
-                    third_party_lib=None,
-                )
-                if not is_dev_install():
-                    url = docs_url(synth)
-                    if url is not None:
-                        chips.append(
-                            chip("View docs", style=shades.light, link=url, underline=True)
-                        )
+                # Prefer a traceback/path-derived Diagnostic so the chips can
+                # carry a real file:line; fall back to a header-derived synth
+                # for plain logger.warning("Foo: …") records that have no
+                # exc_info and no informative pathname.
+                resolved = _diagnostic_from_record(record)
+                if resolved is None or (
+                    resolved.subsystem is None and resolved.third_party_lib is None
+                ):
+                    resolved = Diagnostic(
+                        subsystem=subsystem_from_str(head.lower()),
+                        file="",
+                        line=0,
+                        third_party_lib=None,
+                    )
+                scope = resolved.subsystem.capitalize() if resolved.subsystem else head
+                src = f"{resolved.file}:{resolved.line}" if resolved.file else ""
+                derived = diagnostic_chips(status, scope=scope, src=src, diagnostic=resolved)
+                chips = derived if derived else [chip(head, style=shades.light)]
                 stripped = head_match.group("msg").strip()
                 body = _linkify_message(
                     stripped[:1].upper() + stripped[1:] if stripped else stripped
                 )
+
+        if not chips:
+            diagnostic = _diagnostic_from_record(record)
+            if diagnostic is not None and (
+                diagnostic.subsystem is not None or diagnostic.third_party_lib is not None
+            ):
+                scope = (
+                    diagnostic.subsystem.capitalize()
+                    if diagnostic.subsystem
+                    else record.name.rsplit(".", 1)[-1].capitalize()
+                )
+                src = f"{diagnostic.file}:{diagnostic.line}" if diagnostic.file else ""
+                chips = diagnostic_chips(status, scope=scope, src=src, diagnostic=diagnostic)
 
         self._print_frame(record, StatusFrame(status, body, label=label, chips=chips))
 
@@ -304,6 +321,27 @@ def setup_logging(level: int = logging.INFO) -> None:
     # handler then unpacks it back into a Panel with subtitle = source.
     warnings.formatwarning = _format_warning_compact  # type: ignore[assignment]
     install_rich_traceback(console=get_stderr_console(), show_locals=False, width=None)
+
+
+def _diagnostic_from_record(record: logging.LogRecord) -> Diagnostic | None:
+    """Resolve a :class:`Diagnostic` for *any* log record.
+
+    Walks ``record.exc_info`` traceback first (most informative — pinpoints the
+    actual raising frame inside a raitap subsystem); falls back to the
+    record's own ``pathname``/``lineno`` so non-exception ``logger.warning`` /
+    ``logger.error`` calls still get scope and ``file:line`` chips. Returns
+    ``None`` only when the record carries no usable location at all.
+    """
+    exc_info = record.exc_info
+    if isinstance(exc_info, tuple) and len(exc_info) >= 3 and exc_info[2] is not None:
+        return resolve_diagnostic_from_traceback(
+            exc_info[2],
+            default_file=record.pathname or "",
+            default_line=record.lineno or 0,
+        )
+    if record.pathname:
+        return resolve_diagnostic_from_path(record.pathname, record.lineno or 0)
+    return None
 
 
 def _extract_raitap_error(record: logging.LogRecord) -> RaitapError | None:

--- a/src/raitap/utils/diagnostics.py
+++ b/src/raitap/utils/diagnostics.py
@@ -30,7 +30,10 @@ import sys
 from dataclasses import dataclass
 from enum import StrEnum
 from functools import lru_cache
-from typing import Final
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from types import TracebackType
 
 _SUBSYSTEM_RE = re.compile(r"raitap[\\/](?!src[\\/])(?P<sub>\w+)[\\/]")
 
@@ -182,6 +185,75 @@ def resolve_diagnostic_from_frames(default_file: str, default_line: int) -> Diag
     )
 
 
+def resolve_diagnostic_from_traceback(
+    tb: TracebackType | None,
+    default_file: str = "",
+    default_line: int = 0,
+) -> Diagnostic:
+    """Walk an exception traceback to find the deepest raitap subsystem frame.
+
+    Unlike :func:`resolve_diagnostic_from_frames`, the traceback survives the
+    ``except`` handler, so we can still classify origins after the live frames
+    have been unwound (e.g. inside a ``logger.exception`` handler at emit time).
+    Picks the *deepest* matching subsystem frame so the chip points at the
+    actual raising site, not the entry point.
+    """
+    third_party: str | None = None
+    rai_path: str | None = None
+    rai_line: int = default_line
+    rai_sub: Subsystem | None = None
+
+    cur = tb
+    while cur is not None:
+        path = cur.tb_frame.f_code.co_filename
+        normalized = path.replace("\\", "/")
+        if third_party is None:
+            third_party = _detect_third_party(path)
+        if "/raitap/" in normalized and "/raitap/utils/" not in normalized:
+            sub = _classify_subsystem(path)
+            if sub is not None:
+                rai_path = path
+                rai_line = cur.tb_lineno
+                rai_sub = sub
+        cur = cur.tb_next
+
+    if rai_path is None:
+        return Diagnostic(
+            subsystem=None,
+            file=default_file,
+            line=default_line,
+            third_party_lib=third_party,
+        )
+    return Diagnostic(
+        subsystem=rai_sub,
+        file=rai_path,
+        line=rai_line,
+        third_party_lib=third_party,
+    )
+
+
+def resolve_diagnostic_from_path(path: str, line: int) -> Diagnostic:
+    """Classify a single ``path:line`` location without walking any stack.
+
+    Useful for log records that carry their emission site via
+    ``record.pathname`` / ``record.lineno`` but no exception traceback. Returns
+    a :class:`Diagnostic` with ``subsystem``/``file`` populated when the path
+    sits inside a non-``utils`` raitap subsystem; otherwise the third-party
+    flag may still be set if the path lives inside a wrapped library.
+    """
+    normalized = path.replace("\\", "/")
+    sub: Subsystem | None = None
+    if "/raitap/" in normalized and "/raitap/utils/" not in normalized:
+        sub = _classify_subsystem(path)
+    third_party = _detect_third_party(path)
+    return Diagnostic(
+        subsystem=sub,
+        file=path if sub is not None else "",
+        line=line if sub is not None else 0,
+        third_party_lib=third_party,
+    )
+
+
 @lru_cache(maxsize=1)
 def is_dev_install() -> bool:
     """Return ``True`` when raitap appears to run from a cloned/editable checkout.
@@ -223,5 +295,7 @@ __all__ = [
     "docs_url",
     "is_dev_install",
     "resolve_diagnostic_from_frames",
+    "resolve_diagnostic_from_path",
+    "resolve_diagnostic_from_traceback",
     "subsystem_from_str",
 ]

--- a/src/raitap/utils/diagnostics.py
+++ b/src/raitap/utils/diagnostics.py
@@ -30,10 +30,8 @@ import sys
 from dataclasses import dataclass
 from enum import StrEnum
 from functools import lru_cache
-from typing import TYPE_CHECKING, Final
-
-if TYPE_CHECKING:
-    from types import TracebackType
+from types import TracebackType  # noqa: TC003 — runtime import: keeps public hints resolvable
+from typing import Final
 
 _SUBSYSTEM_RE = re.compile(r"raitap[\\/](?!src[\\/])(?P<sub>\w+)[\\/]")
 

--- a/src/raitap/utils/tests/test_console_errors.py
+++ b/src/raitap/utils/tests/test_console_errors.py
@@ -26,7 +26,7 @@ from raitap.utils.diagnostics import Diagnostic, Subsystem
 from raitap.utils.errors import AdapterError, RaitapError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
 
 @pytest.fixture(autouse=True)
@@ -125,7 +125,63 @@ class TestPrintFailurePanel:
         assert "caused by RuntimeError" in output
 
 
+def _emit_to_handler(record_factory: Callable[[logging.Logger], None]) -> str:
+    console = Console(file=io.StringIO(), force_terminal=False, width=160, theme=THEME)
+    handler = RaitapRichHandler(console=console, show_time=False, show_level=False)
+    handler.setLevel(logging.DEBUG)
+    logger = logging.getLogger("raitap.tests.console_fallback")
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    try:
+        record_factory(logger)
+    finally:
+        logger.removeHandler(handler)
+    return console.file.getvalue()  # type: ignore[attr-defined]
+
+
 class TestRichHandlerErrorPanel:
+    def test_plain_logger_exception_renders_subsystem_chip_from_traceback(self) -> None:
+        # Simulate an exception caught inside src/raitap/robustness/ so the
+        # traceback walker classifies the frame as the robustness subsystem.
+        src = "import logging\ndef boom():\n    raise RuntimeError('inner')\n"
+        code = compile(src, "/tmp/raitap/src/raitap/robustness/fake.py", "exec")
+        ns: dict[str, object] = {}
+        exec(code, ns)
+
+        def fire(logger: logging.Logger) -> None:
+            with patch.object(console_module, "is_dev_install", return_value=True):
+                try:
+                    ns["boom"]()  # type: ignore[operator]
+                except RuntimeError:
+                    logger.exception("verify_sample crashed for index 0")
+
+        output = _emit_to_handler(fire)
+        assert "verify_sample crashed" in output
+        assert "Robustness" in output
+        assert "fake.py:3" in output
+
+    def test_plain_logger_warning_falls_back_to_record_path(self) -> None:
+        def fire(logger: logging.Logger) -> None:
+            with patch.object(console_module, "is_dev_install", return_value=True):
+                # Synthesise a record whose pathname lives in a raitap subsystem
+                # but whose message does NOT match the header pattern.
+                record = logger.makeRecord(
+                    name=logger.name,
+                    level=logging.WARNING,
+                    fn="/tmp/raitap/src/raitap/metrics/factory.py",
+                    lno=51,
+                    msg="bare warning with no header",
+                    args=(),
+                    exc_info=None,
+                )
+                logger.handle(record)
+
+        output = _emit_to_handler(fire)
+        assert "Metrics" in output
+        assert "factory.py:51" in output
+
     def test_logger_error_with_raitap_exc_renders_diagnostic_header(self) -> None:
         diag = Diagnostic(
             subsystem=Subsystem.robustness,


### PR DESCRIPTION
Closes #149.

## Summary

- `RaitapRichHandler._emit_panel` now emits scope / `file:line` / View-docs / `via <lib>` chips for **every** WARNING+ record, not just `RaitapError`, `py.warnings`, and `Header: msg` patterns.
- New `resolve_diagnostic_from_traceback` walks `exc_info[2]` to pinpoint the deepest non-`utils` raitap subsystem frame; new `resolve_diagnostic_from_path` classifies a single `pathname:lineno` for records without an exception.
- Header branch (`Foo: msg`) now also pulls `file:line` from the traceback when present, keeping the bare `head` chip as last-resort.

Concrete effect: `verify_sample crashed for index N` panels (and every other `raitap_log.exception/error/warning` site) now render `· Robustness · base_assessor.py:378` in dev installs and `· Robustness · View docs` in installed wheels.

## Test plan

- [x] `uv run pytest src/raitap/utils/` — 37 passed
- [x] `uv run ruff check src/raitap/utils/`
- [x] `uv run ruff format --check src/raitap/utils/`
- [ ] Smoke-check with a real assessment run that exercises the robustness fallback (`uv run raitap --config-dir examples/lwise-ham10000 --config-name assessment`) — confirm `verify_sample crashed` panels now show the Robustness + path chips.