### PR TITLE
fix(transparency): auto-upsample low-res attributions for blended_heat_map/heat_map

### DIFF
--- a/docs/modules/transparency/visualisers.md
+++ b/docs/modules/transparency/visualisers.md
@@ -63,12 +63,14 @@ token, and time-series layouts.
 
 Layer-based methods (`LayerGradCam`, `LayerActivation`, …) emit attribution
 maps at the chosen layer's spatial resolution (e.g. 7×7 for ResNet-18 `layer4`
-with 224×224 inputs). The visualiser bilinearly upsamples such maps to the
-original image size before rendering so the overlay aligns with the input
-extent across every `method`. The map still snaps to the layer's cell grid
-— this is intrinsic to Grad-CAM and not a visualiser artefact. For tighter
-localisation, use a shallower layer (e.g. `layer3` → 14×14) or a pixel-space
-method (`Saliency`, `IntegratedGradients`, `GuidedGradCam`).
+with 224×224 inputs). When `inputs` are provided, the visualiser bilinearly
+upsamples such maps to the original image size before rendering so the overlay
+aligns with the input extent — applied for every `method` except
+`original_image` (which ignores the attribution). The map still snaps to the
+layer's cell grid — this is intrinsic to Grad-CAM and not a visualiser
+artefact. For tighter localisation, use a shallower layer (e.g. `layer3` →
+14×14) or a pixel-space method (`Saliency`, `IntegratedGradients`,
+`GuidedGradCam`).
 
 ![CaptumImageVisualiser preview](../../_static/visualisers/captum_image_visualiser.png)
 

--- a/docs/modules/transparency/visualisers.md
+++ b/docs/modules/transparency/visualisers.md
@@ -61,6 +61,15 @@ Method families: `GRADIENT`, `PERTURBATION`, `SHAPLEY`, `CAM`,
 (`InputKind.IMAGE`) and an NCHW-compatible attribution shape; rejects tabular,
 token, and time-series layouts.
 
+Layer-based methods (`LayerGradCam`, `LayerActivation`, …) emit attribution
+maps at the chosen layer's spatial resolution (e.g. 7×7 for ResNet-18 `layer4`
+with 224×224 inputs). The visualiser bilinearly upsamples such maps to the
+original image size before rendering so the overlay aligns with the input
+extent across every `method`. The map still snaps to the layer's cell grid
+— this is intrinsic to Grad-CAM and not a visualiser artefact. For tighter
+localisation, use a shallower layer (e.g. `layer3` → 14×14) or a pixel-space
+method (`Saliency`, `IntegratedGradients`, `GuidedGradCam`).
+
 ![CaptumImageVisualiser preview](../../_static/visualisers/captum_image_visualiser.png)
 
 ### CaptumTimeSeriesVisualiser

--- a/src/raitap/transparency/visualisers/captum_visualisers.py
+++ b/src/raitap/transparency/visualisers/captum_visualisers.py
@@ -341,8 +341,9 @@ class CaptumImageVisualiser(BaseVisualiser):
                 orig_i = _normalise_image(orig_i)
 
                 # Layer methods (e.g., LayerGradCam) can yield low-res maps;
-                # masked modes need same HxW.
-                if self.method in {"masked_image", "alpha_scaling"}:
+                # bilinear-upsample so heat overlays align with the original
+                # image extent in matplotlib (also required for masked modes).
+                if self.method != "original_image":
                     attr_hw = attr_i.shape[:2]
                     orig_hw = orig_i.shape[:2]
                     if attr_hw != orig_hw:

--- a/src/raitap/transparency/visualisers/tests/test_visualisers.py
+++ b/src/raitap/transparency/visualisers/tests/test_visualisers.py
@@ -359,8 +359,9 @@ class TestCaptumImageVisualiser:
         fig = visualiser.visualise(attributions, inputs=inputs, max_samples=1)
 
         attr_axes = [ax for ax in fig.axes if getattr(ax, "images", None)]
-        heat_axes_image = attr_axes[-1].images[-1]
-        assert heat_axes_image.get_array().shape[:2] == (224, 224)
+        heat_array = attr_axes[-1].images[-1].get_array()
+        assert heat_array is not None
+        assert heat_array.shape[:2] == (224, 224)
 
     @pytest.mark.usefixtures("needs_captum")
     def test_save(self, sample_images: torch.Tensor, tmp_path: Path) -> None:

--- a/src/raitap/transparency/visualisers/tests/test_visualisers.py
+++ b/src/raitap/transparency/visualisers/tests/test_visualisers.py
@@ -350,6 +350,19 @@ class TestCaptumImageVisualiser:
         assert fig is not None
 
     @pytest.mark.usefixtures("needs_captum")
+    @pytest.mark.parametrize("method", ["blended_heat_map", "heat_map"])
+    def test_layer_methods_resize_low_res_attributions(self, method: str) -> None:
+        visualiser = CaptumImageVisualiser(method=method, sign="positive")
+        attributions = torch.randn(1, 1, 7, 7)
+        inputs = torch.rand(1, 3, 224, 224)
+
+        fig = visualiser.visualise(attributions, inputs=inputs, max_samples=1)
+
+        attr_axes = [ax for ax in fig.axes if getattr(ax, "images", None)]
+        heat_axes_image = attr_axes[-1].images[-1]
+        assert heat_axes_image.get_array().shape[:2] == (224, 224)
+
+    @pytest.mark.usefixtures("needs_captum")
     def test_save(self, sample_images: torch.Tensor, tmp_path: Path) -> None:
         visualiser = CaptumImageVisualiser(method="heat_map")
         attributions = torch.randn_like(sample_images)


### PR DESCRIPTION
## Summary
- Drop `{masked_image, alpha_scaling}` whitelist in `CaptumImageVisualiser`; bilinearly upsample low-res attributions to the original image size for every `method` (except `original_image`).
- Fixes blocky / misaligned overlays for layer methods (`LayerGradCam`, `LayerActivation`, …) where attribution resolution (e.g. 7×7) ≠ input resolution (e.g. 224×224). Without the resize, matplotlib's last `imshow` shrinks axes limits to the small array's extent, leaving the overlay misaligned with the input.
- Adds parametrised tests asserting the rendered heat axes-image matches the input H×W for `blended_heat_map` and `heat_map`.
- Docs: note auto-upsample + Grad-CAM intrinsic cell-grid behaviour in `docs/modules/transparency/visualisers.md`, with pointers to `layer3` / pixel-space methods for tighter localisation.

Closes #181.

## Test plan
- [x] `uv run pytest src/raitap/transparency/visualisers/tests/test_visualisers.py` — 90 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] `uv run pyright` clean
- [x] CI green