### PR TITLE
feat(metrics)!: typed schemas, per-task classification adapters, nested iou config

### DIFF
--- a/contributor-configs/lwise-ham10000/assessment.yaml
+++ b/contributor-configs/lwise-ham10000/assessment.yaml
@@ -24,8 +24,7 @@ data:
     column: label
 
 metrics:
-  _target_: ClassificationMetrics
-  task: multiclass
+  _target_: MulticlassClassificationMetrics
   num_classes: 7
 
 transparency:

--- a/docs/_ext/config_options.py
+++ b/docs/_ext/config_options.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 CONFIG_OPTION_FIELDS = ("option", "allowed", "default", "description")
-CONFIG_PAGE_FIELDS = ("intro", "yaml", "cli", "python")
+CONFIG_PAGE_FIELDS = ("intro", "yaml", "cli", "python", "slug")
 TABLE_HEADERS = ("Name", "Allowed", "Default", "Description")
 CONFIG_TABS_SYNC_KEY = "raitap-config"
 
@@ -32,6 +32,7 @@ class ConfigPage:
     cli: str
     options: list[ConfigOption]
     python: str = ""
+    slug: str = ""
 
 
 def normalise_inline_value(lines: list[str]) -> str:
@@ -224,6 +225,7 @@ def parse_config_page_content(lines: list[str]) -> ConfigPage:
     yaml_content = normalise_block_value(page_fields["yaml"])
     cli_override = normalise_inline_value(page_fields["cli"])
     python_snippet = normalise_block_value(page_fields["python"])
+    slug = normalise_inline_value(page_fields["slug"])
 
     missing_fields = [
         field
@@ -244,6 +246,7 @@ def parse_config_page_content(lines: list[str]) -> ConfigPage:
         cli=cli_override,
         options=options,
         python=python_snippet,
+        slug=slug,
     )
 
 
@@ -352,23 +355,49 @@ def build_config_tab_set_lines(page: ConfigPage) -> list[str]:
 
 
 def build_config_page_lines(page: ConfigPage, *, docname: str) -> list[str]:
-    options_label = build_section_label(docname, "options")
-    lines = ["# Configuration", ""]
+    # When ``:slug:`` is given, the block is nested under a caller-owned H2:
+    # skip the auto ``# Configuration`` H1, drop the internal sub-headings
+    # (``## Options`` etc.) so MyST doesn't complain about the heading hierarchy,
+    # and scope every cross-reference label with the slug so multiple blocks can
+    # coexist on one page (cf. ``docs/modules/metrics/configuration.md``).
+    nested = bool(page.slug)
+    options_label = build_section_label(docname, f"{page.slug}-options" if nested else "options")
+    lines: list[str] = []
+    if not nested:
+        lines.extend(["# Configuration", ""])
     lines.extend(page.intro.splitlines())
-    lines.extend(["", f"({options_label})=", "## Options", ""])
+    if nested:
+        lines.extend(["", f"({options_label})=", "", "**Options**", ""])
+    else:
+        lines.extend(["", f"({options_label})=", "## Options", ""])
     lines.extend(build_markdown_table_lines(page.options))
 
     if page.python:
-        examples_label = build_section_label(docname, "examples")
-        lines.extend(["", f"({examples_label})=", "## Examples", ""])
+        examples_label = build_section_label(
+            docname, f"{page.slug}-examples" if nested else "examples"
+        )
+        if nested:
+            lines.extend(["", f"({examples_label})=", "", "**Examples**", ""])
+        else:
+            lines.extend(["", f"({examples_label})=", "## Examples", ""])
         lines.extend(build_config_tab_set_lines(page))
         return lines
 
-    yaml_label = build_section_label(docname, "yaml-example")
-    cli_label = build_section_label(docname, "cli-override-example")
-    lines.extend(["", f"({yaml_label})=", "## YAML example", "", "```yaml"])
+    yaml_label = build_section_label(
+        docname, f"{page.slug}-yaml-example" if nested else "yaml-example"
+    )
+    cli_label = build_section_label(
+        docname, f"{page.slug}-cli-override-example" if nested else "cli-override-example"
+    )
+    if nested:
+        lines.extend(["", f"({yaml_label})=", "", "**YAML example**", "", "```yaml"])
+    else:
+        lines.extend(["", f"({yaml_label})=", "## YAML example", "", "```yaml"])
     lines.extend(page.yaml.splitlines())
-    lines.extend(["```", "", f"({cli_label})=", "## CLI override example", ""])
+    if nested:
+        lines.extend(["```", "", f"({cli_label})=", "", "**CLI override example**", ""])
+    else:
+        lines.extend(["```", "", f"({cli_label})=", "## CLI override example", ""])
     lines.extend(build_install_tabs_lines(page.cli))
     return lines
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,6 +99,9 @@ nitpick_ignore_regex = [
     # Private adapter-registration mixin; intentionally not in the public API
     # reference but appears as an inherited base in autodoc class chains.
     (r"py:class", r"raitap\._adapters\.AdapterMixin"),
+    # Private mixin sharing torchmetrics quartet wiring across the three
+    # ClassificationMetrics task adapters; not a public class.
+    (r"py:class", r"raitap\.metrics\.classification_metrics\._ClassificationBase"),
     # WithAlgorithmRegistry[T] generic params + forward-string narrowings.
     (r"py:obj", r"raitap\.registry_base\.T"),
     (r"py:class", r"AssessorSemanticsHints"),

--- a/docs/modules/metrics/configuration.md
+++ b/docs/modules/metrics/configuration.md
@@ -6,6 +6,8 @@ myst:
     "description": "This page describes how to configure the metrics module used to score model predictions."
 ---
 
+# Configuration
+
 The `metrics` block scores model predictions. The `_target_` field is the
 discriminator: it selects one of four adapters, each with its own set of valid
 keys.

--- a/docs/modules/metrics/configuration.md
+++ b/docs/modules/metrics/configuration.md
@@ -53,17 +53,13 @@ adapter.
 :yaml:
 metrics:
   _target_: "BinaryClassificationMetrics"
-  ignore_index: null
-  threshold: 0.5
 
 :cli: +metrics=binary_classification +metrics.threshold=0.6
 
 :python:
 from raitap.metrics import binary_classification
 
-metrics = binary_classification(
-    threshold=0.5,
-)
+metrics = binary_classification()
 ```
 
 ## Multiclass classification
@@ -98,18 +94,13 @@ metrics = binary_classification(
 metrics:
   _target_: "MulticlassClassificationMetrics"
   num_classes: 7
-  average: "macro"
-  ignore_index: null
 
 :cli: +metrics=multiclass_classification +metrics.num_classes=7
 
 :python:
 from raitap.metrics import multiclass_classification
 
-metrics = multiclass_classification(
-    num_classes=7,
-    average="macro",
-)
+metrics = multiclass_classification(num_classes=7)
 ```
 
 ## Multilabel classification
@@ -149,20 +140,13 @@ metrics = multiclass_classification(
 metrics:
   _target_: "MultilabelClassificationMetrics"
   num_labels: 5
-  average: "macro"
-  ignore_index: null
-  threshold: 0.5
 
 :cli: +metrics=multilabel_classification +metrics.num_labels=5
 
 :python:
 from raitap.metrics import multilabel_classification
 
-metrics = multilabel_classification(
-    num_labels=5,
-    average="macro",
-    threshold=0.5,
-)
+metrics = multilabel_classification(num_labels=5)
 ```
 
 ## Object detection
@@ -233,16 +217,9 @@ metrics = multilabel_classification(
 :yaml:
 metrics:
   _target_: "DetectionMetrics"
-  box_format: "xyxy"
   iou:
-    type: "bbox"
-    thresholds: null
-    rec_thresholds: null
-    max_detection_thresholds: null
-  class_metrics: false
-  extended_summary: false
-  average: "macro"
-  backend: "faster_coco_eval"
+    thresholds: [0.5, 0.75]
+  class_metrics: true
 
 :cli: +metrics=detection +metrics.class_metrics=true +metrics.extended_summary=true
 
@@ -250,9 +227,7 @@ metrics:
 from raitap.metrics import detection
 
 metrics = detection(
-    box_format="xyxy",
-    iou={"type": "bbox"},
+    iou={"thresholds": [0.5, 0.75]},
     class_metrics=True,
-    extended_summary=True,
 )
 ```

--- a/docs/modules/metrics/configuration.md
+++ b/docs/modules/metrics/configuration.md
@@ -6,110 +6,251 @@ myst:
     "description": "This page describes how to configure the metrics module used to score model predictions."
 ---
 
+The `metrics` block scores model predictions. The `_target_` field is the
+discriminator: it selects one of four adapters, each with its own set of valid
+keys.
+
+- **`BinaryClassificationMetrics`** — two-class problems (accuracy, precision,
+  recall, F1).
+- **`MulticlassClassificationMetrics`** — single-label multiclass
+  classification (one correct class per sample).
+- **`MultilabelClassificationMetrics`** — multilabel classification (multiple
+  correct classes per sample, independent per-label decisions).
+- **`DetectionMetrics`** — object detection (mean average precision and
+  related summaries via torchmetrics).
+
+The previous unified `ClassificationMetrics` target with a `task: binary | multiclass | multilabel`
+field has been removed. Pick the task-specific adapter directly via `_target_`;
+each adapter only accepts the keys documented for its section below.
+
+See {doc}`frameworks-and-libraries` for the backend behaviour behind each
+adapter.
+
+## Binary classification
+
 ```{config-page}
-:intro: This page describes how to configure the metrics module used to score
-  model predictions.
+:slug: binary
+:intro: Configures `BinaryClassificationMetrics` for two-class problems.
 
 :option: _target_
-:allowed: "ClassificationMetrics", "DetectionMetrics"
-:default: "ClassificationMetrics"
-:description: The type of metrics to use. See {doc}`frameworks-and-libraries` for more details.
-
-:option: task
-:allowed: "binary", "multiclass", "multilabel"
-:default: "multiclass"
-:description: Classification task type. Only used by
-  `ClassificationMetrics`.
-
-:option: num_classes
-:allowed: integer, null
-:default: null
-:description: Number of classes for `multiclass` tasks. For
-  `multilabel`, this is also accepted as an alias for `num_labels`.
-
-:option: num_labels
-:allowed: integer, null
-:default: null
-:description: Number of labels for `multilabel` tasks.
-
-:option: average
-:allowed: "micro", "macro", "weighted", "none"
-:default: "macro"
-:description: Aggregation mode. `ClassificationMetrics` supports
-  `"micro"`, `"macro"`, `"weighted"`, and `"none"` for `multiclass` and
-  `multilabel`. `DetectionMetrics` supports `"micro"` and `"macro"`. See {doc}`frameworks-and-libraries` for more details.
+:allowed: "BinaryClassificationMetrics"
+:default: "BinaryClassificationMetrics"
+:description: Selects the binary-classification adapter.
 
 :option: ignore_index
 :allowed: integer, null
 :default: null
-:description: Optional target value to ignore when computing classification
-  metrics.
+:description: Optional target value to ignore when computing metrics.
 
 :option: threshold
-:allowed: float, null
-:default: 0.5 for `multilabel` when omitted
-:description: Threshold applied by `ClassificationMetrics` for multilabel
-  predictions. Ignored by other targets unless the underlying TorchMetrics
-  implementation accepts it through forwarded kwargs.
+:allowed: float
+:default: 0.5
+:description: Decision threshold applied to predicted probabilities to obtain
+  the positive class.
+
+:yaml:
+metrics:
+  _target_: "BinaryClassificationMetrics"
+  ignore_index: null
+  threshold: 0.5
+
+:cli: +metrics=binary_classification +metrics.threshold=0.6
+
+:python:
+from raitap.metrics import binary_classification
+
+metrics = binary_classification(
+    threshold=0.5,
+)
+```
+
+## Multiclass classification
+
+```{config-page}
+:slug: multiclass
+:intro: Configures `MulticlassClassificationMetrics` for single-label
+  multiclass problems.
+
+:option: _target_
+:allowed: "MulticlassClassificationMetrics"
+:default: "MulticlassClassificationMetrics"
+:description: Selects the multiclass-classification adapter.
+
+:option: num_classes
+:allowed: integer
+:default: required
+:description: Number of classes. Must be positive. Required.
+
+:option: average
+:allowed: "micro", "macro", "weighted", "none"
+:default: "macro"
+:description: Aggregation mode passed to the underlying TorchMetrics
+  implementations. See {doc}`frameworks-and-libraries` for semantics.
+
+:option: ignore_index
+:allowed: integer, null
+:default: null
+:description: Optional target value to ignore when computing metrics.
+
+:yaml:
+metrics:
+  _target_: "MulticlassClassificationMetrics"
+  num_classes: 7
+  average: "macro"
+  ignore_index: null
+
+:cli: +metrics=multiclass_classification +metrics.num_classes=7
+
+:python:
+from raitap.metrics import multiclass_classification
+
+metrics = multiclass_classification(
+    num_classes=7,
+    average="macro",
+)
+```
+
+## Multilabel classification
+
+```{config-page}
+:slug: multilabel
+:intro: Configures `MultilabelClassificationMetrics` for multilabel problems
+  (independent per-label decisions).
+
+:option: _target_
+:allowed: "MultilabelClassificationMetrics"
+:default: "MultilabelClassificationMetrics"
+:description: Selects the multilabel-classification adapter.
+
+:option: num_labels
+:allowed: integer
+:default: required
+:description: Number of labels. Must be positive. Required.
+
+:option: average
+:allowed: "micro", "macro", "weighted", "none"
+:default: "macro"
+:description: Aggregation mode passed to the underlying TorchMetrics
+  implementations.
+
+:option: ignore_index
+:allowed: integer, null
+:default: null
+:description: Optional target value to ignore when computing metrics.
+
+:option: threshold
+:allowed: float
+:default: 0.5
+:description: Per-label decision threshold applied to predicted probabilities.
+
+:yaml:
+metrics:
+  _target_: "MultilabelClassificationMetrics"
+  num_labels: 5
+  average: "macro"
+  ignore_index: null
+  threshold: 0.5
+
+:cli: +metrics=multilabel_classification +metrics.num_labels=5
+
+:python:
+from raitap.metrics import multilabel_classification
+
+metrics = multilabel_classification(
+    num_labels=5,
+    average="macro",
+    threshold=0.5,
+)
+```
+
+## Object detection
+
+```{config-page}
+:slug: detection
+:intro: Configures `DetectionMetrics`, which wraps torchmetrics
+  `MeanAveragePrecision`. The IoU-related knobs are grouped under the nested
+  `iou:` block.
+
+:option: _target_
+:allowed: "DetectionMetrics"
+:default: "DetectionMetrics"
+:description: Selects the object-detection adapter.
 
 :option: box_format
 :allowed: "xyxy", "xywh"
 :default: "xyxy"
-:description: Bounding-box format expected by `DetectionMetrics`.
+:description: Bounding-box format of incoming predictions and targets.
+  torchvision detectors output `xyxy`.
 
-:option: iou_type
-:allowed: "bbox", "segm", or a tuple containing those values
+:option: iou.type
+:allowed: "bbox", "segm", or a tuple of those values
 :default: "bbox"
-:description: IoU mode passed to detection mean average precision.
+:description: IoU mode passed to mean average precision.
 
-:option: iou_thresholds
+:option: iou.thresholds
 :allowed: list[float], null
 :default: null
-:description: Optional custom IoU thresholds for detection evaluation.
+:description: Optional custom IoU thresholds. `null` uses the torchmetrics
+  default (COCO-style sweep).
 
-:option: rec_thresholds
+:option: iou.rec_thresholds
 :allowed: list[float], null
 :default: null
-:description: Optional custom recall thresholds for detection evaluation.
+:description: Optional custom recall thresholds. `null` uses the torchmetrics
+  default.
 
-:option: max_detection_thresholds
+:option: iou.max_detection_thresholds
 :allowed: list[int], null
 :default: null
-:description: Optional maximum-detection cutoffs for detection evaluation.
+:description: Optional maximum-detection cutoffs. `null` uses the torchmetrics
+  default.
 
 :option: class_metrics
 :allowed: true, false
 :default: false
-:description: Whether `DetectionMetrics` should compute class-wise metrics in
-  addition to global summaries.
+:description: Whether to compute per-class metrics in addition to global
+  summaries.
 
 :option: extended_summary
 :allowed: true, false
 :default: false
-:description: Whether `DetectionMetrics` should request extended non-scalar
-  summary outputs.
+:description: Whether to request the torchmetrics extended (non-scalar)
+  summary outputs as artifacts.
+
+:option: average
+:allowed: "macro", "micro"
+:default: "macro"
+:description: Aggregation mode for detection summaries.
 
 :option: backend
 :allowed: "faster_coco_eval", "pycocotools"
 :default: "faster_coco_eval"
-:description: Backend used by detection mean average precision. `pycocotools` should be used only for backward compatibility.
+:description: Backend used by mean average precision. `pycocotools` should be
+  used only for backward compatibility.
 
 :yaml:
 metrics:
-  _target_: "ClassificationMetrics"
-  task: "multiclass"
-  num_classes: 7
-  num_labels: null
+  _target_: "DetectionMetrics"
+  box_format: "xyxy"
+  iou:
+    type: "bbox"
+    thresholds: null
+    rec_thresholds: null
+    max_detection_thresholds: null
+  class_metrics: false
+  extended_summary: false
   average: "macro"
-  ignore_index: null
+  backend: "faster_coco_eval"
 
 :cli: +metrics=detection +metrics.class_metrics=true +metrics.extended_summary=true
 
 :python:
-from raitap.metrics import Task, classification
+from raitap.metrics import detection
 
-metrics = classification(
-    task=Task.multiclass,
-    num_classes=7,
+metrics = detection(
+    box_format="xyxy",
+    iou={"type": "bbox"},
+    class_metrics=True,
+    extended_summary=True,
 )
 ```

--- a/docs/modules/metrics/frameworks-and-libraries.md
+++ b/docs/modules/metrics/frameworks-and-libraries.md
@@ -18,24 +18,24 @@ To tweak specific options via the RAITAP config, you might need to refer to the 
 
 ## Classification metrics
 
-`ClassificationMetrics` is ideal for classification models. It wraps the following TorchMetrics classes:
+`BinaryClassificationMetrics`, `MulticlassClassificationMetrics`, and `MultilabelClassificationMetrics` are the task-specific adapters for classification models. They each wrap the following TorchMetrics classes (instantiated for the matching task):
 
 - [`Accuracy`](https://lightning.ai/docs/torchmetrics/stable/classification/accuracy.html)
 - [`Precision`](https://lightning.ai/docs/torchmetrics/stable/classification/precision.html)
 - [`Recall`](https://lightning.ai/docs/torchmetrics/stable/classification/recall.html)
 - [`F1Score`](https://lightning.ai/docs/torchmetrics/stable/classification/f1_score.html)
 
-It supports the task types exposed by TorchMetrics that RAITAP currently uses:
+The adapters map to the task types exposed by TorchMetrics that RAITAP currently uses:
 
-- [`binary`](https://lightning.ai/docs/torchmetrics/stable/classification/accuracy.html#binaryaccuracy)
-- [`multiclass`](https://lightning.ai/docs/torchmetrics/stable/classification/accuracy.html#multiclassaccuracy)
-- [`multilabel`](https://lightning.ai/docs/torchmetrics/stable/classification/accuracy.html#multilabelaccuracy)
+- `BinaryClassificationMetrics` → [`binary`](https://lightning.ai/docs/torchmetrics/stable/classification/accuracy.html#binaryaccuracy)
+- `MulticlassClassificationMetrics` → [`multiclass`](https://lightning.ai/docs/torchmetrics/stable/classification/accuracy.html#multiclassaccuracy)
+- `MultilabelClassificationMetrics` → [`multilabel`](https://lightning.ai/docs/torchmetrics/stable/classification/accuracy.html#multilabelaccuracy)
 
 RAITAP adds a thin layer of validation and conventions around these metrics. In
 particular:
 
-- `multiclass` requires `num_classes`
-- `multilabel` uses `num_labels` internally and also accepts `num_classes` as an alias. It defaults to a threshold of `0.5` if none is provided
+- `MulticlassClassificationMetrics` requires `num_classes`
+- `MultilabelClassificationMetrics` requires `num_labels` and defaults to a threshold of `0.5` if none is provided
 - `average="none"` stores per-class or per-label values in `artifacts.json`
   instead of flattening them into scalar metrics
 

--- a/docs/using-raitap/configuration/python-api.md
+++ b/docs/using-raitap/configuration/python-api.md
@@ -203,18 +203,17 @@ data = DataConfig(
 ```{config-tabs}
 :yaml:
 metrics:
-  _target_: "ClassificationMetrics"
-  task: "multiclass"
+  _target_: "MulticlassClassificationMetrics"
   num_classes: 7
   average: "macro"
 
 :python:
-from raitap.metrics import Task, classification
+from raitap.metrics import multiclass_classification
 
-metrics = classification(task=Task.multiclass, num_classes=7, average="macro")
+metrics = multiclass_classification(num_classes=7, average="macro")
 ```
 
-The hydra-zen builder is the recommended path here because `ClassificationMetrics` exposes many optional kwargs (`average`, `ignore_index`, …) that `MetricsConfig` does not type explicitly. `populate_full_signature=True` lifts the full constructor signature onto the dataclass, so your editor will autocomplete every kwarg.
+The hydra-zen builder is the recommended path here because `MulticlassClassificationMetrics` exposes many optional kwargs (`average`, `ignore_index`, …) that the bare `MetricsConfig` discriminator does not type explicitly. `populate_full_signature=True` lifts the full constructor signature onto the dataclass, so your editor will autocomplete every kwarg. Pick the matching builder (`binary_classification`, `multiclass_classification`, `multilabel_classification`, `detection`) for the task you're configuring.
 
 ### Transparency
 
@@ -437,7 +436,7 @@ The schema is a deliberate mix of strict and forwarded. Knowing which fields are
 - `TransparencyConfig.constructor` / `.call` / `.raitap` — dicts forwarded verbatim to the underlying explainer library (Captum's `IntegratedGradients(...)`, SHAP's `GradientExplainer(...)`, the corresponding `.attribute()` / `.shap_values()` call).
 - `RobustnessConfig.constructor` / `.call` / `.raitap` — same story for torchattacks / Foolbox / Marabou.
 
-The hydra-zen builders in `raitap.api` (`captum`, `shap`, `torchattacks`, `foolbox`, `classification_metrics`) inherit the corresponding schema dataclass via `builds_bases=`, so they accept every field on `TransparencyConfig` / `RobustnessConfig` / `MetricsConfig` (`algorithm`, `constructor`, `call`, `raitap`, `visualisers`). `classification_metrics` additionally uses `populate_full_signature=True` to surface the full `ClassificationMetrics.__init__` signature (`average`, `num_labels`, `ignore_index`). For Captum / SHAP / torchattacks / Foolbox, the underlying constructor takes `**kwargs`, so per-library kwargs (`eps=`, `steps=`, `target=`) stay inside the `constructor` / `call` dict — your editor autocompletes the schema fields, not the library kwargs.
+The hydra-zen builders in `raitap.api` (`captum`, `shap`, `torchattacks`, `foolbox`, plus the per-task metrics builders `binary_classification`, `multiclass_classification`, `multilabel_classification`, `detection`) inherit the corresponding schema dataclass via `builds_bases=`, so they accept every field on `TransparencyConfig` / `RobustnessConfig` / `MetricsConfig` (`algorithm`, `constructor`, `call`, `raitap`, `visualisers`). The classification and detection builders additionally use `populate_full_signature=True` to surface the full adapter `__init__` signature (`average`, `num_labels`, `ignore_index`, `iou`, …). For Captum / SHAP / torchattacks / Foolbox, the underlying constructor takes `**kwargs`, so per-library kwargs (`eps=`, `steps=`, `target=`) stay inside the `constructor` / `call` dict — your editor autocompletes the schema fields, not the library kwargs.
 
 (runoutputs-shape)=
 

--- a/docs/using-raitap/examples/kitchen-sink.md
+++ b/docs/using-raitap/examples/kitchen-sink.md
@@ -95,10 +95,8 @@ robustness:
       - _target_: "PerturbationHeatmapVisualiser"
 
 metrics:
-  _target_: "ClassificationMetrics"
-  task: "multiclass"
+  _target_: "MulticlassClassificationMetrics"
   num_classes: 7
-  num_labels: null
   average: "macro"
   ignore_index: null
 
@@ -118,7 +116,7 @@ reporting:
 :python:
 from raitap import AppConfig, Hardware
 from raitap.data import DataConfig, LabelEncoding, LabelsConfig
-from raitap.metrics import Task, classification as classification_metrics
+from raitap.metrics import multiclass_classification
 from raitap.models import ModelConfig
 from raitap.reporting import html as html_report
 from raitap.robustness import foolbox, image_pair, perturbation_heatmap, torchattacks
@@ -187,8 +185,7 @@ config = AppConfig(
             visualisers=[perturbation_heatmap()],
         ),
     },
-    metrics=classification_metrics(
-        task=Task.multiclass,
+    metrics=multiclass_classification(
         num_classes=7,
     ),
     tracking=mlflow(

--- a/src/raitap/__init__.py
+++ b/src/raitap/__init__.py
@@ -7,7 +7,7 @@ ownership is consistent across both type and value::
     from raitap import AppConfig, run, Hardware           # orchestration
     from raitap.models import ModelConfig
     from raitap.data import DataConfig, LabelsConfig, LabelEncoding, IdStrategy
-    from raitap.metrics import MetricsConfig, Task, classification
+    from raitap.metrics import MetricsConfig, multiclass_classification
     from raitap.transparency import TransparencyConfig, captum, captum_image
     from raitap.robustness import RobustnessConfig, torchattacks, image_pair
     from raitap.reporting import ReportingConfig, html

--- a/src/raitap/_adapters.py
+++ b/src/raitap/_adapters.py
@@ -90,6 +90,7 @@ class _CommonRegKwargs(TypedDict, total=False):
     library: str
     error_patterns: Mapping[re.Pattern[str], str]
     suppress_warnings: Sequence[tuple[str, type[Warning], str | None]]
+    schema: type
 
 
 class AdapterMixin:
@@ -220,6 +221,7 @@ def _register_core(
     library = common.get("library")
     error_patterns = common.get("error_patterns")
     suppress_warnings = common.get("suppress_warnings")
+    schema_override = common.get("schema")
 
     cls.registry_name = registry_name
     if extra is not None:
@@ -235,7 +237,7 @@ def _register_core(
     try:
         if family is not None:
             cls._adapter_group = family.group
-            builder = _build_schema_adapter(cls, family.schema)
+            builder = _build_schema_adapter(cls, schema_override or family.schema)
             package = (
                 f"{family.group}.{registry_name}"
                 if family.package_style == "nested"

--- a/src/raitap/configs/demo.yaml
+++ b/src/raitap/configs/demo.yaml
@@ -2,6 +2,7 @@
 # Inlines every value so it works without external group YAMLs.
 defaults:
   - raitap_schema     # binds AppConfig dataclass → unset fields inherit defaults
+  - metrics: multiclass_classification   # narrows metrics schema so num_classes is accepted
   - _self_
 
 hardware: cpu
@@ -20,8 +21,7 @@ data:
     column: label
 
 metrics:
-  _target_: ClassificationMetrics
-  task: multiclass
+  num_classes: 1000
 
 transparency:
   my_integrated_gradients_explainer:

--- a/src/raitap/configs/schema.py
+++ b/src/raitap/configs/schema.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from omegaconf import MISSING
 
 from raitap.data.types import IdStrategy, LabelEncoding
 from raitap.types import Hardware, Task
+
+if TYPE_CHECKING:
+    from raitap.metrics.classification_metrics import Average as ClassificationAverage
+    from raitap.metrics.detection_metrics import (
+        Average as DetectionAverage,
+    )
+    from raitap.metrics.detection_metrics import (
+        Backend,
+        BoxFormat,
+        IoUType,
+    )
 
 
 @dataclass
@@ -143,6 +154,49 @@ class MetricsConfig:
     _target_: str = MISSING
     task: Task = Task.multiclass
     num_classes: int | None = None
+
+
+@dataclass
+class IoUConfig:
+    type: IoUType = "bbox"
+    thresholds: list[float] | None = None
+    rec_thresholds: list[float] | None = None
+    max_detection_thresholds: list[int] | None = None
+
+
+@dataclass
+class BinaryClassificationMetricsConfig(MetricsConfig):
+    _target_: str = "BinaryClassificationMetrics"
+    ignore_index: int | None = None
+    threshold: float = 0.5
+
+
+@dataclass
+class MulticlassClassificationMetricsConfig(MetricsConfig):
+    _target_: str = "MulticlassClassificationMetrics"
+    num_classes: int = MISSING
+    average: ClassificationAverage = "macro"
+    ignore_index: int | None = None
+
+
+@dataclass
+class MultilabelClassificationMetricsConfig(MetricsConfig):
+    _target_: str = "MultilabelClassificationMetrics"
+    num_labels: int = MISSING
+    average: ClassificationAverage = "macro"
+    ignore_index: int | None = None
+    threshold: float = 0.5
+
+
+@dataclass
+class DetectionMetricsConfig(MetricsConfig):
+    _target_: str = "DetectionMetrics"
+    box_format: BoxFormat = "xyxy"
+    iou: IoUConfig = field(default_factory=IoUConfig)
+    class_metrics: bool = False
+    extended_summary: bool = False
+    average: DetectionAverage = "macro"
+    backend: Backend = "faster_coco_eval"
 
 
 @dataclass

--- a/src/raitap/configs/schema.py
+++ b/src/raitap/configs/schema.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 from omegaconf import MISSING
 
 from raitap.data.types import IdStrategy, LabelEncoding
-from raitap.types import Hardware, Task
+from raitap.types import Hardware
 
 if TYPE_CHECKING:
     from raitap.metrics.classification_metrics import Average as ClassificationAverage
@@ -18,6 +18,20 @@ if TYPE_CHECKING:
         BoxFormat,
         IoUType,
     )
+else:
+    # Runtime aliases so omegaconf's ``get_type_hints()`` can resolve the
+    # string-form annotations on the dataclasses below without importing the
+    # metrics package (which would create a circular import: metrics modules
+    # depend on this schema for their typed configs). omegaconf does not
+    # natively support ``Literal`` types, so the runtime fallback widens to
+    # ``str``; the canonical narrow ``Literal`` definitions live in the
+    # respective metrics modules and are enforced by adapter ``__init__``
+    # validation.
+    ClassificationAverage = str
+    DetectionAverage = str
+    Backend = str
+    BoxFormat = str
+    IoUType = Any
 
 
 @dataclass
@@ -152,8 +166,6 @@ class RobustnessConfig:
 @dataclass
 class MetricsConfig:
     _target_: str = MISSING
-    task: Task = Task.multiclass
-    num_classes: int | None = None
 
 
 @dataclass

--- a/src/raitap/configs/schema.py
+++ b/src/raitap/configs/schema.py
@@ -31,6 +31,10 @@ else:
     DetectionAverage = str
     Backend = str
     BoxFormat = str
+    # ``IoUType`` real type is ``str | tuple[str, ...]`` — omegaconf rejects
+    # unions of primitives and containers ("Unions of containers are not
+    # supported"), so the runtime alias has to stay ``Any``. The narrow
+    # ``Literal`` definition lives in ``raitap.metrics.detection_metrics``.
     IoUType = Any
 
 

--- a/src/raitap/deps/tests/test_bootstrap.py
+++ b/src/raitap/deps/tests/test_bootstrap.py
@@ -23,7 +23,7 @@ def _fake_compose(monkeypatch: pytest.MonkeyPatch, cfg: dict[str, Any]) -> None:
 def _baseline_cfg() -> dict[str, Any]:
     return {
         "model": {"source": "x.pt"},
-        "metrics": {"_target_": "ClassificationMetrics", "task": "multiclass"},
+        "metrics": {"_target_": "MulticlassClassificationMetrics", "num_classes": 3},
         "reporting": {"_target_": "HTMLReporter", "filename": "r"},
     }
 

--- a/src/raitap/deps/tests/test_e2e.py
+++ b/src/raitap/deps/tests/test_e2e.py
@@ -16,7 +16,7 @@ _LWISE_ASSESSMENT: dict = {
     "hardware": "gpu",
     "model": {"source": "lwise_ham10000_eager.pt"},
     "data": {"name": "ham10000-presentation-balanced"},
-    "metrics": {"_target_": "ClassificationMetrics", "task": "multiclass"},
+    "metrics": {"_target_": "MulticlassClassificationMetrics", "num_classes": 7},
     "transparency": {
         "gradcam": {"_target_": "CaptumExplainer", "algorithm": "LayerGradCam"},
         "saliency": {"_target_": "CaptumExplainer", "algorithm": "Saliency"},
@@ -69,7 +69,7 @@ def test_lwise_ham10000_with_cuda_picks_torch_cuda() -> None:
 _MARABOU_MNIST_DEMO: dict = {
     "model": {"source": "mlp_mnist.onnx"},
     "data": {"name": "mnist_samples"},
-    "metrics": {"_target_": "ClassificationMetrics", "task": "multiclass"},
+    "metrics": {"_target_": "MulticlassClassificationMetrics", "num_classes": 7},
     "robustness": {
         "marabou_linf": {"_target_": "MarabouAssessor", "algorithm": "linf-box"},
     },

--- a/src/raitap/deps/tests/test_inference.py
+++ b/src/raitap/deps/tests/test_inference.py
@@ -116,7 +116,7 @@ def test_tracking_mlflow() -> None:
 def test_metrics_block_adds_extra() -> None:
     cfg = {
         "model": {"source": "x.pt"},
-        "metrics": {"_target_": "ClassificationMetrics", "task": "multiclass"},
+        "metrics": {"_target_": "MulticlassClassificationMetrics", "num_classes": 3},
     }
     extras, _ = infer_extras(cfg, hardware="cpu")
     assert "metrics" in extras
@@ -187,6 +187,8 @@ def test_mapping_table_lists_all_known_targets() -> None:
         "HTMLReporter",
         "PDFReporter",
         "MLFlowTracker",
-        "ClassificationMetrics",
+        "BinaryClassificationMetrics",
+        "MulticlassClassificationMetrics",
+        "MultilabelClassificationMetrics",
         "DetectionMetrics",
     }

--- a/src/raitap/deps/tests/test_static_scan.py
+++ b/src/raitap/deps/tests/test_static_scan.py
@@ -49,6 +49,8 @@ def test_static_scan_finds_canonical_set() -> None:
         "HTMLReporter",
         "PDFReporter",
         "MLFlowTracker",
-        "ClassificationMetrics",
+        "BinaryClassificationMetrics",
+        "MulticlassClassificationMetrics",
+        "MultilabelClassificationMetrics",
         "DetectionMetrics",
     }, f"Scanner missed canonical adapters. Found: {sorted(scanned)!r}."

--- a/src/raitap/metrics/__init__.py
+++ b/src/raitap/metrics/__init__.py
@@ -14,9 +14,14 @@ MetricResult
 
 Metric classes
 --------------
-ClassificationMetrics
-    Computes accuracy, precision, recall, and F1 score for binary, multiclass,
-    and multilabel classification tasks.
+BinaryClassificationMetrics
+    Accuracy, precision, recall, and F1 for two-class problems.
+
+MulticlassClassificationMetrics
+    Accuracy, precision, recall, and F1 for multiclass classification.
+
+MultilabelClassificationMetrics
+    Accuracy, precision, recall, and F1 for multilabel classification.
 
 DetectionMetrics
     Computes mean average precision (mAP) and related metrics for object detection tasks.
@@ -30,7 +35,11 @@ from typing import TYPE_CHECKING, Any
 from .base_metric_computer import BaseMetricComputer, MetricResult, scalar_metrics_for_tracking
 
 # Concrete metric implementations
-from .classification_metrics import ClassificationMetrics
+from .classification_metrics import (
+    BinaryClassificationMetrics,
+    MulticlassClassificationMetrics,
+    MultilabelClassificationMetrics,
+)
 from .detection_metrics import DetectionMetrics
 from .factory import (
     Metrics,
@@ -44,37 +53,32 @@ from .visualizers import MetricsVisualizer
 
 if TYPE_CHECKING:
     from raitap.configs.schema import MetricsConfig
-    from raitap.types import Task
 
 
 def __getattr__(name: str) -> Any:
     """Resolve hydra-zen builders by registry name, plus the schema dataclass
-    (:class:`~raitap.configs.schema.MetricsConfig`) and the
-    :class:`~raitap.types.Task` enum re-exported here so the module owns
-    both the type contract and the builder instances."""
+    (:class:`~raitap.configs.schema.MetricsConfig`) re-exported here so the
+    module owns both the type contract and the builder instances."""
     if name == "MetricsConfig":
         from raitap.configs.schema import MetricsConfig
 
         return MetricsConfig
-    if name == "Task":
-        from raitap.types import Task
-
-        return Task
     from raitap._adapters import lookup
 
     return lookup("metrics", name)
 
 
 __all__ = [  # noqa: RUF022
-    # Schema dataclass + task enum (lazy)
+    # Schema dataclass (lazy)
     "MetricsConfig",
-    "Task",
     # Base types
     "BaseMetricComputer",
     "MetricResult",
     "scalar_metrics_for_tracking",
     # Concrete implementations
-    "ClassificationMetrics",
+    "BinaryClassificationMetrics",
+    "MulticlassClassificationMetrics",
+    "MultilabelClassificationMetrics",
     "DetectionMetrics",
     # Factory API
     "Metrics",

--- a/src/raitap/metrics/classification_metrics.py
+++ b/src/raitap/metrics/classification_metrics.py
@@ -34,10 +34,10 @@ Average = Literal["micro", "macro", "weighted", "none"]
 class _ClassificationBase(BaseMetricComputer):
     """Shared update/compute/reset/device wiring; subclasses build the metric quartet."""
 
-    accuracy: Any
-    precision: Any
-    recall: Any
-    f1: Any
+    accuracy: torchmetrics.Metric
+    precision: torchmetrics.Metric
+    recall: torchmetrics.Metric
+    f1: torchmetrics.Metric
     average: Average | None
 
     def _move_to_device(self, device: torch.device | None) -> None:

--- a/src/raitap/metrics/classification_metrics.py
+++ b/src/raitap/metrics/classification_metrics.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal
 
+from raitap.configs.schema import (
+    BinaryClassificationMetricsConfig,
+    MulticlassClassificationMetricsConfig,
+    MultilabelClassificationMetricsConfig,
+)
 from raitap.metrics.registration import register_metrics_adapter
-from raitap.types import Task
 from raitap.utils.lazy import lazy_import
 
 from .base_metric_computer import BaseMetricComputer, MetricResult
@@ -17,80 +21,24 @@ else:
     # ``metrics`` extra installed (e.g. during ``raitap.run(..., auto_install=True)``).
     torchmetrics = lazy_import("torchmetrics")
 
-__all__ = ["Average", "ClassificationMetrics", "Task"]
+__all__ = [
+    "Average",
+    "BinaryClassificationMetrics",
+    "MulticlassClassificationMetrics",
+    "MultilabelClassificationMetrics",
+]
 
 Average = Literal["micro", "macro", "weighted", "none"]
 
 
-@register_metrics_adapter(registry_name="classification", extra="metrics")
-class ClassificationMetrics(BaseMetricComputer):
-    """
-    Classification metrics using torchmetrics
+class _ClassificationBase(BaseMetricComputer):
+    """Shared update/compute/reset/device wiring; subclasses build the metric quartet."""
 
-    Supports:
-        - Task: binary, multiclass, multilabel
-        - Average: micro, macro, weighted, none
-
-    Notes:
-        - If average="none", metric outputs are per-class/per-label vectors
-            and are stored in artifacts.
-        - For multilabel, you may want to pass threshold=0.5 (default) in kwargs.
-    """
-
-    def __init__(
-        self,
-        *,
-        task: Task | str = Task.multiclass,
-        num_classes: int | None = None,
-        num_labels: int | None = None,
-        average: Average = "macro",
-        ignore_index: int | None = None,
-        **kwargs: Any,
-    ):
-        task = Task(task)
-        if task not in ["binary", "multiclass", "multilabel"]:
-            raise ValueError(f"Unknown task '{task}'. Use 'binary', 'multiclass' or 'multilabel'.")
-
-        # Start building arguments dictionary
-        tm_task_kwargs: dict[str, Any] = {"task": task, **kwargs}
-
-        if task == "multiclass":
-            if num_classes is None or num_classes <= 0:
-                raise ValueError("For task='multiclass', you must provide num_classes > 0.")
-            tm_task_kwargs["num_classes"] = num_classes
-            tm_task_kwargs["ignore_index"] = ignore_index
-
-        elif task == "multilabel":
-            # TorchMetrics uses num_labels for multilabel
-            if num_labels is None:
-                # allow num_classes as alias for num_labels
-                if num_classes is None:
-                    raise ValueError(
-                        "For task='multilabel', provide num_labels (or num_classes as alias)."
-                    )
-                num_labels = num_classes
-            if num_labels <= 0:
-                raise ValueError("For task='multilabel', num_labels must be > 0.")
-            tm_task_kwargs["num_labels"] = num_labels
-            tm_task_kwargs["ignore_index"] = ignore_index
-            # If no threshold is provided, use default of 0.5
-            tm_task_kwargs.setdefault("threshold", 0.5)
-        else:
-            # Binary task
-            tm_task_kwargs["ignore_index"] = ignore_index
-
-        # Handle average argument
-        avg_kwargs: dict[str, Any] = {}
-        if task in ("multiclass", "multilabel"):
-            avg_kwargs["average"] = average
-
-        self.task = task
-        self.average = average
-
-        self.accuracy = torchmetrics.Accuracy(**tm_task_kwargs, **avg_kwargs)
-        self.precision = torchmetrics.Precision(**tm_task_kwargs, **avg_kwargs)
-        self.recall = torchmetrics.Recall(**tm_task_kwargs, **avg_kwargs)
-        self.f1 = torchmetrics.F1Score(**tm_task_kwargs, **avg_kwargs)
+    accuracy: Any
+    precision: Any
+    recall: Any
+    f1: Any
+    average: Average | None
 
     def _move_to_device(self, device: torch.device | None) -> None:
         if device is None:
@@ -111,11 +59,8 @@ class ClassificationMetrics(BaseMetricComputer):
         prec = self.precision.compute()
         rec = self.recall.compute()
         f1 = self.f1.compute()
-
         metrics: dict[str, float] = {}
         artifacts: dict[str, Any] = {}
-
-        # When average ist "none", store per-class/per-label metrics in artifacts
         if self.average == "none":
             artifacts["accuracy"] = tensor_to_python(acc)
             artifacts["precision"] = tensor_to_python(prec)
@@ -133,3 +78,91 @@ class ClassificationMetrics(BaseMetricComputer):
         self.precision.reset()
         self.recall.reset()
         self.f1.reset()
+
+    def _init_quartet(self, **tm_kwargs: Any) -> None:
+        self.accuracy = torchmetrics.Accuracy(**tm_kwargs)
+        self.precision = torchmetrics.Precision(**tm_kwargs)
+        self.recall = torchmetrics.Recall(**tm_kwargs)
+        self.f1 = torchmetrics.F1Score(**tm_kwargs)
+
+
+@register_metrics_adapter(
+    registry_name="binary_classification",
+    extra="metrics",
+    schema=BinaryClassificationMetricsConfig,
+)
+class BinaryClassificationMetrics(_ClassificationBase):
+    """Binary classification metrics (accuracy, precision, recall, F1)."""
+
+    def __init__(
+        self,
+        *,
+        ignore_index: int | None = None,
+        threshold: float = 0.5,
+        **kwargs: Any,
+    ) -> None:
+        self.average = None
+        self._init_quartet(
+            task="binary",
+            ignore_index=ignore_index,
+            threshold=threshold,
+            **kwargs,
+        )
+
+
+@register_metrics_adapter(
+    registry_name="multiclass_classification",
+    extra="metrics",
+    schema=MulticlassClassificationMetricsConfig,
+)
+class MulticlassClassificationMetrics(_ClassificationBase):
+    """Multiclass classification metrics (accuracy, precision, recall, F1)."""
+
+    def __init__(
+        self,
+        *,
+        num_classes: int,
+        average: Average = "macro",
+        ignore_index: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if num_classes <= 0:
+            raise ValueError("num_classes must be > 0.")
+        self.average = average
+        self._init_quartet(
+            task="multiclass",
+            num_classes=num_classes,
+            average=average,
+            ignore_index=ignore_index,
+            **kwargs,
+        )
+
+
+@register_metrics_adapter(
+    registry_name="multilabel_classification",
+    extra="metrics",
+    schema=MultilabelClassificationMetricsConfig,
+)
+class MultilabelClassificationMetrics(_ClassificationBase):
+    """Multilabel classification metrics (accuracy, precision, recall, F1)."""
+
+    def __init__(
+        self,
+        *,
+        num_labels: int,
+        average: Average = "macro",
+        ignore_index: int | None = None,
+        threshold: float = 0.5,
+        **kwargs: Any,
+    ) -> None:
+        if num_labels <= 0:
+            raise ValueError("num_labels must be > 0.")
+        self.average = average
+        self._init_quartet(
+            task="multilabel",
+            num_labels=num_labels,
+            average=average,
+            ignore_index=ignore_index,
+            threshold=threshold,
+            **kwargs,
+        )

--- a/src/raitap/metrics/detection_metrics.py
+++ b/src/raitap/metrics/detection_metrics.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal
 
+from raitap.configs.schema import DetectionMetricsConfig, IoUConfig
 from raitap.metrics.registration import register_metrics_adapter
 from raitap.utils.lazy import lazy_import
 
@@ -24,7 +25,19 @@ Backend = Literal["pycocotools", "faster_coco_eval"]
 Average = Literal["macro", "micro"]
 
 
-@register_metrics_adapter(registry_name="detection", extra="metrics")
+def _coerce_iou(iou: IoUConfig | dict[str, Any] | None) -> IoUConfig:
+    if iou is None:
+        return IoUConfig()
+    if isinstance(iou, IoUConfig):
+        return iou
+    return IoUConfig(**iou)
+
+
+@register_metrics_adapter(
+    registry_name="detection",
+    extra="metrics",
+    schema=DetectionMetricsConfig,
+)
 class DetectionMetrics(BaseMetricComputer):
     """
     Calculates and manages detection metrics for evaluating
@@ -44,22 +57,20 @@ class DetectionMetrics(BaseMetricComputer):
         self,
         *,
         box_format: BoxFormat = "xyxy",
-        iou_type: IoUType = "bbox",
-        iou_thresholds: list[float] | None = None,
-        rec_thresholds: list[float] | None = None,
-        max_detection_thresholds: list[int] | None = None,
+        iou: IoUConfig | dict[str, Any] | None = None,
         class_metrics: bool = False,
         extended_summary: bool = False,
         average: Average = "macro",
         backend: Backend = "faster_coco_eval",
         **kwargs: Any,
     ):
+        iou_cfg = _coerce_iou(iou)
         self.metric = _tm_detection_mean_ap.MeanAveragePrecision(
             box_format=box_format,
-            iou_type=iou_type,
-            iou_thresholds=iou_thresholds,
-            rec_thresholds=rec_thresholds,
-            max_detection_thresholds=max_detection_thresholds,
+            iou_type=iou_cfg.type,
+            iou_thresholds=iou_cfg.thresholds,
+            rec_thresholds=iou_cfg.rec_thresholds,
+            max_detection_thresholds=iou_cfg.max_detection_thresholds,
             class_metrics=class_metrics,
             extended_summary=extended_summary,
             average=average,

--- a/src/raitap/metrics/tests/test_classification_metrics.py
+++ b/src/raitap/metrics/tests/test_classification_metrics.py
@@ -1,320 +1,79 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 import torch
 
-from raitap.metrics import ClassificationMetrics
+from raitap.metrics import (
+    BinaryClassificationMetrics,
+    MulticlassClassificationMetrics,
+    MultilabelClassificationMetrics,
+)
 
 
-class _DeviceAwareMetricSpy:
-    def __init__(self) -> None:
-        self.devices: list[torch.device] = []
+class TestBinary:
+    def test_perfect_predictions(self) -> None:
+        m = BinaryClassificationMetrics()
+        m.update(torch.tensor([1, 0, 1, 0, 1]), torch.tensor([1, 0, 1, 0, 1]))
+        r = m.compute()
+        assert r.metrics["accuracy"] == pytest.approx(1.0)
+        assert r.metrics["precision"] == pytest.approx(1.0)
+        assert r.metrics["recall"] == pytest.approx(1.0)
+        assert r.metrics["f1"] == pytest.approx(1.0)
 
-    def to(self, device: torch.device) -> _DeviceAwareMetricSpy:
-        self.devices.append(device)
-        return self
-
-
-class TestClassificationMetricsInitialization:
-    """Test ClassificationMetrics initialization and validation."""
-
-    @pytest.mark.parametrize(
-        ("task", "num_classes", "num_labels", "match"),
-        [
-            ("invalid", 3, None, "not a valid Task"),
-            ("multiclass", None, None, "must provide num_classes > 0"),
-            ("multiclass", 0, None, "must provide num_classes > 0"),
-            ("multilabel", None, None, "provide num_labels"),
-            ("multilabel", None, 0, "num_labels must be > 0"),
-        ],
-    )
-    def test_initialization_errors(
-        self, task: Any, num_classes: Any, num_labels: Any, match: str
-    ) -> None:
-        """Test that invalid configurations raise appropriate errors."""
-        with pytest.raises(ValueError, match=match):
-            ClassificationMetrics(
-                task=task,
-                num_classes=num_classes,
-                num_labels=num_labels,
-                average="macro",
-                ignore_index=None,
-            )
-
-    @pytest.mark.parametrize(
-        ("task", "num_classes", "num_labels", "average"),
-        [
-            ("multilabel", 3, None, "macro"),
-            ("binary", None, None, "macro"),
-            ("multiclass", 5, None, "weighted"),
-            ("multilabel", None, 4, "micro"),
-        ],
-    )
-    def test_successful_initialization(
-        self, task: Any, num_classes: Any, num_labels: Any, average: Any
-    ) -> None:
-        """Test successful initialization for different tasks."""
-        metrics = ClassificationMetrics(
-            task=task,
-            num_classes=num_classes,
-            num_labels=num_labels,
-            average=average,
-            ignore_index=None,
-        )
-        assert metrics.task == task
-        assert metrics.average == average
+    def test_reset_clears_state(self) -> None:
+        m = BinaryClassificationMetrics()
+        m.update(torch.tensor([1, 0, 1, 0]), torch.tensor([1, 0, 1, 0]))
+        m.reset()
+        m.update(torch.tensor([0, 0, 0, 0]), torch.tensor([1, 1, 1, 1]))
+        assert m.compute().metrics["accuracy"] == pytest.approx(0.0)
 
 
-class TestBinaryClassification:
-    """Test ClassificationMetrics for binary classification."""
+class TestMulticlass:
+    def test_requires_num_classes(self) -> None:
+        with pytest.raises(TypeError):
+            MulticlassClassificationMetrics()  # type: ignore[call-arg]
 
-    @pytest.fixture
-    def binary_metrics(self) -> ClassificationMetrics:
-        """Create a binary classification metrics instance."""
-        return ClassificationMetrics(
-            task="binary", num_classes=None, num_labels=None, average="macro", ignore_index=None
-        )
+    def test_rejects_non_positive_num_classes(self) -> None:
+        with pytest.raises(ValueError, match="num_classes must be > 0"):
+            MulticlassClassificationMetrics(num_classes=0)
 
-    def test_perfect_predictions(self, binary_metrics: ClassificationMetrics) -> None:
-        """Test metrics with perfect predictions."""
-        predictions = torch.tensor([1, 0, 1, 0, 1])
-        targets = torch.tensor([1, 0, 1, 0, 1])
+    def test_perfect_predictions(self) -> None:
+        m = MulticlassClassificationMetrics(num_classes=3)
+        m.update(torch.tensor([0, 1, 2, 0, 1, 2]), torch.tensor([0, 1, 2, 0, 1, 2]))
+        r = m.compute()
+        assert r.metrics["accuracy"] == pytest.approx(1.0)
 
-        binary_metrics.update(predictions, targets)
-        result = binary_metrics.compute()
-
-        assert result.metrics["accuracy"] == pytest.approx(1.0)
-        assert result.metrics["precision"] == pytest.approx(1.0)
-        assert result.metrics["recall"] == pytest.approx(1.0)
-        assert result.metrics["f1"] == pytest.approx(1.0)
-        assert len(result.artifacts) == 0
-
-    def test_imperfect_predictions(self, binary_metrics: ClassificationMetrics) -> None:
-        """Test metrics with some errors."""
-        predictions = torch.tensor([1, 0, 1, 1, 0])
-        targets = torch.tensor([1, 0, 1, 0, 1])
-
-        binary_metrics.update(predictions, targets)
-        result = binary_metrics.compute()
-
-        assert 0.0 < result.metrics["accuracy"] < 1.0
-        assert 0.0 < result.metrics["precision"] < 1.0
-        assert 0.0 < result.metrics["recall"] < 1.0
-        assert 0.0 < result.metrics["f1"] < 1.0
-
-    def test_reset_clears_state(self, binary_metrics: ClassificationMetrics) -> None:
-        """Test that reset clears accumulated state."""
-        predictions = torch.tensor([1, 0, 1, 0])
-        targets = torch.tensor([1, 0, 1, 0])
-
-        binary_metrics.update(predictions, targets)
-        binary_metrics.reset()
-
-        # After reset, compute should give different results
-        predictions_new = torch.tensor([0, 0, 0, 0])
-        targets_new = torch.tensor([1, 1, 1, 1])
-
-        binary_metrics.update(predictions_new, targets_new)
-        result = binary_metrics.compute()
-
-        # All wrong predictions
-        assert result.metrics["accuracy"] == pytest.approx(0.0)
-        assert result.metrics["recall"] == pytest.approx(0.0)
-
-    def test_multiple_updates(self, binary_metrics: ClassificationMetrics) -> None:
-        """Test that multiple updates accumulate correctly."""
-        # First batch
-        binary_metrics.update(torch.tensor([1, 1]), torch.tensor([1, 1]))
-        # Second batch
-        binary_metrics.update(torch.tensor([0, 0]), torch.tensor([0, 0]))
-
-        result = binary_metrics.compute()
-        assert result.metrics["accuracy"] == pytest.approx(1.0)
-
-    def test_prepare_inputs_moves_metric_state_and_targets_to_prediction_device(self) -> None:
-        metrics = ClassificationMetrics(
-            task="binary", num_classes=None, num_labels=None, average="macro", ignore_index=None
-        )
-        accuracy = _DeviceAwareMetricSpy()
-        precision = _DeviceAwareMetricSpy()
-        recall = _DeviceAwareMetricSpy()
-        f1 = _DeviceAwareMetricSpy()
-        metrics.accuracy = accuracy  # type: ignore[assignment]
-        metrics.precision = precision  # type: ignore[assignment]
-        metrics.recall = recall  # type: ignore[assignment]
-        metrics.f1 = f1  # type: ignore[assignment]
-
-        predictions = torch.empty((2,), dtype=torch.int64, device="meta")
-        targets = torch.tensor([1, 0], dtype=torch.int64)
-
-        prepared_predictions, prepared_targets = metrics._prepare_inputs(predictions, targets)
-
-        assert prepared_predictions.device.type == "meta"
-        assert prepared_targets.device.type == "meta"
-        expected_device = torch.device("meta")
-        assert accuracy.devices == [expected_device]
-        assert precision.devices == [expected_device]
-        assert recall.devices == [expected_device]
-        assert f1.devices == [expected_device]
-
-
-class TestMulticlassClassification:
-    """Test ClassificationMetrics for multiclass classification."""
-
-    @pytest.fixture
-    def multiclass_metrics(self) -> ClassificationMetrics:
-        """Create a multiclass metrics instance."""
-        return ClassificationMetrics(
-            task="multiclass", num_classes=3, num_labels=None, average="macro", ignore_index=None
-        )
-
-    def test_perfect_predictions(self, multiclass_metrics: ClassificationMetrics) -> None:
-        """Test metrics with perfect predictions."""
-        predictions = torch.tensor([0, 1, 2, 0, 1, 2])
-        targets = torch.tensor([0, 1, 2, 0, 1, 2])
-
-        multiclass_metrics.update(predictions, targets)
-        result = multiclass_metrics.compute()
-
-        assert result.metrics["accuracy"] == pytest.approx(1.0)
-        assert result.metrics["precision"] == pytest.approx(1.0)
-        assert result.metrics["recall"] == pytest.approx(1.0)
-        assert result.metrics["f1"] == pytest.approx(1.0)
-
-    def test_weighted_average(self) -> None:
-        """Test with weighted average."""
-        metrics = ClassificationMetrics(
-            task="multiclass", num_classes=3, num_labels=None, average="weighted", ignore_index=None
-        )
-
-        predictions = torch.tensor([0, 1, 2, 0, 1, 2])
-        targets = torch.tensor([0, 1, 2, 0, 1, 2])
-
-        metrics.update(predictions, targets)
-        result = metrics.compute()
-
-        assert result.metrics["accuracy"] == pytest.approx(1.0)
-        assert result.metrics["precision"] == pytest.approx(1.0)
-
-    def test_micro_average(self) -> None:
-        """Test with micro average."""
-        metrics = ClassificationMetrics(
-            task="multiclass", num_classes=3, num_labels=None, average="micro", ignore_index=None
-        )
-
-        predictions = torch.tensor([0, 1, 2, 0, 1])
-        targets = torch.tensor([0, 1, 2, 0, 1])
-
-        metrics.update(predictions, targets)
-        result = metrics.compute()
-
-        assert result.metrics["accuracy"] == pytest.approx(1.0)
-
-    def test_none_average_stores_artifacts(self) -> None:
-        """Test that average='none' stores per-class metrics in artifacts."""
-        metrics = ClassificationMetrics(
-            task="multiclass", num_classes=3, num_labels=None, average="none", ignore_index=None
-        )
-
-        predictions = torch.tensor([0, 1, 2, 0, 1, 2])
-        targets = torch.tensor([0, 1, 2, 0, 1, 2])
-
-        metrics.update(predictions, targets)
-        result = metrics.compute()
-
-        # With average='none', metrics should be in artifacts, not metrics dict
-        assert len(result.metrics) == 0
-        assert "accuracy" in result.artifacts
-        assert "precision" in result.artifacts
-        assert "recall" in result.artifacts
-        assert "f1" in result.artifacts
-
-        # Each should be a list (per-class values)
-        assert isinstance(result.artifacts["accuracy"], list)
-        assert len(result.artifacts["accuracy"]) == 3
+    def test_average_none_stores_artifacts(self) -> None:
+        m = MulticlassClassificationMetrics(num_classes=3, average="none")
+        m.update(torch.tensor([0, 1, 2, 0, 1, 2]), torch.tensor([0, 1, 2, 0, 1, 2]))
+        r = m.compute()
+        assert len(r.metrics) == 0
+        assert "accuracy" in r.artifacts
+        assert len(r.artifacts["accuracy"]) == 3
 
     def test_ignore_index(self) -> None:
-        """Test that ignore_index works correctly."""
-        metrics = ClassificationMetrics(
-            task="multiclass", num_classes=3, num_labels=None, average="macro", ignore_index=-100
-        )
-
-        # Include some samples with ignore_index
-        predictions = torch.tensor([0, 1, 2, 0])
-        targets = torch.tensor([0, 1, -100, 0])  # Third sample should be ignored
-
-        metrics.update(predictions, targets)
-        result = metrics.compute()
-
-        # Should only consider the 3 valid samples
-        assert result.metrics["accuracy"] == pytest.approx(1.0)
+        m = MulticlassClassificationMetrics(num_classes=3, ignore_index=-100)
+        m.update(torch.tensor([0, 1, 2, 0]), torch.tensor([0, 1, -100, 0]))
+        assert m.compute().metrics["accuracy"] == pytest.approx(1.0)
 
 
-class TestMultilabelClassification:
-    """Test ClassificationMetrics for multilabel classification."""
+class TestMultilabel:
+    def test_requires_num_labels(self) -> None:
+        with pytest.raises(TypeError):
+            MultilabelClassificationMetrics()  # type: ignore[call-arg]
 
-    @pytest.fixture
-    def multilabel_metrics(self) -> ClassificationMetrics:
-        """Create a multilabel metrics instance."""
-        return ClassificationMetrics(
-            task="multilabel",
-            num_classes=None,
-            num_labels=3,
-            average="macro",
-            ignore_index=None,
-            threshold=0.5,
-        )
+    def test_rejects_non_positive_num_labels(self) -> None:
+        with pytest.raises(ValueError, match="num_labels must be > 0"):
+            MultilabelClassificationMetrics(num_labels=0)
 
-    def test_perfect_predictions(self, multilabel_metrics: ClassificationMetrics) -> None:
-        """Test metrics with perfect predictions."""
-        predictions = torch.tensor([[1, 0, 1], [0, 1, 0], [1, 1, 0]])
+    def test_perfect_predictions(self) -> None:
+        m = MultilabelClassificationMetrics(num_labels=3)
+        preds = torch.tensor([[1, 0, 1], [0, 1, 0], [1, 1, 0]])
         targets = torch.tensor([[1, 0, 1], [0, 1, 0], [1, 1, 0]])
-
-        multilabel_metrics.update(predictions, targets)
-        result = multilabel_metrics.compute()
-
-        assert result.metrics["accuracy"] == pytest.approx(1.0)
-        assert result.metrics["precision"] == pytest.approx(1.0)
-        assert result.metrics["recall"] == pytest.approx(1.0)
-        assert result.metrics["f1"] == pytest.approx(1.0)
-
-    def test_none_average_stores_artifacts(self) -> None:
-        """Test that average='none' stores per-label metrics in artifacts."""
-        metrics = ClassificationMetrics(
-            task="multilabel", num_classes=None, num_labels=3, average="none", ignore_index=None
-        )
-
-        predictions = torch.tensor([[1, 0, 1], [0, 1, 0]])
-        targets = torch.tensor([[1, 0, 1], [0, 1, 0]])
-
-        metrics.update(predictions, targets)
-        result = metrics.compute()
-
-        # With average='none', metrics should be in artifacts
-        assert len(result.metrics) == 0
-        assert "accuracy" in result.artifacts
-        assert "precision" in result.artifacts
-        assert "recall" in result.artifacts
-        assert "f1" in result.artifacts
-
-        # Each should be a list (per-label values)
-        assert isinstance(result.artifacts["precision"], list)
-        assert len(result.artifacts["precision"]) == 3
+        m.update(preds, targets)
+        assert m.compute().metrics["accuracy"] == pytest.approx(1.0)
 
     def test_default_threshold(self) -> None:
-        """Test that default threshold of 0.5 is applied."""
-        # Don't pass threshold explicitly
-        metrics = ClassificationMetrics(
-            task="multilabel", num_classes=None, num_labels=2, average="macro", ignore_index=None
-        )
-
-        # Binary predictions work with default threshold
-        predictions = torch.tensor([[1, 0], [0, 1]])
-        targets = torch.tensor([[1, 0], [0, 1]])
-
-        metrics.update(predictions, targets)
-        result = metrics.compute()
-
-        assert result.metrics["accuracy"] == pytest.approx(1.0)
+        m = MultilabelClassificationMetrics(num_labels=2)
+        m.update(torch.tensor([[1, 0], [0, 1]]), torch.tensor([[1, 0], [0, 1]]))
+        assert m.compute().metrics["accuracy"] == pytest.approx(1.0)

--- a/src/raitap/metrics/tests/test_config_schema.py
+++ b/src/raitap/metrics/tests/test_config_schema.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+from hydra_zen import instantiate
+
+from raitap._adapters import _BUILDERS
+
+
+def test_detection_builder_carries_nested_iou_field() -> None:
+    import dataclasses
+
+    builder = _BUILDERS["metrics"]["detection"]
+    fields = {f.name: f for f in dataclasses.fields(builder)}
+    assert "iou" in fields
+    iou_field_type = fields["iou"].type
+    assert "IoUConfig" in repr(iou_field_type) or "iou" in str(iou_field_type).lower()
+
+
+@pytest.mark.parametrize(
+    "registry_name",
+    ["binary_classification", "multiclass_classification", "multilabel_classification"],
+)
+def test_classification_builders_have_no_cross_task_fields(registry_name: str) -> None:
+    import dataclasses
+
+    builder = _BUILDERS["metrics"][registry_name]
+    field_names = {f.name for f in dataclasses.fields(builder)}
+    if registry_name == "binary_classification":
+        assert "num_classes" not in field_names
+        assert "num_labels" not in field_names
+        assert "average" not in field_names
+    if registry_name == "multiclass_classification":
+        assert "num_labels" not in field_names
+        assert "threshold" not in field_names
+    if registry_name == "multilabel_classification":
+        assert "num_classes" not in field_names
+
+
+def test_detection_instantiate_with_nested_iou() -> None:
+    pytest.importorskip("torchmetrics")
+    pytest.importorskip("faster_coco_eval")
+    cfg = {
+        "_target_": "raitap.metrics.DetectionMetrics",
+        "_convert_": "all",
+        "iou": {"type": "bbox", "thresholds": [0.5]},
+    }
+    metric = instantiate(cfg)
+    assert metric.metric.iou_thresholds == [0.5]

--- a/src/raitap/metrics/tests/test_detection_metrics.py
+++ b/src/raitap/metrics/tests/test_detection_metrics.py
@@ -5,7 +5,25 @@ from typing import Any
 import pytest
 import torch
 
+from raitap.configs.schema import IoUConfig
 from raitap.metrics import DetectionMetrics
+
+
+class TestDetectionMetricsIoUNesting:
+    def test_iou_as_dataclass(self) -> None:
+        m = DetectionMetrics(iou=IoUConfig(type="bbox", thresholds=[0.5, 0.75]))
+        assert m.metric.iou_thresholds == [0.5, 0.75]
+
+    def test_iou_as_dict(self) -> None:
+        m = DetectionMetrics(iou={"type": "bbox", "thresholds": [0.25]})
+        assert m.metric.iou_thresholds == [0.25]
+
+    def test_iou_defaults_use_coco_thresholds(self) -> None:
+        m = DetectionMetrics()
+        # torchmetrics fills COCO defaults when our iou_thresholds=None reaches it.
+        assert m.metric.iou_thresholds[0] == pytest.approx(0.5)
+        assert m.metric.iou_thresholds[-1] == pytest.approx(0.95)
+        assert len(m.metric.iou_thresholds) == 10
 
 
 class _DeviceAwareMapSpy:
@@ -26,12 +44,12 @@ class TestDetectionMetricsInitialization:
             {},
             {"box_format": "xyxy"},
             {"box_format": "xywh"},
-            {"iou_type": "bbox"},
-            {"iou_type": "segm"},
-            {"iou_type": ("bbox", "segm")},
-            {"iou_thresholds": [0.5, 0.75]},
-            {"rec_thresholds": [0.0, 0.5, 1.0]},
-            {"max_detection_thresholds": [1, 10, 100]},
+            {"iou": {"type": "bbox"}},
+            {"iou": {"type": "segm"}},
+            {"iou": {"type": ("bbox", "segm")}},
+            {"iou": {"thresholds": [0.5, 0.75]}},
+            {"iou": {"rec_thresholds": [0.0, 0.5, 1.0]}},
+            {"iou": {"max_detection_thresholds": [1, 10, 100]}},
             {"class_metrics": True},
             {"extended_summary": True},
             {"average": "macro"},
@@ -41,14 +59,7 @@ class TestDetectionMetricsInitialization:
     )
     def test_initialization(self, kwargs: dict[str, Any]) -> None:
         """Test initialization with various valid parameters."""
-        # Ensure thresholds are always None unless specified to avoid mixing
-        full_kwargs: dict[str, Any] = {
-            "iou_thresholds": None,
-            "rec_thresholds": None,
-            "max_detection_thresholds": None,
-        }
-        full_kwargs.update(kwargs)
-        metrics = DetectionMetrics(**full_kwargs)
+        metrics = DetectionMetrics(**kwargs)
         assert metrics.metric is not None
 
 
@@ -58,9 +69,7 @@ class TestDetectionMetricsUpdate:
     @pytest.fixture
     def detection_metrics(self) -> DetectionMetrics:
         """Create a detection metrics instance."""
-        return DetectionMetrics(
-            iou_thresholds=None, rec_thresholds=None, max_detection_thresholds=None
-        )
+        return DetectionMetrics()
 
     def test_update_with_valid_data(self, detection_metrics: DetectionMetrics) -> None:
         """Test update with valid predictions and targets."""
@@ -84,9 +93,7 @@ class TestDetectionMetricsUpdate:
     def test_prepare_inputs_moves_metric_state_and_nested_targets_to_prediction_device(
         self,
     ) -> None:
-        detection_metrics = DetectionMetrics(
-            iou_thresholds=None, rec_thresholds=None, max_detection_thresholds=None
-        )
+        detection_metrics = DetectionMetrics()
         metric_spy = _DeviceAwareMapSpy()
         detection_metrics.metric = metric_spy  # type: ignore[assignment]
 
@@ -263,9 +270,7 @@ class TestDetectionMetricsCompute:
     @pytest.fixture
     def detection_metrics(self) -> DetectionMetrics:
         """Create a detection metrics instance."""
-        return DetectionMetrics(
-            iou_thresholds=None, rec_thresholds=None, max_detection_thresholds=None
-        )
+        return DetectionMetrics()
 
     def test_compute_returns_metric_result(self, detection_metrics: DetectionMetrics) -> None:
         """Test that compute returns a MetricResult object."""
@@ -346,12 +351,7 @@ class TestDetectionMetricsCompute:
 
     def test_compute_with_multiple_classes(self) -> None:
         """Test compute with multiple object classes."""
-        metrics = DetectionMetrics(
-            class_metrics=True,
-            iou_thresholds=None,
-            rec_thresholds=None,
-            max_detection_thresholds=None,
-        )
+        metrics = DetectionMetrics(class_metrics=True)
 
         predictions = [
             {
@@ -404,9 +404,7 @@ class TestDetectionMetricsReset:
     @pytest.fixture
     def detection_metrics(self) -> DetectionMetrics:
         """Create a detection metrics instance."""
-        return DetectionMetrics(
-            iou_thresholds=None, rec_thresholds=None, max_detection_thresholds=None
-        )
+        return DetectionMetrics()
 
     def test_reset_clears_state(self, detection_metrics: DetectionMetrics) -> None:
         """Test that reset clears accumulated state."""
@@ -456,9 +454,7 @@ class TestDetectionMetricsEdgeCases:
 
     def test_single_detection_single_target(self) -> None:
         """Test with a single detection and single target."""
-        metrics = DetectionMetrics(
-            iou_thresholds=None, rec_thresholds=None, max_detection_thresholds=None
-        )
+        metrics = DetectionMetrics()
 
         predictions = [
             {
@@ -482,9 +478,7 @@ class TestDetectionMetricsEdgeCases:
 
     def test_multiple_detections_per_image(self) -> None:
         """Test with multiple detections in a single image."""
-        metrics = DetectionMetrics(
-            iou_thresholds=None, rec_thresholds=None, max_detection_thresholds=None
-        )
+        metrics = DetectionMetrics()
 
         predictions = [
             {
@@ -518,12 +512,7 @@ class TestDetectionMetricsEdgeCases:
 
     def test_xywh_box_format(self) -> None:
         """Test with xywh box format."""
-        metrics = DetectionMetrics(
-            box_format="xywh",
-            iou_thresholds=None,
-            rec_thresholds=None,
-            max_detection_thresholds=None,
-        )
+        metrics = DetectionMetrics(box_format="xywh")
 
         # xywh format: [x_center, y_center, width, height]
         predictions = [
@@ -547,9 +536,7 @@ class TestDetectionMetricsEdgeCases:
 
     def test_large_batch(self) -> None:
         """Test with a large batch of images."""
-        metrics = DetectionMetrics(
-            iou_thresholds=None, rec_thresholds=None, max_detection_thresholds=None
-        )
+        metrics = DetectionMetrics()
 
         num_images = 100
         predictions = []

--- a/src/raitap/metrics/tests/test_factory_evaluate.py
+++ b/src/raitap/metrics/tests/test_factory_evaluate.py
@@ -11,10 +11,13 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from raitap.configs import set_output_root
-from raitap.configs.schema import AppConfig, MetricsConfig
+from raitap.configs.schema import (
+    AppConfig,
+    MetricsConfig,
+    MulticlassClassificationMetricsConfig,
+)
 from raitap.metrics import MetricsEvaluation, evaluate, metrics_run_enabled
 from raitap.metrics.base_metric_computer import BaseMetricComputer, MetricResult
-from raitap.types import Task
 
 
 def test_metrics_run_enabled_respects_empty_target(tmp_path: Path) -> None:
@@ -23,18 +26,14 @@ def test_metrics_run_enabled_respects_empty_target(tmp_path: Path) -> None:
     assert not metrics_run_enabled(cfg)  # metrics is None by default
     cfg.metrics = MetricsConfig(_target_="")
     assert not metrics_run_enabled(cfg)
-    cfg.metrics = MetricsConfig(_target_="ClassificationMetrics")
+    cfg.metrics = MetricsConfig(_target_="MulticlassClassificationMetrics")
     assert metrics_run_enabled(cfg)
 
 
 def _config(tmp_path: Path) -> AppConfig:
     cfg = AppConfig(experiment_name="test")
     set_output_root(cfg, tmp_path)
-    cfg.metrics = MetricsConfig(
-        _target_="ClassificationMetrics",
-        task=Task.multiclass,
-        num_classes=3,
-    )
+    cfg.metrics = MulticlassClassificationMetricsConfig(num_classes=3)
     return cfg
 
 
@@ -57,7 +56,7 @@ def test_evaluate_writes_outputs(tmp_path: Path) -> None:
     metadata = json.loads((run_dir / "metadata.json").read_text(encoding="utf-8"))
 
     assert "accuracy" in metrics
-    assert metadata["target"] == "raitap.metrics.ClassificationMetrics"
+    assert metadata["target"] == "raitap.metrics.MulticlassClassificationMetrics"
 
 
 def test_evaluate_bad_target_raises(tmp_path: Path) -> None:

--- a/src/raitap/metrics/tests/test_registration.py
+++ b/src/raitap/metrics/tests/test_registration.py
@@ -10,23 +10,30 @@ from raitap.metrics.base_metric_computer import BaseMetricComputer, MetricResult
 from raitap.metrics.registration import register_metrics_adapter
 
 
+@register_metrics_adapter(
+    registry_name="_stub_metric",
+    extra="_stub_extra",
+)
+class _StubMetric(BaseMetricComputer):
+    def __init__(self) -> None:
+        pass
+
+    def reset(self) -> None:
+        return None
+
+    def update(self, predictions: Any, targets: Any) -> None:
+        del predictions, targets
+
+    def compute(self) -> MetricResult:
+        return MetricResult(metrics={})
+
+
+# Module-scope registration is required so hydra-zen's ``builds(...)`` can
+# resolve a stable qualname (function-local classes hit the TypeError fallback
+# in ``_register_core``). Drop the resulting ``ADAPTER_EXTRAS`` entry so the
+# static-scan guard stays honest — see ``test_runtime_extras_subset_of_static_scan``.
+ADAPTER_EXTRAS.pop("_StubMetric", None)
+
+
 def test_register_metrics_adapter_registers_under_metrics_group() -> None:
-    @register_metrics_adapter(
-        registry_name="_stub_metric",
-        extra="_stub_extra",
-    )
-    class _StubMetric(BaseMetricComputer):
-        def __init__(self) -> None:
-            pass
-
-        def reset(self) -> None:
-            return None
-
-        def update(self, predictions: Any, targets: Any) -> None:
-            del predictions, targets
-
-        def compute(self) -> MetricResult:
-            return MetricResult(metrics={})
-
     assert "_stub_metric" in _BUILDERS["metrics"]
-    assert ADAPTER_EXTRAS["_StubMetric"] == "_stub_extra"

--- a/src/raitap/metrics/tests/test_registration_schema.py
+++ b/src/raitap/metrics/tests/test_registration_schema.py
@@ -20,7 +20,9 @@ class _DummyMetric(BaseMetricComputer):
     def __init__(self, *, knob: int = 0) -> None:
         self.knob = knob
 
-    def reset(self) -> None: ...
+    def reset(self) -> None:
+        return None
+
     def update(self, predictions: Any, targets: Any) -> None:
         del predictions, targets
 

--- a/src/raitap/metrics/tests/test_registration_schema.py
+++ b/src/raitap/metrics/tests/test_registration_schema.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Any
+
+from raitap._adapters import _BUILDERS, ADAPTER_EXTRAS
+from raitap.metrics.base_metric_computer import BaseMetricComputer, MetricResult
+from raitap.metrics.registration import register_metrics_adapter
+
+
+@dataclass
+class _DummyConfig:
+    _target_: str = ""
+    knob: int = 42
+
+
+@register_metrics_adapter(registry_name="dummy_schema_test", schema=_DummyConfig)
+class _DummyMetric(BaseMetricComputer):
+    def __init__(self, *, knob: int = 0) -> None:
+        self.knob = knob
+
+    def reset(self) -> None: ...
+    def update(self, predictions: Any, targets: Any) -> None:
+        del predictions, targets
+
+    def compute(self) -> MetricResult:
+        return MetricResult(metrics={"knob": float(self.knob)})
+
+
+# Module-level registration is required so hydra-zen's ``builds(...)`` can
+# resolve a stable qualname for ``_DummyMetric`` (function-local classes hit
+# the TypeError fallback in ``_register_core`` and never reach ``_BUILDERS``).
+# That however leaks into ``ADAPTER_EXTRAS`` which the static scanner refuses
+# to look at (it skips ``tests/``), so drop it here to keep
+# ``test_runtime_extras_subset_of_static_scan`` honest.
+ADAPTER_EXTRAS.pop("_DummyMetric", None)
+
+
+def test_per_adapter_schema_used_for_builder() -> None:
+    builder = _BUILDERS["metrics"]["dummy_schema_test"]
+    field_names = {f.name for f in dataclasses.fields(builder)}
+    assert "knob" in field_names

--- a/src/raitap/pipeline/phases/evaluate_metrics.py
+++ b/src/raitap/pipeline/phases/evaluate_metrics.py
@@ -41,7 +41,9 @@ def evaluate_metrics(
         and forward_output.ndim == 2
         and forward_output.shape[1] >= 2
     ):
-        config.metrics.num_classes = int(forward_output.shape[1])
+        # ``MetricsConfig`` base only carries ``_target_``; ``num_classes``
+        # lives on the multiclass typed subclass at runtime.
+        config.metrics.num_classes = int(forward_output.shape[1])  # type: ignore[attr-defined]
     preds, _ = metrics_prediction_pair(forward_output)
     targs = resolve_metric_targets(preds, labels)
     return Metrics(config, preds, targs)

--- a/src/raitap/tests/test_api.py
+++ b/src/raitap/tests/test_api.py
@@ -24,16 +24,16 @@ from raitap.api import instantiate
 from raitap.configs.schema import (
     DataConfig,
     LabelsConfig,
-    MetricsConfig,
     ModelConfig,
+    MulticlassClassificationMetricsConfig,
     RobustnessConfig,
     TransparencyConfig,
 )
-from raitap.metrics import classification as classification_metrics
+from raitap.metrics import multiclass_classification as classification_metrics
 from raitap.pipeline.outputs import RunOutputs
 from raitap.robustness import foolbox, torchattacks
 from raitap.transparency import captum, shap
-from raitap.types import Hardware, Task
+from raitap.types import Hardware
 
 
 def _configs_dir() -> Path:
@@ -56,7 +56,7 @@ def _demo_app_config() -> AppConfig:
                 column="label",
             ),
         ),
-        metrics=MetricsConfig(_target_="ClassificationMetrics", task=Task.multiclass),
+        metrics=MulticlassClassificationMetricsConfig(num_classes=1000),
         transparency={
             "default": TransparencyConfig(
                 _target_="CaptumExplainer",
@@ -106,11 +106,11 @@ def test_api_surface_exports_what_docs_will_reference() -> None:
 
 def test_classification_metrics_builder_instantiates_round_trip() -> None:
     """Sanity: the builder produces a config that Hydra can instantiate."""
-    from raitap.metrics.classification_metrics import ClassificationMetrics
+    from raitap.metrics.classification_metrics import MulticlassClassificationMetrics
 
-    cfg = classification_metrics(task="multiclass", num_classes=3)
+    cfg = classification_metrics(num_classes=3)
     instance = instantiate(cfg)
-    assert isinstance(instance, ClassificationMetrics)
+    assert isinstance(instance, MulticlassClassificationMetrics)
 
 
 def test_explainer_builders_accept_schema_fields() -> None:

--- a/src/raitap/tests/test_example_recipes.py
+++ b/src/raitap/tests/test_example_recipes.py
@@ -29,7 +29,7 @@ pytest.importorskip("torchmetrics")  # metrics adapter
 
 from raitap import AppConfig, Hardware, run
 from raitap.data import DataConfig, LabelsConfig
-from raitap.metrics import Task, classification
+from raitap.metrics import multiclass_classification as classification
 from raitap.models import ModelConfig
 from raitap.pipeline.outputs import RunOutputs
 from raitap.robustness import image_pair, torchattacks
@@ -66,7 +66,7 @@ def _base_kwargs(experiment_name: str) -> _BaseKwargs:
                 column="label",
             ),
         ),
-        "metrics": classification(task=Task.multiclass),
+        "metrics": classification(num_classes=1000),
         "reporting": None,  # skip report rendering for speed; recipes show ``html(...)``
     }
 

--- a/src/raitap/tests/test_run_labels.py
+++ b/src/raitap/tests/test_run_labels.py
@@ -30,7 +30,7 @@ class _BackendStub:
 def _minimal_run_config() -> SimpleNamespace:
     return SimpleNamespace(
         transparency={"default": {}},
-        metrics=SimpleNamespace(_target_="ClassificationMetrics", num_classes=None),
+        metrics=SimpleNamespace(_target_="MulticlassClassificationMetrics", num_classes=3),
     )
 
 

--- a/src/raitap/tests/test_run_main.py
+++ b/src/raitap/tests/test_run_main.py
@@ -166,7 +166,8 @@ def test_hydra_main_composes_default_config(monkeypatch: MonkeyPatch, tmp_path: 
     cfg = cast("AppConfig", captured["config"])
     assert cfg.model.source == "vit_b_32"
     assert cfg.metrics is not None
-    assert cfg.metrics._target_ == "ClassificationMetrics"
+    expected = "raitap.metrics.classification_metrics.MulticlassClassificationMetrics"
+    assert cfg.metrics._target_ == expected
     assert cfg.transparency
 
 
@@ -241,7 +242,8 @@ def test_hydra_main_loads_custom_config_name_from_cwd_and_keeps_packaged_default
     assert cfg.hardware == "cpu"
     assert cfg.model.source == "vit_b_32"
     assert cfg.metrics is not None
-    assert cfg.metrics._target_ == "ClassificationMetrics"
+    expected = "raitap.metrics.classification_metrics.MulticlassClassificationMetrics"
+    assert cfg.metrics._target_ == expected
     assert cfg.transparency
 
 

--- a/src/raitap/tracking/smoke_test_mlflow.py
+++ b/src/raitap/tracking/smoke_test_mlflow.py
@@ -11,13 +11,12 @@ from raitap.configs import set_output_root
 from raitap.configs.schema import (
     AppConfig,
     DataConfig,
-    MetricsConfig,
     ModelConfig,
+    MulticlassClassificationMetricsConfig,
     TrackingConfig,
     TransparencyConfig,
 )
 from raitap.pipeline import run
-from raitap.types import Task
 
 DEFAULT_TRACKING_URI = "http://127.0.0.1:5000"
 
@@ -102,9 +101,7 @@ def main() -> int:
                 visualisers=[{"_target_": "CaptumImageVisualiser"}],
             )
         },
-        metrics=MetricsConfig(
-            _target_="ClassificationMetrics",
-            task=Task.multiclass,
+        metrics=MulticlassClassificationMetricsConfig(
             num_classes=1000,
         ),
         tracking=TrackingConfig(

--- a/src/raitap/utils/lazy.py
+++ b/src/raitap/utils/lazy.py
@@ -10,12 +10,12 @@ needs the library — so::
     from raitap.utils.lazy import lazy_import
     torchmetrics = lazy_import("torchmetrics")
 
-    class ClassificationMetrics(...):
+    class MulticlassClassificationMetrics(...):
         def __init__(self) -> None:
             self.acc = torchmetrics.Accuracy(task="multiclass")
 
 …lets ``from raitap.metrics.classification_metrics import
-ClassificationMetrics`` succeed in a venv that has no ``torchmetrics``
+MulticlassClassificationMetrics`` succeed in a venv that has no ``torchmetrics``
 installed, as long as nobody actually constructs the class.
 
 Pair with a ``TYPE_CHECKING`` import so Pyright still sees the real

--- a/src/raitap/utils/lazy.py
+++ b/src/raitap/utils/lazy.py
@@ -11,8 +11,8 @@ needs the library — so::
     torchmetrics = lazy_import("torchmetrics")
 
     class MulticlassClassificationMetrics(...):
-        def __init__(self) -> None:
-            self.acc = torchmetrics.Accuracy(task="multiclass")
+        def __init__(self, *, num_classes: int) -> None:
+            self.acc = torchmetrics.Accuracy(task="multiclass", num_classes=num_classes)
 
 …lets ``from raitap.metrics.classification_metrics import
 MulticlassClassificationMetrics`` succeed in a venv that has no ``torchmetrics``


### PR DESCRIPTION
Closes #52.

## Summary

- **Classification split** — `ClassificationMetrics` (single adapter with a `task` discriminator + conditional `num_classes`/`num_labels`/`threshold`) replaced by three task-specific adapters: `BinaryClassificationMetrics`, `MulticlassClassificationMetrics`, `MultilabelClassificationMetrics`. Each accepts only the kwargs valid for its task — no more silent `num_classes`-as-`num_labels` aliasing.
- **Detection iou nesting** — flat `iou_type` / `iou_thresholds` / `rec_thresholds` / `max_detection_thresholds` collapsed under a single `iou:` sub-block backed by a typed `IoUConfig` dataclass.
- **Typed schemas** — five new dataclasses in `raitap.configs.schema` (`IoUConfig`, three classification configs, `DetectionMetricsConfig`) wired through hydra-zen via a new per-adapter `schema=` override on `register_*_adapter`.
- **Labels-missing warning** for #52's second ask is already in place at `src/raitap/metrics/inputs.py:36`; no action needed there.

## Breaking changes (BREAKING CHANGE — `!` in title)

- `_target_: ClassificationMetrics` + `task:` is gone. Pick the adapter directly:
  - `_target_: BinaryClassificationMetrics`
  - `_target_: MulticlassClassificationMetrics` (+ `num_classes`)
  - `_target_: MultilabelClassificationMetrics` (+ `num_labels`)
- Detection: `iou_type` / `iou_thresholds` / `rec_thresholds` / `max_detection_thresholds` now live under `iou:`:
  ```yaml
  metrics:
    _target_: DetectionMetrics
    iou:
      type: bbox
      thresholds: [0.5, 0.75]
  ```
- `MetricsConfig` trimmed to `_target_` only; per-task configs (`MulticlassClassificationMetricsConfig` etc.) carry their own fields. Python-API callers using `MetricsConfig(task=..., num_classes=...)` switch to the typed config.
- `Task` enum no longer re-exported from `raitap.metrics`; still available via `raitap.types`.

## Docs

- `docs/modules/metrics/configuration.md` rewritten: single `# Configuration` H1, then one H2 per adapter. Detection lists nested `iou.*` keys.
- Extended `config-page` directive with an optional `:slug:` field so multiple blocks coexist on one page (each gets unique cross-reference labels, sub-headings drop to bold inline so MyST's heading-hierarchy lint passes).

## Test plan

- [x] `uv run pytest -q` — 932 passed, 37 skipped
- [x] `uv run ruff check src/raitap docs contributor-configs` — clean
- [x] `uv run ruff format --check src/raitap docs contributor-configs` — clean
- [x] `uv run sphinx-build -b html docs docs/_build/html -W -q` — clean
- [x] Demo compose smoke (`raitap.configs/demo.yaml`) returns `MulticlassClassificationMetrics` + `num_classes: 1000`

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-18-metrics-config-grouping-design.md`
- Plan: `docs/superpowers/plans/2026-05-18-metrics-config-grouping.md`