### PR TITLE
docs: document RAITAP_* environment variables

### DIFF
--- a/docs/modules/data/configuration.md
+++ b/docs/modules/data/configuration.md
@@ -46,8 +46,10 @@ myst:
   leaves the loader untouched; `"model-bundled"` pulls Resize + CenterCrop
   from the model's bundled torchvision preset (image models only); a `.py`
   path loads a factory decorated with `@raitap_preprocessing_factory`. The
-  `.py` path requires the `acknowledge_preprocessing_exec` kwarg or the
-  `--allow-preprocessing-exec` / `-yp` CLI flag. See {doc}`preprocessing`.
+  `.py` path requires the `acknowledge_preprocessing_exec` kwarg, the
+  `--allow-preprocessing-exec` / `-yp` CLI flag, or the
+  `RAITAP_ALLOW_PREPROCESSING_EXEC=1` env var. See {doc}`preprocessing` and
+  {ref}`environment-variables`.
 
 :option: model_input_transformation
 :allowed: null, "model-bundled", path string
@@ -62,8 +64,9 @@ myst:
   decorated with `@raitap_model_input_transformation_factory` and works
   for both Torch and ONNX backends. When both this and `preprocessing` are
   `null` and inputs are images, a loud warning fires — silence it with
-  `acknowledge_preprocessing_off` / `--acknowledge-preprocessing-off`.
-  See {doc}`preprocessing`.
+  `acknowledge_preprocessing_off` / `--acknowledge-preprocessing-off` /
+  `RAITAP_ACKNOWLEDGE_PREPROCESSING_OFF=1`. See {doc}`preprocessing` and
+  {ref}`environment-variables`.
 
 :option: labels.source
 :allowed: string, null

--- a/docs/modules/data/preprocessing.md
+++ b/docs/modules/data/preprocessing.md
@@ -26,8 +26,9 @@ The following values are allowed for both keys:
 - **`null`** (default): no preprocessing
 - **`"model-bundled"`**: use the preprocessing bundled inside the model file (e.g. `torchvision` models)
 - **path to a `.py` file**: load a user factory decorated with the matching
-  RAITAP decorator (see custom examples below). Gated by `--allow-preprocessing-exec` / `-yp` (CLI) or
-  `acknowledge_preprocessing_exec=True` (Python API).
+  RAITAP decorator (see custom examples below). Gated by `--allow-preprocessing-exec` / `-yp` (CLI),
+  `acknowledge_preprocessing_exec=True` (Python API), or `RAITAP_ALLOW_PREPROCESSING_EXEC=1`
+  ({ref}`env var <environment-variables>`).
 
 ## Examples
 

--- a/docs/modules/model/configuration.md
+++ b/docs/modules/model/configuration.md
@@ -41,8 +41,8 @@ myst:
 # Option A:
 # Full pickled nn.Module (deprecated, unsafe).
 # Only use for checkpoints from a fully trusted source; executes arbitrary code embedded in the checkpoint.
-# Consent must be supplied at invocation time. Use the `allow_unsafe_pickle=True` kwarg on `raitap.run(...)` (Python API) or
-# the `--allow-unsafe-pickle` CLI flag.
+# Consent must be supplied at invocation time. Use the `allow_unsafe_pickle=True` kwarg on `raitap.run(...)` (Python API),
+# the `--allow-unsafe-pickle` CLI flag, or set `RAITAP_ALLOW_UNSAFE_PICKLE=1` in the environment.
 model:
   source: "myModel.pth"
 

--- a/docs/modules/model/own-vs-built-in.md
+++ b/docs/modules/model/own-vs-built-in.md
@@ -24,7 +24,8 @@ RAITAP allows you to use your own model in any of the following supported format
   format requires unsafe pickle deserialisation, which executes arbitrary
   code embedded in the file. RAITAP refuses such checkpoints unless you
   explicitly opt in via the `allow_unsafe_pickle=True` kwarg on
-  `raitap.run(...)` (Python API) or the `--allow-unsafe-pickle` CLI flag,
+  `raitap.run(...)` (Python API), the `--allow-unsafe-pickle` CLI flag, or
+  the `RAITAP_ALLOW_UNSAFE_PICKLE=1` env var,
   and only do so for files from a fully trusted source. The pickle also embeds
   fully-qualified class paths so it breaks when classes are renamed or when
   torchvision is bumped. Migrate with one line (in a trusted environment):

--- a/docs/using-raitap/configuration/environment-variables.md
+++ b/docs/using-raitap/configuration/environment-variables.md
@@ -1,0 +1,96 @@
+---
+title: "Environment variables"
+description: "RAITAP-specific environment variables. These mirror the safety-consent CLI flags and let non-CLI entry points (Python API, CI runners, schedulers) opt in without parsing argv."
+myst:
+  html_meta:
+    "description": "RAITAP-specific environment variables. These mirror the safety-consent CLI flags and let non-CLI entry points (Python API, CI runners, schedulers) opt in without parsing argv."
+---
+
+(environment-variables)=
+
+# Environment variables
+
+RAITAP reads a small set of `RAITAP_*` environment variables. They all gate
+behaviour that carries an arbitrary-code or data-correctness risk, so they
+are off by default and must be opted into explicitly.
+
+Each variable mirrors a CLI flag and a Python-API kwarg. Prefer the flag or
+kwarg in interactive use; reach for the env var when invoking RAITAP from a
+wrapper script, CI job, or scheduler that cannot easily mutate `sys.argv`.
+
+The accepted truthy value is the literal string `"1"`. Any other value
+(including `"true"`, `"yes"`, an empty string, or the variable being unset)
+is treated as no consent.
+
+## `RAITAP_ALLOW_PREPROCESSING_EXEC`
+
+Consents to executing a user-supplied preprocessing factory loaded from a
+`.py` file pointed at by `data.preprocessing` or
+`data.model_input_transformation`. Without this consent, RAITAP refuses to
+import the file because doing so runs arbitrary Python at module load.
+
+| Surface | Equivalent |
+|---|---|
+| CLI | `--allow-preprocessing-exec` / `-yp` |
+| Python API | `acknowledge_preprocessing_exec=True` on `raitap.run(...)` |
+| Env var | `RAITAP_ALLOW_PREPROCESSING_EXEC=1` |
+
+See {doc}`../../modules/data/preprocessing` for the underlying mechanism.
+
+## `RAITAP_ACKNOWLEDGE_PREPROCESSING_OFF`
+
+Acknowledges that the run will proceed with no preprocessing on a code path
+where RAITAP would otherwise refuse to start (typical for pretrained image
+models that expect ImageNet normalisation). Use this when you genuinely want
+raw inputs to reach the model.
+
+| Surface | Equivalent |
+|---|---|
+| CLI | `--acknowledge-preprocessing-off` |
+| Python API | `acknowledge_preprocessing_off=True` on `raitap.run(...)` |
+| Env var | `RAITAP_ACKNOWLEDGE_PREPROCESSING_OFF=1` |
+
+See {doc}`../../modules/data/preprocessing` for the conditions that trigger
+the refusal.
+
+## `RAITAP_ALLOW_UNSAFE_PICKLE`
+
+Consents to loading legacy PyTorch checkpoints with
+`torch.load(..., weights_only=False)`. The default `weights_only=True` path
+rejects pickled Python objects; opting out re-enables arbitrary-code
+execution at load time, so only set this for checkpoints you trust.
+
+| Surface | Equivalent |
+|---|---|
+| CLI | `--allow-unsafe-pickle` |
+| Python API | `allow_unsafe_pickle=True` on `raitap.run(...)` |
+| Env var | `RAITAP_ALLOW_UNSAFE_PICKLE=1` |
+
+See {doc}`../../modules/model/own-vs-built-in` for when this is necessary.
+
+## Examples
+
+POSIX shell:
+
+```bash
+export RAITAP_ALLOW_PREPROCESSING_EXEC=1
+export RAITAP_ALLOW_UNSAFE_PICKLE=1
+uv run raitap --config-name assessment
+```
+
+PowerShell:
+
+```powershell
+$env:RAITAP_ALLOW_PREPROCESSING_EXEC = "1"
+$env:RAITAP_ALLOW_UNSAFE_PICKLE = "1"
+uv run raitap --config-name assessment
+```
+
+GitHub Actions:
+
+```yaml
+- run: uv run raitap --config-name assessment
+  env:
+    RAITAP_ALLOW_PREPROCESSING_EXEC: "1"
+    RAITAP_ALLOW_UNSAFE_PICKLE: "1"
+```

--- a/docs/using-raitap/configuration/index.md
+++ b/docs/using-raitap/configuration/index.md
@@ -16,6 +16,7 @@ This section explains high level configuration principles for your use case.
 
 general
 global-config-options
+environment-variables
 python-api
 ```
 


### PR DESCRIPTION
## Summary
- Adds `docs/using-raitap/configuration/environment-variables.md` listing the three `RAITAP_*` env vars (`RAITAP_ALLOW_PREPROCESSING_EXEC`, `RAITAP_ACKNOWLEDGE_PREPROCESSING_OFF`, `RAITAP_ALLOW_UNSAFE_PICKLE`), each with its CLI / Python-API equivalent and POSIX / PowerShell / GitHub Actions examples.
- Wires the new page into the configuration toctree.
- Cross-links from the existing module docs that already mention the matching CLI flag (`docs/modules/data/preprocessing.md`, `docs/modules/data/configuration.md`, `docs/modules/model/configuration.md`, `docs/modules/model/own-vs-built-in.md`) so the env var alternative is discoverable from each consent surface.

Closes #186.

## Test plan
- [x] `uv run sphinx-build` (or the CI docs job) builds without warnings.
- [x] Rendered page is reachable from `using-raitap/configuration/` index.
- [x] `{ref}environment-variables` cross-references resolve from each module doc.