### PR TITLE
fix: validate sample_names length (#97)

### DIFF
--- a/docs/modules/robustness/configuration.md
+++ b/docs/modules/robustness/configuration.md
@@ -73,7 +73,10 @@ myst:
 :default: null
 :description: Optional per-sample names for downstream visualisers. Injected at
   runtime from the data pipeline. Runtime sample names take precedence over
-  `raitap.sample_names` from config.
+  `raitap.sample_names` from config. The list length must equal the number
+  of input samples `N`; a mismatch raises
+  `raitap.utils.errors.SampleNamesLengthError` at factory entry. Omit
+  `sample_names` to fall back to auto-derived sample ids from the data loader.
 
 :option: raitap.show_sample_names
 :allowed: bool

--- a/docs/modules/transparency/configuration.md
+++ b/docs/modules/transparency/configuration.md
@@ -81,6 +81,10 @@ myst:
 :description: Optional per-sample names for downstream visualisers. This can be
   injected at runtime from the data pipeline. If runtime sample names
   are provided, they take precedence over `raitap.sample_names` from config.
+  The list length must equal the number of input samples `N`; a mismatch
+  raises `raitap.utils.errors.SampleNamesLengthError` at factory entry.
+  Omit `sample_names` to fall back to auto-derived sample ids from the
+  data loader.
 
 :option: raitap.show_sample_names
 :allowed: bool

--- a/docs/modules/transparency/frameworks-and-libraries.md
+++ b/docs/modules/transparency/frameworks-and-libraries.md
@@ -247,7 +247,10 @@ name for YAML compatibility.
 Override these via the visualiser `call` key or at runtime:
 
 `sample_names` usually comes from the explainer's `raitap.sample_names` metadata, but
-you can still override it directly on the visualiser call when needed.
+you can still override it directly on the visualiser call when needed. When set, the
+list length must equal the number of input samples `N`; a mismatch raises
+`raitap.utils.errors.SampleNamesLengthError` at factory entry. Omit `sample_names`
+to fall back to auto-derived sample ids from the data loader.
 `show_sample_names` follows the same pattern: set the shared default under
 `raitap.show_sample_names` on the explainer, then override it per visualiser
 via `visualisers[].call.show_sample_names` when one renderer should behave

--- a/src/raitap/robustness/factory.py
+++ b/src/raitap/robustness/factory.py
@@ -17,6 +17,7 @@ from raitap.configs.adapter_factory import (
     resolve_call_data_sources,
 )
 from raitap.models.backend import ModelBackend
+from raitap.utils.errors import SampleNamesLengthError
 
 from .contracts import AssessorAdapter
 from .exceptions import MethodKindVisualiserIncompatibilityError, MissingTargetsError
@@ -137,6 +138,17 @@ class RobustnessAssessment:
                 raitap_cfg["sample_ids"] = sample_ids
             if input_metadata is not None:
                 raitap_cfg["input_metadata"] = input_metadata
+
+            resolved_sample_names = raitap_cfg.get("sample_names")
+            if resolved_sample_names is not None:
+                resolved_list = list(resolved_sample_names)
+                if resolved_list and len(resolved_list) != int(inputs.shape[0]):
+                    source = "runtime kwarg" if sample_names is not None else "raitap.sample_names"
+                    raise SampleNamesLengthError(
+                        got=len(resolved_list),
+                        expected=int(inputs.shape[0]),
+                        source=source,
+                    )
 
             merged_kwargs = resolve_call_data_sources(
                 {**call_from_config, **kwargs}, log_label="robustness call"

--- a/src/raitap/robustness/results.py
+++ b/src/raitap/robustness/results.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 import torch
 
 from raitap.tracking.base_tracker import BaseTracker, Trackable
+from raitap.utils.errors import SampleNamesLengthError
 from raitap.utils.serialization import to_json_serialisable
 
 from .contracts import (
@@ -285,7 +286,12 @@ class RobustnessResult(Trackable):
             sample_names = _normalise_sample_names(sample_names_value)
 
             limit = int(self.clean_inputs.shape[0])
-            sample_names = sample_names[:limit]
+            if sample_names and len(sample_names) != limit:
+                raise SampleNamesLengthError(
+                    got=len(sample_names),
+                    expected=limit,
+                    source="RobustnessResult.visualise",
+                )
 
             context = RobustnessVisualisationContext(
                 algorithm=self.algorithm,
@@ -360,7 +366,12 @@ class RobustnessResult(Trackable):
 
         if sample_index is None:
             result_for_render = self
-            sample_names = sample_names[:batch_size]
+            if sample_names and len(sample_names) != batch_size:
+                raise SampleNamesLengthError(
+                    got=len(sample_names),
+                    expected=batch_size,
+                    source="RobustnessResult.render",
+                )
         else:
             result_for_render = RobustnessResult(
                 clean_inputs=_slice_sample_tensor(self.clean_inputs, sample_index),
@@ -400,7 +411,13 @@ class RobustnessResult(Trackable):
                 ),
                 semantics=self.semantics,
             )
-            sample_names = [sample_names[sample_index]] if sample_index < len(sample_names) else []
+            if sample_names and len(sample_names) != batch_size:
+                raise SampleNamesLengthError(
+                    got=len(sample_names),
+                    expected=batch_size,
+                    source="RobustnessResult.render",
+                )
+            sample_names = [sample_names[sample_index]] if sample_names else []
 
         context = RobustnessVisualisationContext(
             algorithm=self.algorithm,

--- a/src/raitap/robustness/results.py
+++ b/src/raitap/robustness/results.py
@@ -364,14 +364,15 @@ class RobustnessResult(Trackable):
         sample_names_value = merged_call.pop("sample_names", self.kwargs.get("sample_names"))
         sample_names = _normalise_sample_names(sample_names_value)
 
+        if sample_names and len(sample_names) != batch_size:
+            raise SampleNamesLengthError(
+                got=len(sample_names),
+                expected=batch_size,
+                source="RobustnessResult.render",
+            )
+
         if sample_index is None:
             result_for_render = self
-            if sample_names and len(sample_names) != batch_size:
-                raise SampleNamesLengthError(
-                    got=len(sample_names),
-                    expected=batch_size,
-                    source="RobustnessResult.render",
-                )
         else:
             result_for_render = RobustnessResult(
                 clean_inputs=_slice_sample_tensor(self.clean_inputs, sample_index),
@@ -411,12 +412,6 @@ class RobustnessResult(Trackable):
                 ),
                 semantics=self.semantics,
             )
-            if sample_names and len(sample_names) != batch_size:
-                raise SampleNamesLengthError(
-                    got=len(sample_names),
-                    expected=batch_size,
-                    source="RobustnessResult.render",
-                )
             sample_names = [sample_names[sample_index]] if sample_names else []
 
         context = RobustnessVisualisationContext(

--- a/src/raitap/robustness/tests/test_factory.py
+++ b/src/raitap/robustness/tests/test_factory.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import torch
+from omegaconf import OmegaConf
 
 from raitap.robustness.assessors import TorchattacksAssessor
 from raitap.robustness.contracts import MethodKind
 from raitap.robustness.exceptions import MethodKindVisualiserIncompatibilityError
 from raitap.robustness.factory import (
+    RobustnessAssessment,
     _parse_assessor_config,
     _resolve_call_data_sources,
     check_assessor_visualiser_compat,
 )
 from raitap.robustness.results import ConfiguredRobustnessVisualiser
 from raitap.robustness.visualisers.base_visualiser import BaseRobustnessVisualiser
+from raitap.utils.errors import SampleNamesLengthError
 
 
 class _OnlyFormalVisualiser(BaseRobustnessVisualiser):
@@ -62,3 +67,185 @@ def test_check_visualiser_compat_raises_on_method_kind_mismatch() -> None:
             "raitap.robustness.assessors.TorchattacksAssessor",
             configured,
         )
+
+
+# ---------------------------------------------------------------------------
+# Helpers for sample_names validation tests (C1 / C2)
+# ---------------------------------------------------------------------------
+
+
+from raitap.models.backend import ModelBackend  # noqa: E402
+
+
+class _BackendStub(ModelBackend):
+    """Minimal ModelBackend stub — passes isinstance check in _require_model_backend."""
+
+    supports_torch_autograd = True
+
+    @property
+    def hardware_label(self) -> str:
+        return "stub"
+
+    def _prepare_inputs(self, inputs: torch.Tensor) -> torch.Tensor:
+        return inputs
+
+    def _prepare_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        return kwargs
+
+    def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def as_model_for_explanation(self) -> torch.nn.Module:
+        raise NotImplementedError
+
+
+def _make_model_stub() -> Any:
+    """Return an object whose .backend satisfies _require_model_backend."""
+    return SimpleNamespace(backend=_BackendStub())
+
+
+def _make_minimal_config(*, visualisers: list[Any] | None = None, tmp_path: Any = None) -> Any:
+    """Build a minimal AppConfig-like namespace for PGD with no visualisers."""
+    return SimpleNamespace(
+        experiment_name="test_sample_names",
+        _output_root=str(tmp_path) if tmp_path else "/tmp",
+        transparency={},
+        robustness={
+            "pgd": OmegaConf.create(
+                {
+                    "_target_": "raitap.robustness.TorchattacksAssessor",
+                    "algorithm": "PGD",
+                    "constructor": {"eps": 0.03, "alpha": 0.01, "steps": 1},
+                    "call": {},
+                    "visualisers": visualisers or [],
+                }
+            )
+        },
+    )
+
+
+def _make_yaml_names_config(*, sample_names: list[str], tmp_path: Any = None) -> Any:
+    """Build a config whose raitap.sample_names is set in the config (YAML source)."""
+    return SimpleNamespace(
+        experiment_name="test_yaml_sample_names",
+        _output_root=str(tmp_path) if tmp_path else "/tmp",
+        transparency={},
+        robustness={
+            "pgd": OmegaConf.create(
+                {
+                    "_target_": "raitap.robustness.TorchattacksAssessor",
+                    "algorithm": "PGD",
+                    "constructor": {"eps": 0.03, "alpha": 0.01, "steps": 1},
+                    "call": {},
+                    "raitap": {"sample_names": sample_names},
+                    "visualisers": [],
+                }
+            )
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# C1 / C2 factory sample_names validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_robustness_raises_when_runtime_sample_names_longer_than_batch(
+    tmp_path: Any,
+) -> None:
+    config = _make_minimal_config(tmp_path=tmp_path)
+    model = _make_model_stub()
+    inputs = torch.zeros(2, 3, 8, 8)
+    targets = torch.zeros(2, dtype=torch.long)
+    with pytest.raises(SampleNamesLengthError) as info:
+        RobustnessAssessment(
+            config,
+            "pgd",
+            model,
+            inputs,
+            targets,
+            sample_names=["a", "b", "c"],
+        )
+    assert info.value.got == 3
+    assert info.value.expected == 2
+    assert "runtime kwarg" in str(info.value)
+
+
+def test_robustness_raises_when_runtime_sample_names_shorter_than_batch(
+    tmp_path: Any,
+) -> None:
+    config = _make_minimal_config(tmp_path=tmp_path)
+    model = _make_model_stub()
+    inputs = torch.zeros(3, 3, 8, 8)
+    targets = torch.zeros(3, dtype=torch.long)
+    with pytest.raises(SampleNamesLengthError):
+        RobustnessAssessment(
+            config,
+            "pgd",
+            model,
+            inputs,
+            targets,
+            sample_names=["only-one"],
+        )
+
+
+def test_robustness_raises_when_yaml_sample_names_mismatch(
+    tmp_path: Any,
+) -> None:
+    config = _make_yaml_names_config(sample_names=["x", "y"], tmp_path=tmp_path)
+    model = _make_model_stub()
+    inputs = torch.zeros(3, 3, 8, 8)
+    targets = torch.zeros(3, dtype=torch.long)
+    with pytest.raises(SampleNamesLengthError) as info:
+        RobustnessAssessment(
+            config,
+            "pgd",
+            model,
+            inputs,
+            targets,
+        )
+    assert "raitap.sample_names" in str(info.value)
+
+
+def test_robustness_does_not_raise_when_sample_names_is_none(
+    tmp_path: Any,
+) -> None:
+    config = _make_minimal_config(tmp_path=tmp_path)
+    model = _make_model_stub()
+    inputs = torch.zeros(2, 3, 8, 8)
+    targets = torch.zeros(2, dtype=torch.long)
+    try:
+        RobustnessAssessment(
+            config,
+            "pgd",
+            model,
+            inputs,
+            targets,
+            sample_names=None,
+        )
+    except SampleNamesLengthError:
+        pytest.fail("SampleNamesLengthError raised unexpectedly for sample_names=None")
+    except Exception:
+        pass  # other errors (e.g. from assessor) are out of scope
+
+
+def test_robustness_does_not_raise_when_sample_names_length_matches(
+    tmp_path: Any,
+) -> None:
+    config = _make_minimal_config(tmp_path=tmp_path)
+    model = _make_model_stub()
+    inputs = torch.zeros(2, 3, 8, 8)
+    targets = torch.zeros(2, dtype=torch.long)
+    try:
+        RobustnessAssessment(
+            config,
+            "pgd",
+            model,
+            inputs,
+            targets,
+            sample_names=["a", "b"],
+        )
+    except SampleNamesLengthError:
+        pytest.fail("SampleNamesLengthError raised unexpectedly for matching sample_names")
+    except Exception:
+        pass  # other errors (e.g. from assessor) are out of scope

--- a/src/raitap/robustness/tests/test_results.py
+++ b/src/raitap/robustness/tests/test_results.py
@@ -241,3 +241,78 @@ def test_visualise_does_not_swallow_visualiser_errors(tmp_path: Path) -> None:
 
     assert result.visualiser_targets == []
     assert not any(result.run_dir.glob("*.png"))
+
+
+# ---------------------------------------------------------------------------
+# C3 / C4 — RobustnessResult sample_names length-validation tests
+# ---------------------------------------------------------------------------
+
+
+def _result_with_sample_names(
+    tmp_path: Path,
+    *,
+    batch: int,
+    sample_names: list[str] | None,
+) -> RobustnessResult:
+    """Build a RobustnessResult with a recording visualiser and the given sample_names."""
+    inputs = torch.zeros(batch, 3, 4, 4)
+    result = RobustnessResult(
+        clean_inputs=inputs,
+        targets=torch.zeros(batch, dtype=torch.long),
+        clean_predictions=torch.zeros(batch, dtype=torch.long),
+        verdicts=encode_verdicts([RobustnessVerdict.NOT_ATTACKED] * batch),
+        metrics=_empirical_metrics(),
+        run_dir=tmp_path / "robustness/pgd",
+        experiment_name="test_sample_names",
+        assessor_target="raitap.robustness.assessors.TorchattacksAssessor",
+        algorithm="PGD",
+        assessor_name="pgd",
+        semantics=_semantics_for_test(),
+    )
+    result.kwargs["sample_names"] = sample_names
+    result.visualisers = [
+        ConfiguredRobustnessVisualiser(visualiser=_RecordingRobustnessVisualiser())
+    ]
+    return result
+
+
+def test_robustness_visualise_raises_on_mismatched_sample_names(tmp_path: Path) -> None:
+    result = _result_with_sample_names(tmp_path, batch=2, sample_names=["a", "b", "c"])
+    from raitap.utils.errors import SampleNamesLengthError
+
+    with pytest.raises(SampleNamesLengthError) as info:
+        result.visualise()
+    assert info.value.got == 3
+    assert info.value.expected == 2
+
+
+def test_robustness_render_raises_on_mismatched_sample_names(tmp_path: Path) -> None:
+    result = _result_with_sample_names(tmp_path, batch=2, sample_names=["a", "b", "c"])
+    from raitap.utils.errors import SampleNamesLengthError
+
+    with pytest.raises(SampleNamesLengthError):
+        result.render_visualisation_for_report(0)  # full-batch path (sample_index=None)
+
+
+def test_robustness_render_per_sample_raises_on_mismatched_sample_names(tmp_path: Path) -> None:
+    # batch=3, sample_names length=2 → mismatch should raise even on valid sample_index.
+    result = _result_with_sample_names(tmp_path, batch=3, sample_names=["a", "b"])
+    from raitap.utils.errors import SampleNamesLengthError
+
+    with pytest.raises(SampleNamesLengthError):
+        result.render_visualisation_for_report(0, sample_index=2)
+
+
+def test_robustness_visualise_passes_with_matching_sample_names(tmp_path: Path) -> None:
+    result = _result_with_sample_names(tmp_path, batch=2, sample_names=["a", "b"])
+    # Must not raise; close the figure to avoid resource leak.
+    vis_results = result.visualise()
+    for vr in vis_results:
+        plt.close(vr.figure)
+
+
+def test_robustness_visualise_passes_with_none_sample_names(tmp_path: Path) -> None:
+    result = _result_with_sample_names(tmp_path, batch=2, sample_names=None)
+    vis_results = result.visualise()
+    for vr in vis_results:
+        plt.close(vr.figure)

--- a/src/raitap/transparency/factory.py
+++ b/src/raitap/transparency/factory.py
@@ -17,6 +17,7 @@ from raitap.configs.adapter_factory import (
     resolve_call_data_sources,
 )
 from raitap.models.backend import ModelBackend
+from raitap.utils.errors import SampleNamesLengthError
 
 from .algorithm_allowlist import ensure_algorithm_in_allowlist
 from .contracts import (
@@ -197,6 +198,17 @@ class Explanation:
                 raitap_cfg["sample_ids"] = sample_ids
             if input_metadata is not None:
                 raitap_cfg["input_metadata"] = input_metadata
+
+            resolved_sample_names = raitap_cfg.get("sample_names")
+            if resolved_sample_names is not None:
+                resolved_list = list(resolved_sample_names)
+                if resolved_list and len(resolved_list) != int(inputs.shape[0]):
+                    source = "runtime kwarg" if sample_names is not None else "raitap.sample_names"
+                    raise SampleNamesLengthError(
+                        got=len(resolved_list),
+                        expected=int(inputs.shape[0]),
+                        source=source,
+                    )
 
             merged_kwargs = resolve_call_data_sources(
                 {**call_from_config, **kwargs}, log_label="call"

--- a/src/raitap/transparency/results.py
+++ b/src/raitap/transparency/results.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 import torch
 
 from raitap.tracking.base_tracker import BaseTracker, Trackable
+from raitap.utils.errors import SampleNamesLengthError
 from raitap.utils.serialization import to_json_serialisable
 
 from .contracts import (
@@ -199,8 +200,12 @@ class ExplanationResult(Trackable):
             sample_names = _normalise_sample_names(sample_names_value)
 
             limit = _batch_size(attributions) or _batch_size(inputs)
-            if limit is not None:
-                sample_names = sample_names[:limit]
+            if sample_names and limit is not None and len(sample_names) != limit:
+                raise SampleNamesLengthError(
+                    got=len(sample_names),
+                    expected=limit,
+                    source="ExplanationResult.visualise",
+                )
 
             # Standard RAITAP pipeline metadata
             context = VisualisationContext(
@@ -324,15 +329,18 @@ class ExplanationResult(Trackable):
         sample_names_value = merged_call.pop("sample_names", self.kwargs.get("sample_names"))
         sample_names = _normalise_sample_names(sample_names_value)
 
+        batch_size = _batch_size(attributions) or _batch_size(inputs)
+        if sample_names and batch_size is not None and len(sample_names) != batch_size:
+            raise SampleNamesLengthError(
+                got=len(sample_names),
+                expected=batch_size,
+                source="ExplanationResult.render_visualisation_for_scope",
+            )
         if sample_index is not None:
             attributions = attributions[sample_index : sample_index + 1]
             inputs = inputs[sample_index : sample_index + 1]
             if sample_names:
                 sample_names = sample_names[sample_index : sample_index + 1]
-        else:
-            limit = _batch_size(attributions) or _batch_size(inputs)
-            if limit is not None:
-                sample_names = sample_names[:limit]
 
         context = VisualisationContext(
             algorithm=self.algorithm,

--- a/src/raitap/transparency/tests/test_factory.py
+++ b/src/raitap/transparency/tests/test_factory.py
@@ -31,6 +31,7 @@ from raitap.transparency.factory import (
 )
 from raitap.transparency.results import ConfiguredVisualiser, ExplanationResult
 from raitap.transparency.visualisers.base_visualiser import BaseVisualiser
+from raitap.utils.errors import SampleNamesLengthError
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -354,12 +355,22 @@ def test_explanation_passes_sample_ids_display_names_and_input_metadata(
         model=model,  # type: ignore[arg-type]
         inputs=sample_images,
         input_metadata={"kind": "image", "shape": sample_images.shape, "layout": "NCHW"},
-        sample_ids=["stable-1", "stable-2"],
-        sample_names=["Display 1", "Display 2"],
+        sample_ids=["stable-1", "stable-2", "stable-3", "stable-4"],
+        sample_names=["Display 1", "Display 2", "Display 3", "Display 4"],
     )
 
-    assert explainer.last_raitap_kwargs["sample_ids"] == ["stable-1", "stable-2"]
-    assert explainer.last_raitap_kwargs["sample_names"] == ["Display 1", "Display 2"]
+    assert explainer.last_raitap_kwargs["sample_ids"] == [
+        "stable-1",
+        "stable-2",
+        "stable-3",
+        "stable-4",
+    ]
+    assert explainer.last_raitap_kwargs["sample_names"] == [
+        "Display 1",
+        "Display 2",
+        "Display 3",
+        "Display 4",
+    ]
     assert explainer.last_raitap_kwargs["input_metadata"]["kind"] == "image"
     assert explainer.last_raitap_kwargs["input_metadata"]["layout"] == "NCHW"
     assert explainer.last_raitap_kwargs["show_sample_names"] is True
@@ -1037,12 +1048,12 @@ def test_explanation_runtime_sample_names_override_raitap_config(
             "test_explainer",
             model=model,  # type: ignore[arg-type]
             inputs=sample_images,
-            sample_names=["from_runtime_1", "from_runtime_2"],
+            sample_names=["from_runtime_1", "from_runtime_2", "from_runtime_3", "from_runtime_4"],
         )
 
     assert explainer.last_explain_kwargs["raitap_kwargs"] == {
         "show_sample_names": True,
-        "sample_names": ["from_runtime_1", "from_runtime_2"],
+        "sample_names": ["from_runtime_1", "from_runtime_2", "from_runtime_3", "from_runtime_4"],
     }
     assert "override raitap.sample_names from config" in caplog.text
 
@@ -1112,7 +1123,7 @@ def test_explanation_warns_once_on_misplaced_raitap_call_keys(
             {
                 "_target_": "raitap.transparency.CaptumExplainer",
                 "algorithm": "Saliency",
-                "call": {"sample_names": ["cfg_a", "cfg_b"]},
+                "call": {"sample_names": ["cfg_a", "cfg_b", "cfg_c", "cfg_d"]},
                 "visualisers": [],
             }
         ),
@@ -1572,3 +1583,191 @@ class TestResolveCallDataSources:
         bg_tensor = explainer.last_explain_kwargs["background_data"]
         assert isinstance(bg_tensor, torch.Tensor)
         assert bg_tensor.shape[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# sample_names length validation — Task B1
+# ---------------------------------------------------------------------------
+
+
+def _make_stub_explainer() -> Any:
+    class _StubExplainer:
+        algorithm = "Saliency"
+
+        def check_backend_compat(self, backend: object) -> None:
+            del backend
+
+        def explain(self, *_args: Any, **_kwargs: Any) -> ExplanationResult:
+            return MagicMock(spec=ExplanationResult)
+
+    return _StubExplainer()
+
+
+def test_explanation_raises_when_runtime_sample_names_longer_than_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    stub = _make_stub_explainer()
+    config = _make_config(
+        tmp_path,
+        OmegaConf.create(
+            {
+                "_target_": "raitap.transparency.CaptumExplainer",
+                "algorithm": "Saliency",
+                "visualisers": [],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "raitap.transparency.factory.create_explainer",
+        lambda _cfg: (stub, "raitap.transparency.CaptumExplainer"),
+    )
+    monkeypatch.setattr("raitap.transparency.factory.create_visualisers", lambda _cfg: [])
+
+    inputs = torch.zeros(2, 3, 8, 8)
+    model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
+    with pytest.raises(SampleNamesLengthError) as info:
+        Explanation(
+            config,
+            "test_explainer",
+            model=model,  # type: ignore[arg-type]
+            inputs=inputs,
+            sample_names=["a", "b", "c"],
+        )
+    assert info.value.got == 3
+    assert info.value.expected == 2
+    assert "runtime kwarg" in str(info.value)
+
+
+def test_explanation_raises_when_runtime_sample_names_shorter_than_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    stub = _make_stub_explainer()
+    config = _make_config(
+        tmp_path,
+        OmegaConf.create(
+            {
+                "_target_": "raitap.transparency.CaptumExplainer",
+                "algorithm": "Saliency",
+                "visualisers": [],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "raitap.transparency.factory.create_explainer",
+        lambda _cfg: (stub, "raitap.transparency.CaptumExplainer"),
+    )
+    monkeypatch.setattr("raitap.transparency.factory.create_visualisers", lambda _cfg: [])
+
+    inputs = torch.zeros(3, 3, 8, 8)
+    model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
+    with pytest.raises(SampleNamesLengthError):
+        Explanation(
+            config,
+            "test_explainer",
+            model=model,  # type: ignore[arg-type]
+            inputs=inputs,
+            sample_names=["only-one"],
+        )
+
+
+def test_explanation_raises_when_yaml_sample_names_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """YAML raitap.sample_names = ['x', 'y'] but inputs have 3 samples — no runtime kwarg."""
+    stub = _make_stub_explainer()
+    config = _make_config(
+        tmp_path,
+        OmegaConf.create(
+            {
+                "_target_": "raitap.transparency.CaptumExplainer",
+                "algorithm": "Saliency",
+                "raitap": {"sample_names": ["x", "y"]},
+                "visualisers": [],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "raitap.transparency.factory.create_explainer",
+        lambda _cfg: (stub, "raitap.transparency.CaptumExplainer"),
+    )
+    monkeypatch.setattr("raitap.transparency.factory.create_visualisers", lambda _cfg: [])
+
+    inputs = torch.zeros(3, 3, 8, 8)
+    model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
+    with pytest.raises(SampleNamesLengthError) as info:
+        Explanation(
+            config,
+            "test_explainer",
+            model=model,  # type: ignore[arg-type]
+            inputs=inputs,
+        )
+    assert "raitap.sample_names" in str(info.value)
+
+
+def test_explanation_does_not_raise_when_sample_names_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    stub = _make_stub_explainer()
+    config = _make_config(
+        tmp_path,
+        OmegaConf.create(
+            {
+                "_target_": "raitap.transparency.CaptumExplainer",
+                "algorithm": "Saliency",
+                "visualisers": [],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "raitap.transparency.factory.create_explainer",
+        lambda _cfg: (stub, "raitap.transparency.CaptumExplainer"),
+    )
+    monkeypatch.setattr("raitap.transparency.factory.create_visualisers", lambda _cfg: [])
+
+    inputs = torch.zeros(2, 3, 8, 8)
+    model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
+    # Should not raise SampleNamesLengthError.
+    Explanation(
+        config,
+        "test_explainer",
+        model=model,  # type: ignore[arg-type]
+        inputs=inputs,
+        sample_names=None,
+    )
+
+
+def test_explanation_does_not_raise_when_sample_names_length_matches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    stub = _make_stub_explainer()
+    config = _make_config(
+        tmp_path,
+        OmegaConf.create(
+            {
+                "_target_": "raitap.transparency.CaptumExplainer",
+                "algorithm": "Saliency",
+                "visualisers": [],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "raitap.transparency.factory.create_explainer",
+        lambda _cfg: (stub, "raitap.transparency.CaptumExplainer"),
+    )
+    monkeypatch.setattr("raitap.transparency.factory.create_visualisers", lambda _cfg: [])
+
+    inputs = torch.zeros(2, 3, 8, 8)
+    model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
+    # Should not raise.
+    Explanation(
+        config,
+        "test_explainer",
+        model=model,  # type: ignore[arg-type]
+        inputs=inputs,
+        sample_names=["a", "b"],
+    )

--- a/src/raitap/transparency/tests/test_results.py
+++ b/src/raitap/transparency/tests/test_results.py
@@ -32,6 +32,7 @@ from raitap.transparency.results import (
 )
 from raitap.transparency.visualisers import ShapImageVisualiser
 from raitap.transparency.visualisers.base_visualiser import BaseVisualiser
+from raitap.utils.errors import SampleNamesLengthError
 
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
@@ -466,30 +467,9 @@ def test_explanation_visualise_uses_explainer_level_show_sample_names_default(
     assert vis.last_sample_names == ["ISIC_1", "ISIC_2"]
 
 
-def test_explanation_visualise_trims_sample_names_for_shorter_batch(tmp_path: Path) -> None:
-    class _SampleNameVisualiser(BaseVisualiser):
-        def __init__(self) -> None:
-            self.received_names: list[str] = []
-
-        def visualise(
-            self,
-            attributions: torch.Tensor,
-            inputs: torch.Tensor | None = None,
-            *,
-            context: VisualisationContext | None = None,
-            **kw: Any,
-        ) -> Figure:
-            del attributions, inputs, kw
-            sample_names = context.sample_names if context is not None else None
-            show_sample_names = context.show_sample_names if context is not None else False
-            self.received_names = [] if sample_names is None else list(sample_names)
-            fig, _ax = plt.subplots(figsize=(1, 1))
-            if show_sample_names and self.received_names:
-                fig.suptitle(self.received_names[0])
-            return fig
-
+def test_explanation_visualise_raises_when_sample_names_longer_than_batch(tmp_path: Path) -> None:
+    """Providing more sample_names than batch samples raises SampleNamesLengthError."""
     run_dir = tmp_path / "exp_trim_names"
-    vis = _SampleNameVisualiser()
     explanation = ExplanationResult(
         attributions=torch.randn(1, 3, 4, 4),
         inputs=torch.randn(1, 3, 4, 4),
@@ -500,7 +480,7 @@ def test_explanation_visualise_trims_sample_names_for_shorter_batch(tmp_path: Pa
         semantics=_semantics(),
         visualisers=[
             ConfiguredVisualiser(
-                visualiser=vis,
+                visualiser=MagicMock(spec=BaseVisualiser),
                 call_kwargs={"show_sample_names": True},
             )
         ],
@@ -508,9 +488,10 @@ def test_explanation_visualise_trims_sample_names_for_shorter_batch(tmp_path: Pa
     )
     explanation.write_artifacts()
 
-    explanation.visualise()
-
-    assert vis.received_names == ["ISIC_1"]
+    with pytest.raises(SampleNamesLengthError) as info:
+        explanation.visualise()
+    assert info.value.got == 3
+    assert info.value.expected == 1
 
 
 def test_report_visualisation_resets_visualiser_sample_index_for_sliced_batch(
@@ -791,3 +772,119 @@ def test_explanation_visualise_forwards_algorithm_to_shap_subclasses(tmp_path: P
 
     titles = [ax.get_title() for ax in result.figure.axes if ax.get_title()]
     assert titles == ["Original Image", "DeepExplainer (SHAP)"]
+
+
+# ---------------------------------------------------------------------------
+# sample_names length validation — Task B3
+# ---------------------------------------------------------------------------
+
+
+def test_explanation_result_visualise_raises_on_mismatched_sample_names(tmp_path: Path) -> None:
+    """visualise() raises SampleNamesLengthError when sample_names count != batch size."""
+    run_dir = tmp_path / "exp_mismatch"
+    explanation = ExplanationResult(
+        attributions=torch.randn(2, 3, 4, 4),
+        inputs=torch.randn(2, 3, 4, 4),
+        run_dir=run_dir,
+        experiment_name="e",
+        explainer_target="t",
+        algorithm="a",
+        semantics=_semantics(),
+        visualisers=[
+            ConfiguredVisualiser(
+                visualiser=MagicMock(spec=BaseVisualiser),
+                call_kwargs={},
+            )
+        ],
+        kwargs={"sample_names": ["a", "b", "c"]},
+    )
+    explanation.write_artifacts()
+
+    with pytest.raises(SampleNamesLengthError) as info:
+        explanation.visualise()
+    assert info.value.got == 3
+    assert info.value.expected == 2
+
+
+def test_explanation_result_visualise_passes_with_matching_sample_names(tmp_path: Path) -> None:
+    """visualise() does not raise when sample_names length matches batch size."""
+    run_dir = tmp_path / "exp_match"
+    explanation = ExplanationResult(
+        attributions=torch.randn(2, 3, 4, 4),
+        inputs=torch.randn(2, 3, 4, 4),
+        run_dir=run_dir,
+        experiment_name="e",
+        explainer_target="t",
+        algorithm="a",
+        semantics=_semantics(),
+        visualisers=[
+            ConfiguredVisualiser(
+                visualiser=MagicMock(spec=BaseVisualiser),
+                call_kwargs={},
+            )
+        ],
+        kwargs={"sample_names": ["a", "b"]},
+    )
+    explanation.write_artifacts()
+    # Should not raise.
+    explanation.visualise()
+
+
+def test_explanation_result_visualise_passes_with_none_sample_names(tmp_path: Path) -> None:
+    """visualise() does not raise when sample_names is None."""
+    run_dir = tmp_path / "exp_none_names"
+    explanation = ExplanationResult(
+        attributions=torch.randn(2, 3, 4, 4),
+        inputs=torch.randn(2, 3, 4, 4),
+        run_dir=run_dir,
+        experiment_name="e",
+        explainer_target="t",
+        algorithm="a",
+        semantics=_semantics(),
+        visualisers=[
+            ConfiguredVisualiser(
+                visualiser=MagicMock(spec=BaseVisualiser),
+                call_kwargs={},
+            )
+        ],
+        kwargs={},
+    )
+    explanation.write_artifacts()
+    # Should not raise.
+    explanation.visualise()
+
+
+def test_render_visualisation_for_scope_raises_on_mismatched_sample_names(
+    tmp_path: Path,
+) -> None:
+    class _StubVisualiser(BaseVisualiser):
+        def visualise(
+            self,
+            attributions: torch.Tensor,
+            inputs: torch.Tensor | None = None,
+            *,
+            context: VisualisationContext | None = None,
+            **kw: Any,
+        ) -> Figure:
+            del inputs, context, kw
+            fig, _ax = plt.subplots(figsize=(1, 1))
+            return fig
+
+    explanation = ExplanationResult(
+        attributions=torch.zeros(2, 3, 4, 4),
+        inputs=torch.zeros(2, 3, 4, 4),
+        run_dir=tmp_path / "exp_render_mismatch",
+        experiment_name="e",
+        explainer_target="t",
+        algorithm="a",
+        semantics=_semantics(),
+        kwargs={"sample_names": ["a", "b", "c"], "show_sample_names": True},
+        visualisers=[
+            ConfiguredVisualiser(visualiser=_StubVisualiser(), call_kwargs={}),
+        ],
+    )
+
+    with pytest.raises(SampleNamesLengthError) as info:
+        explanation.render_visualisation_for_scope(0, scope="local")
+    assert info.value.got == 3
+    assert info.value.expected == 2

--- a/src/raitap/utils/errors.py
+++ b/src/raitap/utils/errors.py
@@ -94,6 +94,27 @@ class ModelInputShapeError(RaitapError):
         super().__init__(message, diagnostic=diagnostic)
 
 
+class SampleNamesLengthError(RaitapError):
+    """Raised when ``raitap.sample_names`` length does not match batch size N.
+
+    Surfaces at factory entry (``Explanation`` / ``RobustnessAssessment``) and
+    as a defensive check in ``ExplanationResult`` / ``RobustnessResult``
+    visualisation paths. ``None`` / empty lists are not errors (they mean
+    "no labels"); only length mismatch raises.
+    """
+
+    def __init__(self, *, got: int, expected: int, source: str) -> None:
+        self.got = got
+        self.expected = expected
+        message = (
+            f"`raitap.sample_names` length mismatch: got {got} name(s), "
+            f"expected {expected} (one per input sample). Source: {source}. "
+            f"Either supply a list of length {expected} or omit "
+            f"`sample_names` to use auto-derived sample ids."
+        )
+        super().__init__(message)
+
+
 def resolve_diagnostic_from_traceback(
     tb: TracebackType | None,
     *,
@@ -212,6 +233,7 @@ __all__ = [
     "AdapterError",
     "ModelInputShapeError",
     "RaitapError",
+    "SampleNamesLengthError",
     "resolve_diagnostic_from_traceback",
     "rethrow",
 ]

--- a/src/raitap/utils/tests/test_errors_sample_names.py
+++ b/src/raitap/utils/tests/test_errors_sample_names.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from raitap.utils.errors import RaitapError, SampleNamesLengthError
+
+
+def test_subclass_of_raitap_error() -> None:
+    assert issubclass(SampleNamesLengthError, RaitapError)
+
+
+def test_message_includes_counts_and_source() -> None:
+    exc = SampleNamesLengthError(got=3, expected=2, source="runtime kwarg")
+    msg = str(exc)
+    assert "3" in msg
+    assert "2" in msg
+    assert "runtime kwarg" in msg
+    assert "sample_names" in msg
+
+
+def test_attributes_set() -> None:
+    exc = SampleNamesLengthError(got=5, expected=4, source="raitap.sample_names")
+    assert exc.got == 5
+    assert exc.expected == 4
+
+
+def test_raises_as_expected() -> None:
+    with pytest.raises(SampleNamesLengthError):
+        raise SampleNamesLengthError(got=1, expected=2, source="x")


### PR DESCRIPTION
## Summary

Closes #97.

`raitap.sample_names` (user-supplied per-row labels) was silently truncated when its length did not match the input batch size `N` — mislabelled visualisations with no error or warning. This change replaces silent truncation with a fail-fast `SampleNamesLengthError`.

## Changes

- New `raitap.utils.errors.SampleNamesLengthError(RaitapError)` with `(got, expected, source)` payload.
- Validation at factory entry in both `transparency.Explanation` and `robustness.RobustnessAssessment` (runtime kwarg vs `raitap.sample_names` from YAML disambiguated via `source`).
- Defensive re-checks in `ExplanationResult.visualise` / `render_visualisation_for_scope` and `RobustnessResult.visualise` / `render_visualisation_for_report` (full-batch + per-sample branches).
- `None` / empty list preserved as no-op.
- Pipeline path (`pipeline/phases/assess_*.py`) unaffected — `sample_names` there is auto-derived from `data.sample_ids`, length matches by construction.

## Breaking change

Configurations / callers that previously relied on silent truncation now raise. Fix: supply exactly `N` names or omit `sample_names`.

## Tests

- New `src/raitap/utils/tests/test_errors_sample_names.py` (4 tests).
- New mismatch/match/None tests in transparency + robustness `test_factory.py` and `test_results.py` covering each defensive seam.
- 102/102 targeted tests pass; 931 full suite pass (2 pre-existing unrelated Windows drive-letter failures in `test_log.py`).

## Docs

User-facing length constraint added to:
- `docs/modules/transparency/configuration.md`
- `docs/modules/robustness/configuration.md`
- `docs/modules/transparency/frameworks-and-libraries.md`

## Test plan

- [x] `uv run ruff format .` + `uv run ruff check .` clean
- [x] `uv run pytest` green (modulo pre-existing unrelated failures)
- [x] CI green on PR