### PR TITLE
fix(model)!: refuse unsafe pickle checkpoints unless opted in

### DIFF
--- a/docs/modules/model/configuration.md
+++ b/docs/modules/model/configuration.md
@@ -29,10 +29,21 @@
   weights before loading the state-dict (`weights="DEFAULT"`). Usually
   `false` since the state-dict already supplies the weights.
 
+:option: allow_unsafe_pickle
+:allowed: bool
+:default: false
+:description: Opt in to loading checkpoints that require unsafe pickle
+  deserialisation (full `nn.Module` files saved via `torch.save(model, path)`).
+  This executes arbitrary code embedded in the file, so RAITAP refuses such
+  files by default. Only set `true` for checkpoints from a fully trusted
+  source. Prefer re-saving as a state-dict or TorchScript archive instead.
+
 :yaml:
-# Option A — full pickled nn.Module (deprecated, fragile across environments):
+# Option A — full pickled nn.Module (deprecated, requires explicit opt-in;
+# only use for checkpoints from a fully trusted source):
 model:
   source: "myModel.pth"
+  allow_unsafe_pickle: true
 
 # Option B — state_dict + arch (recommended):
 model:

--- a/docs/modules/model/own-vs-built-in.md
+++ b/docs/modules/model/own-vs-built-in.md
@@ -12,10 +12,13 @@ RAITAP allows you to use your own model in any of the following supported format
   `torch.jit.save(scripted, path)`). Self-contained — no `arch` /
   `num_classes` needed.
 - `.pt` / `.pth` containing a full pickled `torch.nn.Module` (saved via
-  `torch.save(model, path)`). **Deprecated** — emits a
-  `DeprecationWarning`. The pickle embeds fully-qualified class paths so it
-  breaks when classes are renamed or when torchvision is bumped. Migrate
-  with one line:
+  `torch.save(model, path)`). **Deprecated and refused by default** — this
+  format requires unsafe pickle deserialisation, which executes arbitrary
+  code embedded in the file. RAITAP refuses such checkpoints unless you
+  explicitly opt in by setting `model.allow_unsafe_pickle: true`, and only
+  do so for files from a fully trusted source. The pickle also embeds
+  fully-qualified class paths so it breaks when classes are renamed or when
+  torchvision is bumped. Migrate with one line (in a trusted environment):
   ```python
   m = torch.load("model.pth", weights_only=False)
   torch.save(m.state_dict(), "weights.pth")

--- a/src/raitap/configs/schema.py
+++ b/src/raitap/configs/schema.py
@@ -21,6 +21,12 @@ class ModelConfig:
     # before loading the state-dict. Usually ``False`` since weights come from
     # the state-dict itself.
     pretrained: bool = False
+    # Opt-in to loading checkpoints that require unsafe pickle deserialisation
+    # (i.e. pickled ``nn.Module`` files that fail ``weights_only=True``). This
+    # executes arbitrary code embedded in the file and MUST only be enabled for
+    # checkpoints from a fully trusted source. Default refuses such files and
+    # asks the user to re-save as a state-dict or TorchScript archive.
+    allow_unsafe_pickle: bool = False
 
 
 @dataclass

--- a/src/raitap/models/model.py
+++ b/src/raitap/models/model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pickle
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -167,13 +168,17 @@ def _load_torch_module_from_path(path: Path, *, model_cfg: Any, device: torch.de
 
     # Try the safe path first: `weights_only=True` only deserialises tensors and
     # state-dicts, refusing arbitrary pickled objects (no code execution risk).
-    # Pickled `nn.Module` checkpoints fail this and require the unsafe path,
-    # which executes arbitrary code embedded in the file. We refuse it unless
-    # the user has explicitly opted in via ``model.allow_unsafe_pickle``.
+    # Pickled `nn.Module` checkpoints fail this with `pickle.UnpicklingError`
+    # ("Weights only load failed ... Unsupported global ...") and require the
+    # unsafe path, which executes arbitrary code embedded in the file. We
+    # refuse it unless the user has explicitly opted in via
+    # ``model.allow_unsafe_pickle``. Any other exception (corrupted archive,
+    # I/O error, version incompatibility) is re-raised as-is so the real
+    # failure mode is not masked by the unsafe-pickle guidance.
     pickled_module = False
     try:
         obj: Any = torch.load(path, map_location="cpu", weights_only=True)
-    except Exception as safe_load_error:
+    except pickle.UnpicklingError as safe_load_error:
         if not bool(getattr(model_cfg, "allow_unsafe_pickle", False)):
             raise ValueError(
                 f"Refusing to load {path}: the file requires unsafe pickle "

--- a/src/raitap/models/model.py
+++ b/src/raitap/models/model.py
@@ -167,12 +167,24 @@ def _load_torch_module_from_path(path: Path, *, model_cfg: Any, device: torch.de
 
     # Try the safe path first: `weights_only=True` only deserialises tensors and
     # state-dicts, refusing arbitrary pickled objects (no code execution risk).
-    # Pickled `nn.Module` checkpoints fail this and fall through to the
-    # deprecated unsafe path below.
+    # Pickled `nn.Module` checkpoints fail this and require the unsafe path,
+    # which executes arbitrary code embedded in the file. We refuse it unless
+    # the user has explicitly opted in via ``model.allow_unsafe_pickle``.
     pickled_module = False
     try:
         obj: Any = torch.load(path, map_location="cpu", weights_only=True)
-    except Exception:
+    except Exception as safe_load_error:
+        if not bool(getattr(model_cfg, "allow_unsafe_pickle", False)):
+            raise ValueError(
+                f"Refusing to load {path}: the file requires unsafe pickle "
+                "deserialisation, which executes arbitrary code embedded in "
+                "the checkpoint. Re-save it as a state-dict "
+                "(`torch.save(model.state_dict(), path)` plus model.arch + "
+                "model.num_classes in the config) or a TorchScript archive "
+                "(`torch.jit.save(scripted, path)`). If the source is fully "
+                "trusted, set `model.allow_unsafe_pickle: true` to override. "
+                f"Underlying error: {safe_load_error}"
+            ) from safe_load_error
         pickled_module = True
         obj = torch.load(path, map_location="cpu", weights_only=False)
 

--- a/src/raitap/models/tests/test_model_class.py
+++ b/src/raitap/models/tests/test_model_class.py
@@ -25,6 +25,7 @@ def _make_config(
     num_classes: int | None = None,
     pretrained: bool = False,
     hardware: str = "cpu",
+    allow_unsafe_pickle: bool = False,
 ) -> AppConfig:
     return cast(
         "AppConfig",
@@ -34,6 +35,7 @@ def _make_config(
                 arch=arch,
                 num_classes=num_classes,
                 pretrained=pretrained,
+                allow_unsafe_pickle=allow_unsafe_pickle,
             ),
             hardware=hardware,
         ),
@@ -54,11 +56,20 @@ class TestModelConstructor:
         model_path = tmp_path / "model.pth"
         torch.save(dummy_model, model_path)
 
-        config = _make_config(str(model_path))
+        config = _make_config(str(model_path), allow_unsafe_pickle=True)
         with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
             model = Model(config)
 
         assert isinstance(model.backend.as_model_for_explanation(), torch.nn.Module)
+
+    def test_model_refuses_pickled_module_without_opt_in(self, tmp_path: Path) -> None:
+        dummy_model = torch.nn.Linear(10, 5)
+        model_path = tmp_path / "model.pth"
+        torch.save(dummy_model, model_path)
+
+        config = _make_config(str(model_path))
+        with pytest.raises(ValueError, match=r"Refusing to load.*allow_unsafe_pickle"):
+            Model(config)
 
     def test_model_loads_from_state_dict(self, tmp_path: Path) -> None:
         from torchvision import models as tv_models

--- a/src/raitap/models/tests/test_models.py
+++ b/src/raitap/models/tests/test_models.py
@@ -69,6 +69,7 @@ def _make_config(
     arch: str | None = None,
     num_classes: int | None = None,
     pretrained: bool = False,
+    allow_unsafe_pickle: bool = False,
 ) -> AppConfig:
     return cast(
         "AppConfig",
@@ -84,6 +85,7 @@ def _make_config(
                         "arch": arch,
                         "num_classes": num_classes,
                         "pretrained": pretrained,
+                        "allow_unsafe_pickle": allow_unsafe_pickle,
                     },
                 )(),
                 "hardware": hardware,
@@ -152,24 +154,29 @@ def saved_onnx(tmp_path: Path) -> Path:
 
 class TestLoadModelFromPath:
     def test_loads_pth_file(self, saved_pth: Path) -> None:
-        cfg = _make_config(str(saved_pth))
+        cfg = _make_config(str(saved_pth), allow_unsafe_pickle=True)
         with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
             model = Model(cfg)
         assert isinstance(model.backend, TorchBackend)
         assert isinstance(model.backend.as_model_for_explanation(), nn.Module)
 
     def test_loads_pt_file(self, saved_pt: Path) -> None:
-        cfg = _make_config(str(saved_pt))
+        cfg = _make_config(str(saved_pt), allow_unsafe_pickle=True)
         with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
             model = Model(cfg)
         assert isinstance(model.backend, TorchBackend)
         assert isinstance(model.backend.as_model_for_explanation(), nn.Module)
 
     def test_returns_eval_mode(self, saved_pth: Path) -> None:
-        cfg = _make_config(str(saved_pth))
+        cfg = _make_config(str(saved_pth), allow_unsafe_pickle=True)
         with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
             model = Model(cfg).backend.as_model_for_explanation()
         assert not model.training
+
+    def test_pickled_module_load_refused_without_opt_in(self, saved_pth: Path) -> None:
+        cfg = _make_config(str(saved_pth))
+        with pytest.raises(ValueError, match=r"Refusing to load.*allow_unsafe_pickle"):
+            Model(cfg)
 
     def test_missing_file_raises_file_not_found(self, tmp_path: Path) -> None:
         cfg = _make_config(str(tmp_path / "ghost.pth"))
@@ -224,7 +231,7 @@ class TestLoadModelFromPath:
         torch.testing.assert_close(loaded(x), ref(x))
 
     def test_pickled_module_load_emits_deprecation_warning(self, saved_pth: Path) -> None:
-        cfg = _make_config(str(saved_pth))
+        cfg = _make_config(str(saved_pth), allow_unsafe_pickle=True)
         with pytest.warns(
             DeprecationWarning,
             match=r"Loading pickled nn\.Module.*Prefer.*state_dict",
@@ -267,9 +274,10 @@ class TestLoadModelFromPath:
             Model(cfg)
 
     def test_torch_hardware_cpu_sets_cpu_device(self, saved_pth: Path) -> None:
-        cfg = _make_config(str(saved_pth), hardware="cpu")
+        cfg = _make_config(str(saved_pth), hardware="cpu", allow_unsafe_pickle=True)
 
-        model = Model(cfg)
+        with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
+            model = Model(cfg)
 
         assert isinstance(model.backend, TorchBackend)
         assert model.backend.device == torch.device("cpu")
@@ -513,9 +521,10 @@ class TestLoadModelFromPath:
     @pytest.mark.cuda
     @pytest.mark.skipif(_cuda_not_available(), reason="CUDA is not available")
     def test_torch_gpu_uses_real_cuda_backend(self, saved_pth: Path) -> None:
-        cfg = _make_config(str(saved_pth), hardware="gpu")
+        cfg = _make_config(str(saved_pth), hardware="gpu", allow_unsafe_pickle=True)
 
-        model = Model(cfg)
+        with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
+            model = Model(cfg)
 
         assert isinstance(model.backend, TorchBackend)
         assert model.backend.device.type == "cuda"


### PR DESCRIPTION
## Summary

Closes #156.

`_load_torch_module_from_path` silently fell back from `torch.load(..., weights_only=True)` to `weights_only=False` whenever the safe path raised. The unsafe fallback executes arbitrary `__reduce__` payloads embedded in the pickle, so a malicious `.pth`/`.pt` from an untrusted source (HuggingFace, paper supplements, shared artifacts) yielded RCE the moment a user pointed `model.source` at it.

This PR removes the silent fallback. The unsafe path now requires an explicit per-config opt-in: `model.allow_unsafe_pickle: true`. Without it, RAITAP raises `ValueError` and tells the user to re-save the checkpoint as a state-dict or TorchScript archive.

## Changes

- `src/raitap/configs/schema.py` — new `ModelConfig.allow_unsafe_pickle: bool = False`.
- `src/raitap/models/model.py` — refuse fallback unless opted in; raise with migration guidance.
- `docs/modules/model/configuration.md`, `docs/modules/model/own-vs-built-in.md` — document the new field and the refusal default.
- Tests:
  - Updated existing pickled-`nn.Module` load tests to opt in.
  - Added `test_pickled_module_load_refused_without_opt_in` and `test_model_refuses_pickled_module_without_opt_in` to lock in the secure default.

## Breaking change

Configs that load `torch.save(model, path)` checkpoints (full `nn.Module` pickle) now fail unless they set `model.allow_unsafe_pickle: true`. State-dict and TorchScript loads are unaffected.

## Test plan

- [x] `uv run --extra ... pytest src/raitap/models/tests/test_models.py src/raitap/models/tests/test_model_class.py` — 50 passed, 15 skipped (CUDA/MPS-gated).
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Full CI green.