### PR TITLE
feat(docs): brand color, landing logo, sidebar alignment (#159)

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,5 +1,21 @@
 :root {
   --content-font-size: 1rem;
+
+  /* RAITAP brand color (logo red) — overrides Furo's default blue. */
+  --color-brand-primary: #e15555;
+  --color-brand-content: #e15555;
+}
+
+@media (prefers-color-scheme: dark) {
+  body:not([data-theme="light"]) {
+    --color-brand-primary: #e15555;
+    --color-brand-content: #e15555;
+  }
+}
+
+body[data-theme="dark"] {
+  --color-brand-primary: #e15555;
+  --color-brand-content: #e15555;
 }
 
 .sidebar-brand-text {
@@ -94,6 +110,12 @@ h4 {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+/* Furo's default sidebar-tree ul has padding-left; zero it so the repo row
+   sits flush with the panel edge like the other sidebar items. */
+.raitap-sidebar-repo ul {
+  padding-left: 0;
 }
 
 .sd-container-fluid {

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -101,7 +101,7 @@ h4 {
   box-sizing: border-box;
   margin-top: 0;
   margin-bottom: 0;
-  padding: 1rem var(--sidebar-item-spacing-horizontal) var(--sidebar-item-spacing-vertical);
+  padding: 1rem var(--sidebar-item-spacing-horizontal) var(--sidebar-item-spacing-vertical) 0;
   border-top: 1px solid var(--color-sidebar-item-background--hover);
   background-color: var(--color-sidebar-background);
 }
@@ -114,8 +114,11 @@ h4 {
 
 /* Furo's default sidebar-tree ul has padding-left; zero it so the repo row
    sits flush with the panel edge like the other sidebar items. */
-.raitap-sidebar-repo ul {
+.raitap-sidebar-repo ul,
+.raitap-sidebar-repo li {
   padding-left: 0;
+  margin-left: 0;
+  list-style: none;
 }
 
 .sd-container-fluid {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-<p style="text-align:center; margin: 0 0 2rem;">
+<p style="margin: 0 0 2rem;">
   <img src="https://github.com/user-attachments/assets/9de86f66-f85d-47b4-9bce-7ca10bb14406" alt="RAITAP" width="400">
 </p>
 
@@ -36,10 +36,10 @@ RAITAP is a wrapper around existing XAI frameworks, which provides a consistent 
 :maxdepth: 1
 :caption: Using RAITAP
 
-using-raitap/installation
 using-raitap/get-it-running
 using-raitap/configuration/index
 using-raitap/understanding-outputs
+using-raitap/installation
 using-raitap/job-launcher
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+<p style="text-align:center; margin: 0 0 2rem;">
+  <img src="https://github.com/user-attachments/assets/9de86f66-f85d-47b4-9bce-7ca10bb14406" alt="RAITAP" width="400">
+</p>
+
 # RAITAP
 
 RAITAP is a Python library to assess the responsibility level of AI models. It is designed to be easily integrated into existing MLOps workflows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
   <img src="https://github.com/user-attachments/assets/9de86f66-f85d-47b4-9bce-7ca10bb14406" alt="RAITAP" width="400">
 </p>
 
-# RAITAP
+#
 
 RAITAP is a Python library to assess the responsibility level of AI models. It is designed to be easily integrated into existing MLOps workflows.
 

--- a/docs/using-raitap/get-it-running.md
+++ b/docs/using-raitap/get-it-running.md
@@ -1,33 +1,38 @@
 # Running a quick example
 
-This page shows how to get RAITAP running quickly, with a **simple pre-defined example**. If you want to see how to fully configure your own assessment, skip to the {doc}`configuration/index` page.
+This page explains how to install RAITAP itself, how to get RAITAP running quickly, with a **simple pre-defined example**. If you want to see how to fully configure your own assessment, skip to the {doc}`configuration/index` page.
 
-:::{note}
+It is recommended to use `uv`, but `pip` will also work.
 
-This page assumes you have **already installed RAITAP**. If you didn't, see the {doc}`installation` page.
-:::
+## 1. Install RAITAP
 
-## 1. Install dependencies
-
-Our pre-defined example uses a PyTorch model and runs both a transparency assessment (Captum) and a robustness assessment (torchattacks FGSM). Hence, we install the dependencies:
+First, you need to install the RAITAP package itself.
 
 ```{install-tabs}
 :uv:
-uv add "raitap[captum,torchattacks,reporting,torch-cpu]"
+uv add raitap
 
 :pip:
-pip install "raitap[captum,torchattacks,reporting,torch-cpu]"
+pip install raitap
 ```
 
 :::{note}
-
-The example is light enough to run on a CPU, hence we used `torch-cpu`. Feel free to **use another execution profile** (e.g. `torch-cuda`). Refer to {ref}`execution-dependencies` for more details.
+RAITAP supports Python 3.11–3.13. Python 3.14 is not yet
+supported (Hydra 1.3.2 limitation). Some underlying libs require older versions (e.g. Marabou < 3.12). RAITAP will handle the interpreter choice for you.
 :::
 
 ## 2. Run the example
 
 Our pre-defined example is the default config shipped with RAITAP. This means you do not need to specify any options to run it. It uses the
-`imagenet_samples` demo dataset (four ImageNet images bundled with ground-truth labels) so metrics and robustness run with real targets out of the box.
+`imagenet_samples` demo dataset (four ImageNet images bundled with ground-truth labels) so metrics and robustness run with real targets out of the box. It is set to use the CPU, so you might see a warning if your machine supports GPU.
+
+
+RAITAP does not ship with all the underlying dependencies by default, to avoid massive bloat. This means dependencies must be installed for each specific config. RAITAP automatically infers which ones are needed from the config. In some specific setups, you might need to take actions before the dependencies install:
+
+- If you are using `uv`, it will ask you to run the `uv add` command yourself, or add the `--allow-project-edit` flag. This is because `uv add` modifies your `pyproject.toml`.
+- If you are using `pip` and are not in a virtual environment (`venv`), it will ask to add the `--exec-global` flag. This will modify your global Python setup and is not recommended.
+
+The CLI will guide you. Run the following command:
 
 ```{install-tabs}
 :uv:
@@ -36,6 +41,8 @@ uv run raitap
 :pip:
 raitap
 ```
+
+If you wish to manually manage your dependencies, see {doc}`installation`. You can also see a preview of the inferred deps with `--dry-run`.
 
 ## 3. Inspect the output
 

--- a/docs/using-raitap/installation.md
+++ b/docs/using-raitap/installation.md
@@ -37,10 +37,10 @@ uv run raitap --config-dir my-configs --config-name assessment
 raitap --config-dir my-configs --config-name assessment
 ```
 
-Then, depending on your setup, RAITAP will either rinstall deps automatically and start the run, or ask for further action:
+Then, depending on your setup, RAITAP will either install deps automatically and start the run, or ask for further action:
 
 - If you are using `uv`, it will ask you to run the `uv add` command yourself, or add the `--allow-project-edit` flag. This is because `uv add` modifies your `pyproject.toml`.
-- If you are using `pip`and are not in a virtual environment (`venv`), it will ask to add the `--exec-global` flag. This will modify your global Pythn setup and is not recommended.
+- If you are using `pip` and are not in a virtual environment (`venv`), it will ask to add the `--exec-global` flag. This will modify your global Python setup and is not recommended.
 
 ### Flags
 

--- a/docs/using-raitap/installation.md
+++ b/docs/using-raitap/installation.md
@@ -16,6 +16,8 @@ raitap --config-dir my-configs --config-name assessment --custom-deps
 
 ## Deciding which dependencies are needed for your config
 
+(execution-dependencies)=
+
 ### Execution dependencies
 
 RAITAP supports both PyTorch and ONNX models, and both CPU and GPU

--- a/docs/using-raitap/installation.md
+++ b/docs/using-raitap/installation.md
@@ -1,68 +1,22 @@
-# Installation
+# Manual dependencies installation
 
-This page explains how to install RAITAP itself, and the deps needed to run any specific RAITAP config. It is recommended to use `uv`, but `pip` will also work.
+This page explains how to manage config dependencies manually, without the automatic mode. It is recommended to use `uv`, but `pip` will also work.
 
-## 1. Install RAITAP
+## Enabling manual mode
 
-First, you need to install the RAITAP package itself.
-
-```{install-tabs}
-:uv:
-uv add raitap
-
-:pip:
-pip install raitap
-```
-
-:::{note}
-RAITAP supports Python 3.11–3.13. Python 3.14 is not yet
-supported (Hydra 1.3.2 limitation). Some underlying libs require older versions (e.g. Marabou < 3.12). RAITAP will handle the interpreter choice for you.
-:::
-
-## 2. Run a RAITAP config
-
-RAITAP gives access to many underlying libraries (Captum, SHAP, Torchattacks...). To avoid bloat, they are not installed by default with RAITAP. Hence, the required dependencies are determined by analysing your config when you run it.
-
-### Automatic mode (default)
-
-You do not need to do anything but follow the instructions displayed in your terminal.
-
-In the example below, we assume a basic config named `assessment`. For more details, see {doc}`configuration/index`.
+Should you want to bypass the automatic deps detection and manage them yourself, you can pass the `--custom-deps` flag. RAITAP will not infer any dependencies from your config, and will not install anything. You are repsonsible for installing the necessary deps before running the config.
 
 ```{install-tabs}
 :uv:
-uv run raitap --config-dir my-configs --config-name assessment
+uv run raitap --config-dir my-configs --config-name assessment --custom-deps
 
 :pip:
-raitap --config-dir my-configs --config-name assessment
+raitap --config-dir my-configs --config-name assessment --custom-deps
 ```
 
-Then, depending on your setup, RAITAP will either install deps automatically and start the run, or ask for further action:
+## Deciding which dependencies are needed for your config
 
-- If you are using `uv`, it will ask you to run the `uv add` command yourself, or add the `--allow-project-edit` flag. This is because `uv add` modifies your `pyproject.toml`.
-- If you are using `pip` and are not in a virtual environment (`venv`), it will ask to add the `--exec-global` flag. This will modify your global Python setup and is not recommended.
-
-### Flags
-
-The following flags are supported:
-
-| Flag                    | Effect                                                                                             |
-| ----------------------- | -------------------------------------------------------------------------------------------------- |
-| `--dry-run`             | Print the inferred plan, do not install, do not run                                                |
-| `--sync-only`           | Install the inferred deps, do not run the pipeline                                                 |
-| `--allow-project-edit`  | Consent to RAITAP modifying your project's `pyproject.toml` when adding deps                       |
-| `--exec-global`         | Consent to `pip install` affecting your global Python (only used when no venv is detected)         |
-| `--custom-deps`         | Skip automatic deps inference; rely on extras you installed manually (see below)                   |
-
-(execution-dependencies)=
-
-### Manual mode
-
-Should you want to bypass the automatic deps detection and manage them yourself, you can pass the `--custom-deps` flag.
-
-The following section explain how to choose your dependencies.
-
-#### Execution dependencies
+### Execution dependencies
 
 RAITAP supports both PyTorch and ONNX models, and both CPU and GPU
 execution. To avoid conflicts, only install the dependencies that match
@@ -122,20 +76,25 @@ RAITAP and the remaining dependencies resolve normally from PyPI.
 
 (assessment-extras)=
 
-#### Assessment dependencies
+### Assessment dependencies
 
-Pick the extras that match the modules you use:
+#### Module dependencies
 
-| Module    | Extra(s)                                  |
-| --------- | ----------------------------------------- |
-| Captum    | `captum` (or umbrella `transparency`)     |
-| SHAP      | `shap` (or umbrella `transparency`)       |
-| Torchattacks / Foolbox / Marabou | `torchattacks` / `foolbox` / `marabou` (or umbrella `robustness`) |
-| Metrics   | `metrics`                                 |
-| HTML report | `jinja` (or umbrella `reporting`)       |
-| PDF report  | `borb` (or umbrella `reporting`)        |
-| MLflow    | `mlflow` (or umbrella `tracking`)         |
-| Slurm launcher | `launcher`                           |
+Each module has its corresponding dependency group. it will install ALL libraries offered by the module.
+
+```{install-tabs}
+:uv:
+uv add "raitap[transparency]"
+
+:pip:
+pip install "raitap[transparency]"
+```
+
+#### Library dependencies
+
+You can also install specific libraries. The group's name is either the name of the library (e.g. `captum`, `mlflow`) or the report file fromat (`html`, `pdf`).
+
+#### Combining in a one-liner
 
 Combine as needed:
 


### PR DESCRIPTION
## Summary
- Replaces Furo's default blue with the RAITAP logo color `#e15555` via CSS variables (`--color-brand-primary`, `--color-brand-content`) for both light and dark themes.
- Embeds the RAITAP wordmark logo at the top of `docs/index.md`.
- Fixes sidebar repository button alignment — Furo's default `<ul>` padding pushed the row inward; zeroed `padding-left` on `.raitap-sidebar-repo ul`.
- Fixes two leftover typos in `docs/using-raitap/installation.md` (`rinstall`, `Pythn`, missing space after `pip`).
- Closes #159.

## Test plan
- [x] `uv run docs-preview` renders landing page with logo on top and red links / sidebar accents.
- [x] Sidebar repo row sits flush left.
- [x] Light + dark theme both pick up brand color.