### PR TITLE
feat: decorator parity + third-party plugin system

### DIFF
--- a/docs/contributor/adding-a-module.md
+++ b/docs/contributor/adding-a-module.md
@@ -94,7 +94,7 @@ from raitap._adapters import (
     ALL,
     FamilyConfig,
     _AllAlgorithmsSentinel,
-    _CommonRegKwargs,
+    AdapterDecoratorOptions,
     _register_core,
 )
 from raitap.configs.schema import FairnessConfig
@@ -118,7 +118,7 @@ def register_fairness_adapter(
     *,
     algorithm_registry: Mapping[str, FairnessAdapterSemanticsHints],
     onnx_compatible_algorithms: frozenset[str] | _AllAlgorithmsSentinel = frozenset(),
-    **common: Unpack[_CommonRegKwargs],
+    **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     def wrap(cls: type[T]) -> type[T]:
         cls.algorithm_registry = algorithm_registry  # type: ignore[misc]
@@ -132,7 +132,7 @@ def register_fairness_adapter(
     return wrap
 ```
 
-Pyright errors at decoration if `registry_name` (via `_CommonRegKwargs.Required`) or `algorithm_registry` is missing.
+Pyright errors at decoration if `registry_name` (via `AdapterDecoratorOptions.Required`) or `algorithm_registry` is missing.
 
 ## 4. Schema (`configs/schema.py`)
 

--- a/docs/contributor/adding-a-task-family.md
+++ b/docs/contributor/adding-a-task-family.md
@@ -181,7 +181,7 @@ If the new family needs more than one explanation per sample (detection: one per
 ### 10. Write a visualiser
 
 ```python
-@register_transparency_visualiser(registry_name="detection_image")
+@visualisers.transparency(registry_name="detection_image")
 class DetectionImageVisualiser(BaseVisualiser):
     supported_output_spaces: ClassVar[frozenset[ExplanationOutputSpace]] = frozenset(
         {ExplanationOutputSpace.DETECTION_BOXES}

--- a/docs/contributor/adding-an-adapter.md
+++ b/docs/contributor/adding-an-adapter.md
@@ -1,9 +1,9 @@
 ---
 title: "Adding an adapter"
-description: "Adapters (explainers, assessors, metrics, reporters, trackers, visualisers) self-register via a per-family decorator (@register_transparency_adapter, @register_robustness_adapter, ...). Adding one is a single file plus optional pyproject.toml + test + docs entries. No central registry to edit."
+description: "Adapters (explainers, assessors, metrics, reporters, trackers, visualisers) self-register via a namespaced facade decorator (@adapters.transparency, @adapters.robustness, ...). Adding one is a single file plus optional pyproject.toml + test + docs entries. No central registry to edit."
 myst:
   html_meta:
-    "description": "Adapters (explainers, assessors, metrics, reporters, trackers, visualisers) self-register via a per-family decorator (@register_transparency_adapter, @register_robustness_adapter, ...). Adding one is a single file plus optional pyproject.toml + test + docs entries. No central registry to edit."
+    "description": "Adapters (explainers, assessors, metrics, reporters, trackers, visualisers) self-register via a namespaced facade decorator (@adapters.transparency, @adapters.robustness, ...). Adding one is a single file plus optional pyproject.toml + test + docs entries. No central registry to edit."
 ---
 
 # Adding an adapter
@@ -26,8 +26,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+from raitap import adapters
 from raitap.transparency.contracts import MethodFamily
-from raitap.transparency.explainers.registration import register_transparency_adapter
 
 from .base_explainer import AttributionOnlyExplainer
 
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     import torch.nn as nn
 
 
-@register_transparency_adapter(
+@adapters.transparency(
     registry_name="superxai",      # CLI `+transparency=superxai` / Python `from raitap.transparency import superxai`
     # extra="superxai",            # uv extra name; defaults to `registry_name` (omit unless they differ — see metrics for an exception)
     library="superxai-lib",        # real PyPI package name; drives `self._lazy_import()`
@@ -80,7 +80,7 @@ class SuperXAIExplainer(AttributionOnlyExplainer):
 ```
 
 - **Base class.** `AttributionOnlyExplainer` provides batching, artefact persistence, and `explain()` orchestration. Other families use other bases (`EmpiricalAttackAssessor` for robustness, `BaseMetricComputer` for metrics, etc.) — find them in files starting with `base_`. The concrete adapter is just a normal class; nothing flags it as abstract (the old `abstract=True` workaround was removed).
-- **Decorator.** `@register_transparency_adapter(...)` is the sole entry point for registration. `registry_name` is required and pyright-checked at the decoration site via `Required[str]`. Each family has its own decorator (`register_robustness_adapter`, `register_metrics_adapter`, `register_reporter`, `register_tracker`, `register_transparency_visualiser`, `register_robustness_visualiser`) — pick the one matching your base class.
+- **Decorator.** `@adapters.transparency(...)` is the sole entry point for registration. `registry_name` is required and pyright-checked at the decoration site via `Required[str]`. Each family has its own facade attribute (`adapters.robustness`, `adapters.metrics`, `adapters.reporter`, `adapters.tracker`, `visualisers.transparency`, `visualisers.robustness`) — pick the one matching your base class.
 - **Registration kwargs.** `library` is the pip name powering `self._lazy_import()` — pass it when you wrap a third-party package (the usual case). `extra` is the uv extra surfaced in install hints and scanned by `raitap.deps.inference`; it **defaults to `registry_name`** so you only need to set it explicitly when they differ (e.g. `classification_metrics` + `detection_metrics` both share `extra="metrics"`). `error_patterns` and `suppress_warnings` are optional polish.
 - **`algorithm_registry` (decorator kwarg).** Transparency and robustness only. Maps algorithm name → method families (or `AssessorSemanticsHints` for robustness) RAITAP tracks and reports on. **Required** — pyright errors at the decoration site if you omit it. Missing or misnamed entries make algorithms unselectable. The decorator assigns it onto the class so `type(self).algorithm_registry` still works at runtime.
 - **`output_payload_kind` (decorator kwarg).** Transparency only. Tells the report renderer what artefact shape the explainer emits (`ATTRIBUTIONS`, `SALIENCY_MAP`, ...). Defaults to `ExplanationPayloadKind.ATTRIBUTIONS` — only pass it if your explainer emits something else.
@@ -111,7 +111,7 @@ Tests go in `tests/raitap/<module>/<subdir>/test_<name>_<entity>.py`. Also add a
 
 Cover at minimum: registry membership, `check_backend_compat`, decorator wiring (the class lands in `_BUILDERS["<group>"]["<name>"]` and in `ADAPTER_EXTRAS`), and one `compute_attributions` / `generate_adversarial` / `compute` happy path. CI enforces module coverage.
 
-No stub workaround needed — concrete adapters are just concrete classes, and the decorator carries every family-required piece of metadata (`algorithm_registry`, `output_payload_kind`, `onnx_compatible_algorithms`). A test stub is just `@register_<family>_adapter(registry_name="_stub", algorithm_registry={...}, ...)` over a minimal subclass implementing the abstract methods.
+No stub workaround needed — concrete adapters are just concrete classes, and the decorator carries every family-required piece of metadata (`algorithm_registry`, `output_payload_kind`, `onnx_compatible_algorithms`). A test stub is just `@adapters.<family>(registry_name="_stub", algorithm_registry={...}, ...)` over a minimal subclass implementing the abstract methods.
 
 ## 5. Update the docs
 
@@ -119,14 +119,14 @@ Add a row to `docs/modules/<module>/frameworks-and-libraries.md` documenting the
 
 ## Adapter families and where to look
 
-| Module                 | Abstract base                                                                                                                               | Registration decorator                                                       | Group              | Schema               |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------ | -------------------- |
-| Transparency explainer | `raitap.transparency.explainers.base_explainer.AttributionOnlyExplainer` / `FullExplainer`                                                  | `@register_transparency_adapter`                                             | `transparency`     | `TransparencyConfig` |
-| Robustness assessor    | `raitap.robustness.assessors.base_assessor.EmpiricalAttackAssessor` / `FormalVerificationAssessor`                                          | `@register_robustness_adapter`                                               | `robustness`       | `RobustnessConfig`   |
-| Metric                 | `raitap.metrics.base_metric_computer.BaseMetricComputer`                                                                                    | `@register_metrics_adapter`                                                  | `metrics`          | `MetricsConfig`      |
-| Reporter               | `raitap.reporting.base_reporter.BaseReporter`                                                                                               | `@register_reporter`                                                         | `reporting`        | `ReportingConfig`    |
-| Tracker                | `raitap.tracking.base_tracker.BaseTracker`                                                                                                  | `@register_tracker`                                                          | `tracking`         | `TrackingConfig`     |
-| Visualiser             | `raitap.transparency.visualisers.base_visualiser.BaseVisualiser` / `raitap.robustness.visualisers.base_visualiser.BaseRobustnessVisualiser` | `@register_transparency_visualiser` / `@register_robustness_visualiser`      | — (no Hydra group) | —                    |
+| Module                 | Abstract base                                                                                                                               | Registration decorator                                              | Group              | Schema               |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------ | -------------------- |
+| Transparency explainer | `raitap.transparency.explainers.base_explainer.AttributionOnlyExplainer` / `FullExplainer`                                                  | `@adapters.transparency`                                            | `transparency`     | `TransparencyConfig` |
+| Robustness assessor    | `raitap.robustness.assessors.base_assessor.EmpiricalAttackAssessor` / `FormalVerificationAssessor`                                          | `@adapters.robustness`                                              | `robustness`       | `RobustnessConfig`   |
+| Metric                 | `raitap.metrics.base_metric_computer.BaseMetricComputer`                                                                                    | `@adapters.metrics`                                                 | `metrics`          | `MetricsConfig`      |
+| Reporter               | `raitap.reporting.base_reporter.BaseReporter`                                                                                               | `@adapters.reporter`                                                | `reporting`        | `ReportingConfig`    |
+| Tracker                | `raitap.tracking.base_tracker.BaseTracker`                                                                                                  | `@adapters.tracker`                                                 | `tracking`         | `TrackingConfig`     |
+| Visualiser             | `raitap.transparency.visualisers.base_visualiser.BaseVisualiser` / `raitap.robustness.visualisers.base_visualiser.BaseRobustnessVisualiser` | `@visualisers.transparency` / `@visualisers.robustness`             | — (no Hydra group) | —                    |
 
 ## Adding a new algorithm to an existing adapter
 

--- a/docs/contributor/adding-an-algorithm.md
+++ b/docs/contributor/adding-an-algorithm.md
@@ -14,7 +14,7 @@ The walkthrough below uses Captum and a hypothetical new method `NewMethod`.
 
 ## 1. Find the adapter
 
-Adapter classes live under `src/raitap/<module>/<subdir>/`. Look for the file matching the wrapped library (e.g. `captum_explainer.py`, `torchattacks_assessor.py`). The class is decorated with `@register_<family>_adapter(...)`.
+Adapter classes live under `src/raitap/<module>/<subdir>/`. Look for the file matching the wrapped library (e.g. `captum_explainer.py`, `torchattacks_assessor.py`). The class is decorated with `@adapters.<family>(...)`.
 
 ## 2. Add the algorithm to `algorithm_registry`
 
@@ -23,7 +23,9 @@ Adapter classes live under `src/raitap/<module>/<subdir>/`. Look for the file ma
 **Transparency explainer** (`captum_explainer.py`):
 
 ```python
-@register_transparency_adapter(
+from raitap import adapters
+
+@adapters.transparency(
     registry_name="captum",
     library="captum",
     algorithm_registry={
@@ -39,7 +41,9 @@ class CaptumExplainer(AttributionOnlyExplainer): ...
 **Robustness assessor** (`torchattacks_assessor.py`):
 
 ```python
-@register_robustness_adapter(
+from raitap import adapters
+
+@adapters.robustness(
     registry_name="torchattacks",
     library="torchattacks",
     algorithm_registry={
@@ -67,7 +71,7 @@ A missing entry means the algorithm cannot be selected via config — the family
 If the new algorithm runs on ONNX-exported models (not just torch), add it to `onnx_compatible_algorithms`:
 
 ```python
-@register_transparency_adapter(
+@adapters.transparency(
     ...,
     onnx_compatible_algorithms=frozenset({"Occlusion", "FeatureAblation", "NewMethod"}),
 )

--- a/docs/contributor/architecture.md
+++ b/docs/contributor/architecture.md
@@ -38,7 +38,7 @@ In prose: the CLI entry (`raitap.cli.main`) routes to either the tracking-stop s
 
 ## Adapter registration
 
-Every concrete adapter (explainer, assessor, metric, reporter, tracker, visualiser) self-registers via a family decorator (`@register_transparency_adapter`, `@register_robustness_adapter`, `@register_metrics_adapter`, `@register_reporter`, `@register_tracker`, `@register_transparency_visualiser`, `@register_robustness_visualiser`). The decorator lives in `<module>/registration.py`; it delegates to `raitap._adapters._register_core`, which builds the hydra-zen builder, registers it with the `ConfigStore`, and populates `_BUILDERS` / `ADAPTER_EXTRAS` / `THIRD_PARTY_LIBS`. Lazy `__getattr__` on each family package resolves `raitap.<family>.<name>` via `raitap._adapters.lookup`.
+Every concrete adapter (explainer, assessor, metric, reporter, tracker, visualiser) self-registers via a namespaced facade decorator (`@adapters.transparency`, `@adapters.robustness`, `@adapters.metrics`, `@adapters.reporter`, `@adapters.tracker`, `@visualisers.transparency`, `@visualisers.robustness`). The decorator lives in `<module>/registration.py`; it delegates to `raitap._adapters._register_core`, which builds the hydra-zen builder, registers it with the `ConfigStore`, and populates `_BUILDERS` / `ADAPTER_EXTRAS` / `THIRD_PARTY_LIBS`. Lazy `__getattr__` on each family package resolves `raitap.<family>.<name>` via `raitap._adapters.lookup`.
 
 See {doc}`adding-an-adapter` / {doc}`adding-an-algorithm` / {doc}`adding-a-module` for the contributor workflow.
 
@@ -112,7 +112,7 @@ src/
     │
     ├── metrics/                    # metrics adapters (currently torchmetrics-backed)
     │   ├── factory.py              # metrics_run_enabled, evaluate(), instantiation via adapter_factory
-    │   ├── registration.py         # `register_metrics_adapter` family decorator
+    │   ├── registration.py         # `@adapters.metrics` family decorator
     │   ├── base_metric_computer.py # `BaseMetricComputer` ABC + `MetricResult` dataclass
     │   ├── classification_metrics.py
     │   └── inputs.py               # target/prediction alignment, fallbacks when labels missing
@@ -122,20 +122,20 @@ src/
     │   ├── contracts.py            # ExplanationPayloadKind, InputSpec, MethodFamily, …
     │   ├── results.py              # ExplanationResult + Explanation orchestration object
     │   ├── explainers/             # CaptumExplainer, ShapExplainer + `registration.py`
-    │   │                           # (`register_transparency_adapter`) + `base_explainer.py`
+    │   │                           # (`@adapters.transparency`) + `base_explainer.py`
     │   └── visualisers/            # CaptumImageVisualiser, ShapImageVisualiser, … + `registration.py`
-    │                               # (`register_transparency_visualiser`) + `base_visualiser.py`
+    │                               # (`@visualisers.transparency`) + `base_visualiser.py`
     │
     ├── robustness/                 # adversarial-attack + formal-verification adapters
     │   ├── factory.py              # create_assessor; raitap-key migration warnings
     │   ├── assessors/              # TorchattacksAssessor, FoolboxAssessor, MarabouAssessor +
-    │   │                           # `registration.py` (`register_robustness_adapter`) +
+    │   │                           # `registration.py` (`@adapters.robustness`) +
     │   │                           # `base_assessor.py`
     │   └── visualisers/            # ImagePairVisualiser, PerturbationHeatmapVisualiser, formal/* +
-    │                               # `registration.py` (`register_robustness_visualiser`)
+    │                               # `registration.py` (`@visualisers.robustness`)
     │
     ├── reporting/                  # HTML + PDF report builders + multirun aggregation
-    │   ├── registration.py         # `register_reporter` family decorator
+    │   ├── registration.py         # `@adapters.reporter` family decorator
     │   ├── base_reporter.py        # `BaseReporter` ABC
     │   ├── builder.py              # build_report(): assembles sections from RunOutputs
     │   ├── html_reporter.py        # Jinja2-backed HTML renderer
@@ -146,7 +146,7 @@ src/
     │   └── templates/              # Jinja templates
     │
     ├── tracking/                   # experiment-tracking adapters
-    │   ├── registration.py         # `register_tracker` family decorator
+    │   ├── registration.py         # `@adapters.tracker` family decorator
     │   ├── base_tracker.py         # BaseTracker abstract class + stop_detached hook
     │   ├── mlflow_tracker.py       # MLflow adapter
     │   ├── process_registry.py     # ~/.raitap/tracking_processes.json (used by `tracking stop`)

--- a/docs/contributor/architecture.md
+++ b/docs/contributor/architecture.md
@@ -56,7 +56,7 @@ src/
     ├── docs_preview.py             # `docs-preview` console-script: serves built Sphinx output for local preview
     ├── types.py                    # `Hardware` enum + small shared types
     ├── _adapters.py                # registration core: `AdapterMixin` (instance helpers), `FamilyConfig`,
-    │                               # `_CommonRegKwargs` TypedDict, `_register_core`, `_BUILDERS`,
+    │                               # `AdapterDecoratorOptions` TypedDict, `_register_core`, `_BUILDERS`,
     │                               # `ADAPTER_EXTRAS`, `THIRD_PARTY_LIBS`, `ALL` sentinel, `discover`, `lookup`
     │
     ├── configs/                    # Hydra config tree shipped with the wheel

--- a/docs/contributor/index.md
+++ b/docs/contributor/index.md
@@ -23,6 +23,7 @@ Adding an adapter <adding-an-adapter>
 Adding an algorithm <adding-an-algorithm>
 Adding a module <adding-a-module>
 Adding a task family <adding-a-task-family>
+Writing a plugin <writing-a-plugin>
 Data module <data>
 Metrics module <metrics>
 Tracking module <tracking>

--- a/docs/contributor/logging.md
+++ b/docs/contributor/logging.md
@@ -56,11 +56,13 @@ raise ValueError(
 )
 ```
 
-For wrapped third-party calls (captum / shap / foolbox / torchattacks), use the adapter's `self._rethrow()` helper. It pulls `library`, the family group, and the `error_patterns` map straight from the adapter's `@register_*_adapter(...)` decoration — no kwargs needed at the call site:
+For wrapped third-party calls (captum / shap / foolbox / torchattacks), use the adapter's `self._rethrow()` helper. It pulls `library`, the family group, and the `error_patterns` map straight from the adapter's `@adapters.<family>(...)` decoration — no kwargs needed at the call site:
 
 ```python
 # src/raitap/transparency/explainers/shap_explainer.py
-@register_transparency_adapter(
+from raitap import adapters
+
+@adapters.transparency(
     registry_name="shap",
     library="shap",
     error_patterns={
@@ -104,7 +106,9 @@ raitap_log.warn(
 Use the `suppress_warnings=` decorator kwarg on the adapter, not a module-level `raitap_log.suppress` call. The decorator installs the filter at registration time (same as a module-level call would), but the noise spec stays colocated with the adapter that owns it:
 
 ```python
-@register_transparency_adapter(
+from raitap import adapters
+
+@adapters.transparency(
     registry_name="captum",
     library="captum",
     suppress_warnings=[

--- a/docs/contributor/robustness.md
+++ b/docs/contributor/robustness.md
@@ -27,8 +27,7 @@ BaseAssessor                            # root — declares method_kind + budget
 ```
 
 - **`BaseAssessor`** — root. Declares `method_kind: ClassVar[MethodKind]`,
-  `threat_model_default`, `objective_default`, `budget_kwarg_source`, and the
-  no-op `check_backend_compat`. Never subclass directly.
+  `budget_kwarg_source`, and the no-op `check_backend_compat`. Never subclass directly.
 - **`EmpiricalAttackAssessor`** — subclasses implement only
   `generate_adversarial(model, inputs, targets, ...) → Tensor`. Batching,
   prediction, verdict computation, distance computation, semantics inference,

--- a/docs/contributor/robustness.md
+++ b/docs/contributor/robustness.md
@@ -45,7 +45,7 @@ Every assessor declares two `ClassVar`s the framework relies on:
   algorithm names to their threat model / norm / families. `assessor_semantics`
   uses this to build `RobustnessResult.semantics.budget`, so the reported
   metadata always matches what the adapter actually executed. Passed via the
-  `@register_robustness_adapter(algorithm_registry=...)` decorator kwarg.
+  `@adapters.robustness(algorithm_registry=...)` decorator kwarg.
 - `budget_kwarg_source: ClassVar[str]` — `"init_kwargs"` (torchattacks reads
   the budget at construction time) or `"call_kwargs"` (foolbox reads it at
   call time). Defaults to `"init_kwargs"`.
@@ -104,7 +104,7 @@ reported `perturbation_distance` always matches the configured threat model.
   both empirical attacks and formal verification.
 - `factory.py` — typed config parsing, `_resolve_call_data_sources`, and the
   `RobustnessAssessment` Hydra entry point. Adapter paths are resolved via the
-  `@register_robustness_adapter` decorator — no manual path table to maintain.
+  `@adapters.robustness` decorator — no manual path table to maintain.
 - `results.py` — `RobustnessResult`, `RobustnessMetrics`, verdict encoding.
 - `visualisers/base_visualiser.py` — `BaseRobustnessVisualiser` +
   `MethodKind` compatibility check.
@@ -139,7 +139,7 @@ well-defined reference (a warning is logged).
   norm, family tags) from `semantics.py`.
 - **New robustness library** — see {doc}`adding-an-adapter`. Pick
   `EmpiricalAttackAssessor` or `FormalVerificationAssessor` as the base,
-  decorate with `@register_robustness_adapter(...)`, and set
+  decorate with `@adapters.robustness(...)`, and set
   `budget_kwarg_source="call_kwargs"` if the library reads the budget at
   call time. Override `check_backend_compat` if the library imposes extra
   backend constraints (e.g. white-box attacks require
@@ -149,7 +149,7 @@ well-defined reference (a warning is logged).
 ## Adding a new visualiser
 
 Subclass `BaseRobustnessVisualiser` and decorate with
-`@register_robustness_visualiser(...)` (see {doc}`adding-an-adapter` for the
+`@visualisers.robustness(...)` (see {doc}`adding-an-adapter` for the
 decorator scaffolding). Robustness-specific notes:
 
 - Set `supported_method_kinds` so the factory rejects mismatched assessor

--- a/docs/contributor/transparency.md
+++ b/docs/contributor/transparency.md
@@ -32,7 +32,7 @@ BaseExplainer                       # root — owns output_payload_kind + check_
 - **`AttributionOnlyExplainer`** — extend this when the framework maps cleanly to a single `compute_attributions(model, inputs, **kwargs) -> torch.Tensor` call. Batching, normalisation, result wrapping, and `write_artifacts` are handled for you. Captum and SHAP both subclass this.
 - **`FullExplainer`** — extend this when you own the entire `explain` pipeline yourself (data conversion, model invocation, result construction, persistence).
 
-`output_payload_kind: ClassVar[ExplanationPayloadKind]` (default `ATTRIBUTIONS`) records what artefact shape the explainer emits. It's set via the `@register_transparency_adapter` decorator kwarg.
+`output_payload_kind: ClassVar[ExplanationPayloadKind]` (default `ATTRIBUTIONS`) records what artefact shape the explainer emits. It's set via the `@adapters.transparency` decorator kwarg.
 
 ## Visualiser semantic contract
 
@@ -62,7 +62,7 @@ Plus two instance-level hooks:
 - Don't promote arbitrary debug batches or representative montages to `GLOBAL`.
 - Image visualisers with `embeds_original_input = True` **must** accept the runtime kwarg `include_original_input`. Reporting uses this to render one shared sample thumbnail and suppress repeated originals in sample-major compact local report sections. Keep YAML constructor names backward-compatible (the built-in image visualisers still accept `include_original_image`).
 
-For the decorator/registration scaffolding (`@register_transparency_visualiser`, `registry_name`, exports), see {doc}`adding-an-adapter`. The bullets above are the transparency-specific additions on top of that scaffolding.
+For the decorator/registration scaffolding (`@visualisers.transparency`, `registry_name`, exports), see {doc}`adding-an-adapter`. The bullets above are the transparency-specific additions on top of that scaffolding.
 
 ## Typed semantics contract
 
@@ -138,4 +138,4 @@ Each explainer writes to its own subdirectory under the Hydra run folder. See {d
 - `src/raitap/transparency/explainers/full_explainer.py` — `FullExplainer`.
 - `src/raitap/transparency/visualisers/base_visualiser.py` — `BaseVisualiser` and the semantic-contract ClassVars.
 
-**Name resolution.** Bare class names in YAML `_target_` keys (e.g. `_target_: CaptumExplainer`) are resolved through the `@register_transparency_adapter` / `@register_transparency_visualiser` decorators and `raitap._adapters.lookup("transparency", name)` — *not* via the legacy class-kwarg path. To make a new class addressable by bare name, decorate it; that's the only requirement.
+**Name resolution.** Bare class names in YAML `_target_` keys (e.g. `_target_: CaptumExplainer`) are resolved through the `@adapters.transparency` / `@visualisers.transparency` decorators and `raitap._adapters.lookup("transparency", name)` — *not* via the legacy class-kwarg path. To make a new class addressable by bare name, decorate it; that's the only requirement.

--- a/docs/contributor/writing-a-plugin.md
+++ b/docs/contributor/writing-a-plugin.md
@@ -10,76 +10,74 @@ myst:
 
 This page explains how to write a lightwight plugin adapter so your library can seamlessly be used via RAITAP. That way, you do not need to open a PR in the RAITAP repo, and consumers can use your library like any 1st party RAITAP adapter.
 
+In the following guide, we will imagine you want to create 
 
-## Step 1 — Create the package
+## 1. Create the package
 
 A plugin is an ordinary pip package. Lay it out like any `src/`-style project:
 
 ```
-raitap-myattack/
+raitap-superxai/
 ├── pyproject.toml
 └── src/
-    └── raitap_myattack/
+    └── raitap_superxai/
         └── __init__.py   # holds the decorated adapter; runs on import
 ```
 
-## Step 2 — Write the adapter
+## 2. Write the adapter
 
 Implement the adapter exactly as in {doc}`adding-an-adapter` — the only
-difference is your class lives in your own package, not under `src/raitap/`.
-Decorate it with the public `@adapters.<family>(...)` surface (`from raitap
-import adapters`). Example, robustness family:
+difference is your class lives in your own package, so import the base class by
+its full path (`from raitap.transparency.explainers.base_explainer import ...`)
+instead of the in-tree relative import. Decorate it with the public
+`@adapters.<family>(...)` surface (`from raitap import adapters`). Same
+`superxai-lib` transparency example as the adapter guide:
 
 ```python
-# src/raitap_myattack/__init__.py
+# src/raitap_superxai/__init__.py
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import re
+from typing import TYPE_CHECKING
 
 from raitap import adapters
-from raitap.robustness.assessors.base_assessor import EmpiricalAttackAssessor
-from raitap.robustness.contracts import MethodKind, Objective, PerturbationNorm, ThreatModel
-from raitap.robustness.semantics import AssessorSemanticsHints
-from raitap.utils.lazy import lazy_import
+from raitap.transparency.contracts import MethodFamily
+from raitap.transparency.explainers.base_explainer import AttributionOnlyExplainer
 
 if TYPE_CHECKING:
     import torch
-    from torch import nn
-else:
-    torch = lazy_import("torch")
+    import torch.nn as nn
 
 
-@adapters.robustness(
-    registry_name="myattack",           # CLI `+robustness=myattack` / Python `from raitap.robustness import myattack`
-    library="myattack-lib",             # real PyPI name; drives self._lazy_import()
-    algorithm_registry={
-        "MyPGD": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
-            ThreatModel.WHITE_BOX,
-            Objective.UNTARGETED,
-            PerturbationNorm.LINF,
-            families=frozenset({"gradient_sign", "iterative"}),
-        ),
+@adapters.transparency(
+    registry_name="superxai",      # CLI `+transparency=superxai` / Python `from raitap.transparency import superxai`
+    library="superxai-lib",        # real PyPI package name; drives `self._lazy_import()`
+    error_patterns={               # rewrite cryptic upstream errors at call sites
+        re.compile(r"some library footgun"): "Do X instead.",
     },
+    algorithm_registry={
+        "supertreeshap": frozenset({MethodFamily.SHAPLEY}),
+    },
+    onnx_compatible_algorithms=frozenset({"supertreeshap"}),
 )
-class MyAttackAssessor(EmpiricalAttackAssessor):
-    def __init__(self, algorithm: str, **init_kwargs: Any) -> None:
+class SuperXAIExplainer(AttributionOnlyExplainer):
+    def __init__(self, algorithm: str, **init_kwargs):
+        super().__init__()
         self.algorithm = algorithm
-        self.init_kwargs = dict(init_kwargs)
+        self.init_kwargs = init_kwargs
 
-    def generate_adversarial(
+    def compute_attributions(
         self,
         model: nn.Module,
         inputs: torch.Tensor,
-        targets: torch.Tensor,
-        *,
-        backend: object | None = None,
-        **kwargs: Any,
+        backend=None,
+        **call_kwargs,
     ) -> torch.Tensor:
-        lib = self._lazy_import()
+        superxai = self._lazy_import()
         with self._rethrow():
-            attack = getattr(lib, self.algorithm)(model, **self.init_kwargs)
-            return attack(inputs, targets)
+            return getattr(superxai, self.algorithm)(model, **self.init_kwargs).attribute(
+                inputs, **call_kwargs
+            )
 ```
 
 Decorator kwargs (`library`, `algorithm_registry`, `error_patterns`,
@@ -95,14 +93,14 @@ you).
 
 ```toml
 [project]
-name = "raitap-myattack"
+name = "raitap-superxai"
 dependencies = [
     "raitap>=0.5,<0.6",   # required — RAITAP reads this pin at load time
-    "myattack-lib",
+    "superxai-lib",
 ]
 
 [project.entry-points."raitap.adapters"]
-myattack = "raitap_myattack"   # value is the module to import; decorator fires on import
+superxai = "raitap_superxai"   # value is the module to import; decorator fires on import
 ```
 
 RAITAP reads the `Requires-Dist: raitap ...` metadata from your installed
@@ -117,12 +115,12 @@ Install your plugin alongside RAITAP and confirm it resolves like a first-party
 adapter:
 
 ```bash
-pip install raitap raitap-myattack
+pip install raitap raitap-superxai
 ```
 
 ```bash
 # resolves only if discovery + version check passed
-python -c "from raitap.robustness import myattack; print(myattack)"
+python -c "from raitap.transparency import superxai; print(superxai)"
 ```
 
 If nothing resolves, check the logs for a skip/crash warning naming your plugin
@@ -133,20 +131,18 @@ If nothing resolves, check the logs for a skip/crash warning naming your plugin
 Consumers reference your adapter by its `registry_name`, in YAML:
 
 ```yaml
-robustness:
+transparency:
   my_run:
-    _target_: MyAttackAssessor
-    algorithm: MyPGD
-    constructor:
-      eps: 0.03
+    _target_: SuperXAIExplainer
+    algorithm: supertreeshap
 ```
 
 or in Python:
 
 ```python
-from raitap.robustness import myattack
+from raitap.transparency import superxai
 
-robustness = {"my_run": myattack(algorithm="MyPGD", constructor={"eps": 0.03})}
+transparency = {"my_run": superxai(algorithm="supertreeshap")}
 ```
 
 ## How discovery works

--- a/docs/contributor/writing-a-plugin.md
+++ b/docs/contributor/writing-a-plugin.md
@@ -8,26 +8,27 @@ myst:
 
 # Writing a plugin
 
-A **plugin** is a separate pip package that registers a RAITAP adapter via the
-`raitap.adapters` entry-point group. No fork or pull request needed — once
-installed alongside RAITAP the adapter appears in every family namespace just
-like an in-tree one.
+This page explains how to write a lightwight plugin adapter so your library can seamlessly be used via RAITAP. That way, you do not need to open a PR in the RAITAP repo, and consumers can use your library like any 1st party RAITAP adapter.
 
-## Package layout
+
+## Step 1 — Create the package
+
+A plugin is an ordinary pip package. Lay it out like any `src/`-style project:
 
 ```
 raitap-myattack/
 ├── pyproject.toml
 └── src/
     └── raitap_myattack/
-        └── __init__.py   # decorator fires on import
+        └── __init__.py   # holds the decorated adapter; runs on import
 ```
 
-## The adapter
+## Step 2 — Write the adapter
 
-Implement the adapter exactly as described in {doc}`adding-an-adapter`. The only
-difference is that your file lives in your own package instead of under
-`src/raitap/`. The example below uses the robustness family:
+Implement the adapter exactly as in {doc}`adding-an-adapter` — the only
+difference is your class lives in your own package, not under `src/raitap/`.
+Decorate it with the public `@adapters.<family>(...)` surface (`from raitap
+import adapters`). Example, robustness family:
 
 ```python
 # src/raitap_myattack/__init__.py
@@ -83,10 +84,14 @@ class MyAttackAssessor(EmpiricalAttackAssessor):
 
 Decorator kwargs (`library`, `algorithm_registry`, `error_patterns`,
 `suppress_warnings`, …) are documented in {doc}`adding-an-adapter`.
-`AdapterDecoratorOptions` is also exported for typing: `from raitap import
+`AdapterDecoratorOptions` is exported for typing: `from raitap import
 AdapterDecoratorOptions`.
 
-## pyproject.toml
+## Step 3 — Declare the entry point and version pin
+
+Two things in `pyproject.toml`: the `raitap.adapters` entry point (so RAITAP
+finds your module) and a `raitap` dependency pin (so RAITAP can version-check
+you).
 
 ```toml
 [project]
@@ -100,29 +105,32 @@ dependencies = [
 myattack = "raitap_myattack"   # value is the module to import; decorator fires on import
 ```
 
-**Version pin.** RAITAP reads the `Requires-Dist: raitap ...` metadata from
-your installed distribution at load time. If the running RAITAP version does not
-satisfy the pin, or if no `raitap` pin is declared at all, the plugin is
-**skipped with a warning** and never breaks the user's run. Pin a tight range
-(`>=x,<y`) whenever you rely on internal API that may change.
+RAITAP reads the `Requires-Dist: raitap ...` metadata from your installed
+distribution at load time. If the running RAITAP version doesn't satisfy the
+pin — or if no `raitap` pin is declared at all — your plugin is **skipped with a
+warning** and never breaks the user's run. Pin a tight range (`>=x,<y`) whenever
+you rely on internal API that may change.
 
-## Discovery and isolation
+## Step 4 — Install and verify
 
-- Discovery fires at **config-registration time** (`register_zen_groups` /
-  `register_configs`), not on a bare `import raitap`.
-- Loading is **default-allow**: all installed plugins under `raitap.adapters`
-  are discovered automatically.
-- A plugin that **crashes at import** is logged (naming the plugin) and skipped
-  — it never breaks RAITAP.
-- Set `RAITAP_DISABLE_PLUGINS=1` to skip all plugin discovery entirely.
-
-## User consumption
+Install your plugin alongside RAITAP and confirm it resolves like a first-party
+adapter:
 
 ```bash
 pip install raitap raitap-myattack
 ```
 
-Then in YAML:
+```bash
+# resolves only if discovery + version check passed
+python -c "from raitap.robustness import myattack; print(myattack)"
+```
+
+If nothing resolves, check the logs for a skip/crash warning naming your plugin
+(see *How discovery works* below), or run with `RAITAP_DISABLE_PLUGINS` unset.
+
+## Step 5 — Use it
+
+Consumers reference your adapter by its `registry_name`, in YAML:
 
 ```yaml
 robustness:
@@ -133,10 +141,20 @@ robustness:
       eps: 0.03
 ```
 
-Or in Python:
+or in Python:
 
 ```python
 from raitap.robustness import myattack
 
 robustness = {"my_run": myattack(algorithm="MyPGD", constructor={"eps": 0.03})}
 ```
+
+## How discovery works
+
+- Discovery fires at **config-registration time** (`register_zen_groups` /
+  `register_configs`), not on a bare `import raitap`.
+- Loading is **default-allow**: every installed plugin under the
+  `raitap.adapters` entry-point group is discovered automatically.
+- A plugin that **crashes at import** is logged (naming the plugin) and skipped
+  — one bad plugin never breaks RAITAP.
+- Set `RAITAP_DISABLE_PLUGINS=1` to skip all plugin discovery entirely.

--- a/docs/contributor/writing-a-plugin.md
+++ b/docs/contributor/writing-a-plugin.md
@@ -10,7 +10,7 @@ myst:
 
 This page explains how to write a lightwight plugin adapter so your library can seamlessly be used via RAITAP. That way, you do not need to open a PR in the RAITAP repo, and consumers can use your library like any 1st party RAITAP adapter.
 
-In the following guide, we will imagine you want to create 
+In the following guide, we will imagine you want to make you "SuperXAI" library usable to RAITAP users seamlessly.
 
 ## 1. Create the package
 
@@ -21,7 +21,7 @@ raitap-superxai/
 ├── pyproject.toml
 └── src/
     └── raitap_superxai/
-        └── __init__.py   # holds the decorated adapter; runs on import
+        └── __init__.py   # holds the decorated adapter; runs on import (see below)
 ```
 
 ## 2. Write the adapter
@@ -35,6 +35,7 @@ instead of the in-tree relative import. Decorate it with the public
 
 ```python
 # src/raitap_superxai/__init__.py
+
 from __future__ import annotations
 
 import re
@@ -51,18 +52,18 @@ if TYPE_CHECKING:
 
 @adapters.transparency(
     registry_name="superxai",      # CLI `+transparency=superxai` / Python `from raitap.transparency import superxai`
-    library="superxai-lib",        # real PyPI package name; drives `self._lazy_import()`
+    library="superxai-lib",        # real name of your PyPI package; drives `self._lazy_import()` (defaults to registry_name)
     error_patterns={               # rewrite cryptic upstream errors at call sites
-        re.compile(r"some library footgun"): "Do X instead.",
+        re.compile(r"some library footgun"): "Do X instead.", # nicer error messages to avoid deep stack traces in RAITAP
     },
     algorithm_registry={
-        "supertreeshap": frozenset({MethodFamily.SHAPLEY}),
+        "supertreeshap": frozenset({MethodFamily.SHAPLEY}), # the algos your library offers
     },
-    onnx_compatible_algorithms=frozenset({"supertreeshap"}),
+    onnx_compatible_algorithms=frozenset({"supertreeshap"}), # algos compatible with ONNX models
 )
 class SuperXAIExplainer(AttributionOnlyExplainer):
     def __init__(self, algorithm: str, **init_kwargs):
-        super().__init__()
+        super().__init__()              # don't omit!
         self.algorithm = algorithm
         self.init_kwargs = init_kwargs
 
@@ -73,7 +74,7 @@ class SuperXAIExplainer(AttributionOnlyExplainer):
         backend=None,
         **call_kwargs,
     ) -> torch.Tensor:
-        superxai = self._lazy_import()
+        superxai = self._lazy_import()  # don't omit!
         with self._rethrow():
             return getattr(superxai, self.algorithm)(model, **self.init_kwargs).attribute(
                 inputs, **call_kwargs
@@ -82,25 +83,27 @@ class SuperXAIExplainer(AttributionOnlyExplainer):
 
 Decorator kwargs (`library`, `algorithm_registry`, `error_patterns`,
 `suppress_warnings`, …) are documented in {doc}`adding-an-adapter`.
-`AdapterDecoratorOptions` is exported for typing: `from raitap import
+
+`AdapterDecoratorOptions` is exported for typing, in case you want additional custom logic on top of the decorator: `from raitap import
 AdapterDecoratorOptions`.
 
-## Step 3 — Declare the entry point and version pin
+## 3. Declare the entry point and version pin
 
-Two things in `pyproject.toml`: the `raitap.adapters` entry point (so RAITAP
-finds your module) and a `raitap` dependency pin (so RAITAP can version-check
-you).
+Two things to add to your `pyproject.toml`:
+
+- the `raitap.adapters` entry point (so RAITAP finds your module)
+- a `raitap` dependency pin (so RAITAP can version-check you).
 
 ```toml
 [project]
-name = "raitap-superxai"
+name = "raitap-superxai"  # plugin name, not your published PyPI package
 dependencies = [
     "raitap>=0.5,<0.6",   # required — RAITAP reads this pin at load time
-    "superxai-lib",
+    "superxai-lib",       # your published PyPI package
 ]
 
 [project.entry-points."raitap.adapters"]
-superxai = "raitap_superxai"   # value is the module to import; decorator fires on import
+superxai = "raitap_superxai"   # name of the file in src (see Step 1), NOT YOUR PLUGIN NAME
 ```
 
 RAITAP reads the `Requires-Dist: raitap ...` metadata from your installed
@@ -109,12 +112,16 @@ pin — or if no `raitap` pin is declared at all — your plugin is **skipped wi
 warning** and never breaks the user's run. Pin a tight range (`>=x,<y`) whenever
 you rely on internal API that may change.
 
-## Step 4 — Install and verify
+## 4. Do a self-test
 
 Install your plugin alongside RAITAP and confirm it resolves like a first-party
 adapter:
 
-```bash
+```{install-tabs}
+:uv:
+uv add raitap raitap-superxai
+
+:pip:
 pip install raitap raitap-superxai
 ```
 
@@ -124,26 +131,13 @@ python -c "from raitap.transparency import superxai; print(superxai)"
 ```
 
 If nothing resolves, check the logs for a skip/crash warning naming your plugin
-(see *How discovery works* below), or run with `RAITAP_DISABLE_PLUGINS` unset.
+(see {ref}`disco`), or run with `RAITAP_DISABLE_PLUGINS` unset.
 
-## Step 5 — Use it
+## 5. Document consumer usage
 
-Consumers reference your adapter by its `registry_name`, in YAML:
+RAITAP already documents how to use plugins ({doc}`../using-raitap/using-plugins`), but it's always good to add a section in your own docs too.
 
-```yaml
-transparency:
-  my_run:
-    _target_: SuperXAIExplainer
-    algorithm: supertreeshap
-```
-
-or in Python:
-
-```python
-from raitap.transparency import superxai
-
-transparency = {"my_run": superxai(algorithm="supertreeshap")}
-```
+(disco)=
 
 ## How discovery works
 

--- a/docs/contributor/writing-a-plugin.md
+++ b/docs/contributor/writing-a-plugin.md
@@ -12,6 +12,16 @@ This page explains how to write a lightwight plugin adapter so your library can 
 
 In the following guide, we will imagine you want to make you "SuperXAI" library usable to RAITAP users seamlessly.
 
+## Supported modules
+
+Plugins can register:
+
+- Transparency explainers and robustness assessors
+- Metrics, reporting, and tracking adapters
+- Transparency and robustness visualisers
+
+Backends are not plugin-extensible.
+
 ## 1. Create the package
 
 A plugin is an ordinary pip package. Lay it out like any `src/`-style project:

--- a/docs/contributor/writing-a-plugin.md
+++ b/docs/contributor/writing-a-plugin.md
@@ -1,0 +1,142 @@
+---
+title: "Writing a plugin"
+description: "Ship a RAITAP adapter as a standalone pip package — no fork, no PR required."
+myst:
+  html_meta:
+    "description": "Ship a RAITAP adapter as a standalone pip package — no fork, no PR required."
+---
+
+# Writing a plugin
+
+A **plugin** is a separate pip package that registers a RAITAP adapter via the
+`raitap.adapters` entry-point group. No fork or pull request needed — once
+installed alongside RAITAP the adapter appears in every family namespace just
+like an in-tree one.
+
+## Package layout
+
+```
+raitap-myattack/
+├── pyproject.toml
+└── src/
+    └── raitap_myattack/
+        └── __init__.py   # decorator fires on import
+```
+
+## The adapter
+
+Implement the adapter exactly as described in {doc}`adding-an-adapter`. The only
+difference is that your file lives in your own package instead of under
+`src/raitap/`. The example below uses the robustness family:
+
+```python
+# src/raitap_myattack/__init__.py
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from raitap import adapters
+from raitap.robustness.assessors.base_assessor import EmpiricalAttackAssessor
+from raitap.robustness.contracts import MethodKind, Objective, PerturbationNorm, ThreatModel
+from raitap.robustness.semantics import AssessorSemanticsHints
+from raitap.utils.lazy import lazy_import
+
+if TYPE_CHECKING:
+    import torch
+    from torch import nn
+else:
+    torch = lazy_import("torch")
+
+
+@adapters.robustness(
+    registry_name="myattack",           # CLI `+robustness=myattack` / Python `from raitap.robustness import myattack`
+    library="myattack-lib",             # real PyPI name; drives self._lazy_import()
+    algorithm_registry={
+        "MyPGD": AssessorSemanticsHints(
+            MethodKind.EMPIRICAL_ATTACK,
+            ThreatModel.WHITE_BOX,
+            Objective.UNTARGETED,
+            PerturbationNorm.LINF,
+            families=frozenset({"gradient_sign", "iterative"}),
+        ),
+    },
+)
+class MyAttackAssessor(EmpiricalAttackAssessor):
+    def __init__(self, algorithm: str, **init_kwargs: Any) -> None:
+        self.algorithm = algorithm
+        self.init_kwargs = dict(init_kwargs)
+
+    def generate_adversarial(
+        self,
+        model: nn.Module,
+        inputs: torch.Tensor,
+        targets: torch.Tensor,
+        *,
+        backend: object | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        lib = self._lazy_import()
+        with self._rethrow():
+            attack = getattr(lib, self.algorithm)(model, **self.init_kwargs)
+            return attack(inputs, targets)
+```
+
+Decorator kwargs (`library`, `algorithm_registry`, `error_patterns`,
+`suppress_warnings`, …) are documented in {doc}`adding-an-adapter`.
+`AdapterDecoratorOptions` is also exported for typing: `from raitap import
+AdapterDecoratorOptions`.
+
+## pyproject.toml
+
+```toml
+[project]
+name = "raitap-myattack"
+dependencies = [
+    "raitap>=0.5,<0.6",   # required — RAITAP reads this pin at load time
+    "myattack-lib",
+]
+
+[project.entry-points."raitap.adapters"]
+myattack = "raitap_myattack"   # value is the module to import; decorator fires on import
+```
+
+**Version pin.** RAITAP reads the `Requires-Dist: raitap ...` metadata from
+your installed distribution at load time. If the running RAITAP version does not
+satisfy the pin, or if no `raitap` pin is declared at all, the plugin is
+**skipped with a warning** and never breaks the user's run. Pin a tight range
+(`>=x,<y`) whenever you rely on internal API that may change.
+
+## Discovery and isolation
+
+- Discovery fires at **config-registration time** (`register_zen_groups` /
+  `register_configs`), not on a bare `import raitap`.
+- Loading is **default-allow**: all installed plugins under `raitap.adapters`
+  are discovered automatically.
+- A plugin that **crashes at import** is logged (naming the plugin) and skipped
+  — it never breaks RAITAP.
+- Set `RAITAP_DISABLE_PLUGINS=1` to skip all plugin discovery entirely.
+
+## User consumption
+
+```bash
+pip install raitap raitap-myattack
+```
+
+Then in YAML:
+
+```yaml
+robustness:
+  my_run:
+    _target_: MyAttackAssessor
+    algorithm: MyPGD
+    constructor:
+      eps: 0.03
+```
+
+Or in Python:
+
+```python
+from raitap.robustness import myattack
+
+robustness = {"my_run": myattack(algorithm="MyPGD", constructor={"eps": 0.03})}
+```

--- a/docs/contributor/writing-a-plugin.md
+++ b/docs/contributor/writing-a-plugin.md
@@ -16,11 +16,13 @@ In the following guide, we will imagine you want to make you "SuperXAI" library 
 
 Plugins can register:
 
-- Transparency explainers and robustness assessors
-- Metrics, reporting, and tracking adapters
-- Transparency and robustness visualisers
+- **Transparency** explainers & visualisers
+- **Robustness** assessors & visualisers
+- **Metrics** computers 
+- **Reporting** renderers
+- **Trackers**
 
-Backends are not plugin-extensible.
+Backends are not yet plugin-extensible. You can open a feature request or a PR for 1st party support.
 
 ## 1. Create the package
 
@@ -96,6 +98,11 @@ Decorator kwargs (`library`, `algorithm_registry`, `error_patterns`,
 
 `AdapterDecoratorOptions` is exported for typing, in case you want additional custom logic on top of the decorator: `from raitap import
 AdapterDecoratorOptions`.
+
+**Multiple modules.** One plugin can register adapters for several RAITAP
+modules — add more decorated classes to your `__init__.py` (e.g. an
+`@adapters.robustness(...)` assessor next to the explainer). Every decorator
+fires when the plugin is imported on discovery.
 
 ## 3. Declare the entry point and version pin
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,7 @@ using-raitap/installing/index
 using-raitap/configuration/index
 using-raitap/understanding-outputs
 using-raitap/job-launcher
+using-raitap/using-plugins
 using-raitap/flags
 using-raitap/examples/index
 ```

--- a/docs/modules/metrics/frameworks-and-libraries.md
+++ b/docs/modules/metrics/frameworks-and-libraries.md
@@ -55,3 +55,10 @@ include `boxes` and `labels`.
 Scalar detection results such as `map` are written to `metrics.json`. Larger
 structured outputs, such as class-wise or extended summaries, are written to
 `artifacts.json`.
+
+## Third-party adapters
+
+Third-party adapters published to PyPI can register under the `raitap.adapters`
+entry-point group and are auto-discovered at config-registration time. Once
+installed they appear alongside in-tree metric computers. See
+{doc}`../../contributor/writing-a-plugin`.

--- a/docs/modules/robustness/frameworks-and-libraries.md
+++ b/docs/modules/robustness/frameworks-and-libraries.md
@@ -159,3 +159,11 @@ during bisection (TIMEOUT / UNKNOWN) break the search conservatively; the
 returned bound is the loosest still-certified value, never a falsely tight
 one. If every probe for a given class/mode is inconclusive the assessor
 emits a `WARNING` log so vacuous bounds are obvious.
+
+## Third-party adapters
+
+Third-party adapters published to PyPI can register under the `raitap.adapters`
+entry-point group and are auto-discovered at config-registration time. Once
+installed they appear alongside in-tree assessors: `+robustness=myattack` in the
+CLI or `from raitap.robustness import myattack` in Python. See
+{doc}`../../contributor/writing-a-plugin`.

--- a/docs/modules/tracking/frameworks-and-libraries.md
+++ b/docs/modules/tracking/frameworks-and-libraries.md
@@ -74,3 +74,10 @@ For each run, MLflow receives:
 ### Model logging
 
 When `log_model: true`, RAITAP logs the assessed model to MLflow. This can take significant time and resources for large models.
+
+## Third-party adapters
+
+Third-party adapters published to PyPI can register under the `raitap.adapters`
+entry-point group and are auto-discovered at config-registration time. Once
+installed they appear alongside in-tree trackers. See
+{doc}`../../contributor/writing-a-plugin`.

--- a/docs/modules/transparency/frameworks-and-libraries.md
+++ b/docs/modules/transparency/frameworks-and-libraries.md
@@ -334,3 +334,11 @@ transparency = {
 ```
 
 **Note:** `ShapImageVisualiser` requires pixel-level SHAP values from `GradientExplainer` or `DeepExplainer`. Other SHAP visualisers are intended for tabular or interpretable feature outputs and are treated as cohort summaries when they aggregate the selected batch.
+
+## Third-party adapters
+
+Third-party adapters published to PyPI can register under the `raitap.adapters`
+entry-point group and are auto-discovered at config-registration time. Once
+installed they appear alongside in-tree explainers: `+transparency=myexplainer`
+in the CLI or `from raitap.transparency import myexplainer` in Python. See
+{doc}`../../contributor/writing-a-plugin`.

--- a/docs/using-raitap/configuration/general.md
+++ b/docs/using-raitap/configuration/general.md
@@ -265,6 +265,8 @@ config = AppConfig(model=ModelConfig(source="./my-custom-model.onnx"))
 
 In the above example, the final config will use the custom ONNX model, because `_self_` is applied last.
 
+(multirun)=
+
 ### Batch runs
 
 Hydra can execute multiple runs from a single command using `--multirun`.

--- a/docs/using-raitap/configuration/python-api.md
+++ b/docs/using-raitap/configuration/python-api.md
@@ -126,7 +126,7 @@ Library-forwarded kwargs (unchecked at schema time):
 
 ## Multiruns in Python
 
-Only the CLi can benefit from Hydra's multirun feature (see {ref}`general:multirun`), but you can recreate the loop in Python directly:
+Only the CLI can benefit from Hydra's multirun feature (see {ref}`multirun`), but you can recreate the loop in Python directly:
 
 ```python
 from copy import deepcopy

--- a/docs/using-raitap/configuration/python-api.md
+++ b/docs/using-raitap/configuration/python-api.md
@@ -13,38 +13,27 @@ This page explains how to use RAITAP from Python directly, without YAML files or
 
 ## When to use which
 
-**Use YAML + CLI when** your job is reproducible from disk, when you sweep parameters with Hydra multirun, or when you launch on Slurm. The CLI gives you `--multirun`, `--help`, dotted overrides, and persistent output directories. Configs in version control are the source of truth.
+**Use YAML + CLI when** your job is reproducible from disk, when you **sweep parameters with Hydra multirun**, or when you launch on **Slurm**. The CLI gives you `--multirun`, `--help`, dotted overrides, and persistent output directories. Configs in version control are the source of truth.
 
-**Use Python when** you work in a notebook, embed RAITAP into another tool, want type checking against the dataclass schema, or build configs dynamically (e.g. a sweep generated in a `for` loop where each iteration depends on the previous result). The Python path skips Hydra's `chdir` and its logging hijack, so it composes cleanly with your own logging and working-directory conventions.
+**Use Python when** you work in a **notebook**, embed RAITAP into another tool, want **type-checking** against the dataclass schema, or **build configs dynamically** (e.g. a sweep generated in a `for` loop where each iteration depends on the previous result). The Python path skips Hydra's `chdir` and its logging hijack, so it composes cleanly with your own logging and working-directory conventions.
 
 ## API surface
 
-The Python API is laid out so each module is the single owner of *both* its type contract (the schema dataclass) and its instances (the hydra-zen builders). Adding a new adapter is therefore strictly a single-file change inside its module — nothing else needs editing.
+The general use objects are exported by the `raitap` package:
 
-**Top-level — `from raitap import …`.** Orchestration-level only.
+```python
+from raitap import AppConfig, Hardware, run
+```
 
-| Name         | Kind      | Why top-level                                |
-| ------------ | --------- | -------------------------------------------- |
-| `run`        | function  | runs an `AppConfig` through the orchestrator |
-| `AppConfig`  | dataclass | root schema; consumed by `run`               |
-| `Hardware`   | `StrEnum` | cross-cuts orchestrator + deps inference     |
-| `raitap_log` | logger    | unified info/warn singleton                  |
+The module-specific objects are exported by the respective modules:
 
-**Per-module — `from raitap.<module> import …`.** Each module exposes its schema dataclass, its adapter builders, and any module-local enum.
-
-| Module                | Schema                       | Builders                                                                                                                                                                                                     | Module enums                  |
-| --------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------- |
-| `raitap.models`       | `ModelConfig`                | —                                                                                                                                                                                                            | —                             |
-| `raitap.data`         | `DataConfig`, `LabelsConfig` | —                                                                                                                                                                                                            | `LabelEncoding`, `IdStrategy` |
-| `raitap.metrics`      | `MetricsConfig`              | `binary_classification`, `multiclass_classification`, `multilabel_classification`, `detection`                                                                                                               | —                             |
-| `raitap.transparency` | `TransparencyConfig`         | `captum`, `shap`, `captum_image`, `captum_text`, `captum_time_series`, `shap_bar`, `shap_beeswarm`, `shap_force`, `shap_image`, `shap_waterfall`, `tabular_bar_chart`                                        | —                             |
-| `raitap.robustness`   | `RobustnessConfig`           | `torchattacks`, `foolbox`, `marabou`, `image_pair`, `perturbation_heatmap`, `output_bounds_cohort`, `output_bounds_pinned`, `output_bounds_width_heatmap`, `output_bounds_margin_heatmap`, `verdict_summary` | —                             |
-| `raitap.reporting`    | `ReportingConfig`            | `html`, `pdf`                                                                                                                                                                                                | —                             |
-| `raitap.tracking`     | `TrackingConfig`             | `mlflow`                                                                                                                                                                                                     | —                             |
-
-Each builder is a hydra-zen `builds()` dataclass; calling it returns an instance the orchestrator `instantiate`s. See {ref}`type-safety-map` for what is statically typed vs forwarded.
-
-All names load lazily via :pep:`562` ``__getattr__`` so ``import raitap`` does not pull torch / Captum / torchattacks. `TYPE_CHECKING` blocks list every name statically so editor autocomplete still surfaces them.
+```python
+from raitap.models import ModelConfig
+from raitap.data import DataConfig, LabelsConfig
+from raitap.metrics import multiclass_classification
+from raitap.robustness import image_pair, torchattacks
+from raitap.transparency import captum, captum_image
+```
 
 ## Install + quickstart
 
@@ -58,41 +47,9 @@ from raitap.models import ModelConfig
 from raitap.robustness import image_pair, torchattacks
 from raitap.transparency import captum, captum_image
 
-cfg = AppConfig(
-    hardware=Hardware.cpu,
-    experiment_name="demo",
-    model=ModelConfig(source="vit_b_32"),
-    data=DataConfig(
-        name="imagenet_samples",
-        source="imagenet_samples",
-        forward_batch_size=4,
-        labels=LabelsConfig(
-            source="imagenet_samples",
-            id_column="image",
-            column="label",
-        ),
-    ),
-    metrics=multiclass_classification(num_classes=1000),
-    transparency={
-        "captum_ig": captum(
-            algorithm="IntegratedGradients",
-            call={"target": 0},
-            visualisers=[captum_image()],
-        ),
-    },
-    robustness={
-        "pgd": torchattacks(
-            algorithm="PGD",
-            constructor={"eps": 0.03, "alpha": 0.005, "steps": 10},
-            visualisers=[image_pair()],
-        ),
-    },
-)
+cfg = # config code, omitted
 
 outputs = run(cfg, verbose=False)
-
-first_explanation = outputs.explanations[0]
-metric_values = outputs.metrics.result.metrics if outputs.metrics else {}
 ```
 
 `verbose=False` suppresses the rich console summary panel but does not silence Python `logging`; configure the root logger yourself if you want quiet output.
@@ -107,304 +64,17 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 ### Auto-installing extras from Python
 
-The `raitap` CLI walks the composed Hydra config before any heavy import, then installs the matching extras via `uv add` / `uv sync` (see <a href="../flags.html#flag-allow-project-edit"><code>--allow-project-edit</code></a>). The Python entry point gets the same flow with <a href="../flags.html#flag-allow-project-edit"><code>auto_install_deps=True</code></a>:
+Pass the corresponding flag to the `run` function:
 
 ```python
-from raitap import AppConfig, Hardware, run
-from raitap.data import DataConfig, LabelsConfig
-from raitap.metrics import multiclass_classification
-from raitap.models import ModelConfig
-from raitap.reporting import html
-from raitap.robustness import image_pair, torchattacks
-from raitap.transparency import captum, captum_image
+# imports omitted
 
-cfg = AppConfig(
-    hardware=Hardware.gpu,
-    model=ModelConfig(source="vit_b_32"),
-    metrics=multiclass_classification(num_classes=1000),
-    transparency={"default": captum(algorithm="IntegratedGradients", call={"target": 0}, visualisers=[captum_image()])},
-    robustness={"pgd": torchattacks(algorithm="PGD", constructor={"eps": 0.03}, visualisers=[image_pair()])},
-    reporting=html(filename="report"),
-)
+cfg = # config code, omitted
+
 run(cfg, auto_install_deps=True)
 ```
 
-Why this works in a venv with **no extras installed yet**: every adapter module wraps its third-party library imports in `raitap.utils.lazy.lazy_import`, so importing `from raitap.metrics import multiclass_classification` does not pull `torchmetrics` at module load — only when you later instantiate the wrapped class. With `auto_install_deps=True`, `run` walks the cfg, infers the extras (it reads `_target_` strings the builders bake in), runs `uv add raitap[<extras>]`, and re-execs the script so the freshly-installed packages are visible when the pipeline actually invokes them. Idempotent: a sentinel env var short-circuits the second pass after the re-exec, so the same script line runs once and then becomes a no-op on the relaunch.
-
 `auto_install_deps` is opt-in. Without it `run(cfg)` assumes the extras the config references are already installed — the typical case after a CLI bootstrap or a manual `uv sync`. A missing adapter library surfaces as the usual `ModuleNotFoundError` from the adapter import chain.
-
-Pass <a href="../flags.html#flag-exec-global"><code>exec_global=True</code></a> together with `auto_install_deps=True` to consent to the bare-`pip install` fallback when no venv is active.
-
-Each module exposes [hydra-zen `builds`](https://mit-ll-responsible-ai.github.io/hydra-zen/) factories — one per adapter — derived automatically from the class declaration. Import them from the relevant module:
-
-```python
-from raitap.transparency import captum, shap
-from raitap.robustness import foolbox, torchattacks
-from raitap.metrics import multiclass_classification, detection
-```
-
-These return *dataclass types* whose fields inherit the schema dataclass (`TransparencyConfig` / `RobustnessConfig` / `MetricsConfig`). Calling them with keyword arguments produces a config instance the orchestrator `instantiate`s — the same path Hydra takes when reading YAML. They are interchangeable with hand-written schema instances; choose whichever gives you better autocomplete in your editor.
-
-## Kitchen-sink translation
-
-The blocks below mirror, section by section, the YAML in {doc}`../examples/kitchen-sink`. Each `config-tabs` group renders the YAML on the left and the Python equivalent on the right.
-
-### Model
-
-```{config-tabs}
-:yaml:
-model:
-  source: "./models/my-model.onnx"
-
-:python:
-from raitap.models import ModelConfig
-
-model = ModelConfig(source="./models/my-model.onnx")
-```
-
-### Data
-
-`DataConfig` nests a `LabelsConfig`. Both are plain dataclasses, so editor tooling will type-check the field names.
-
-```{config-tabs}
-:yaml:
-data:
-  name: "my-dataset"
-  description: "Internal validation set"
-  source: "./data/images"
-  forward_batch_size: 32
-  labels:
-    source: "./data/labels.csv"
-    id_column: "image"
-    column: "label"
-    encoding: "index"
-
-:python:
-from raitap.data import DataConfig, LabelEncoding, LabelsConfig
-
-data = DataConfig(
-    name="my-dataset",
-    description="Internal validation set",
-    source="./data/images",
-    forward_batch_size=32,
-    labels=LabelsConfig(
-        source="./data/labels.csv",
-        id_column="image",
-        column="label",
-        encoding=LabelEncoding.index,  # or the literal string "index"
-    ),
-)
-```
-
-### Metrics
-
-```{config-tabs}
-:yaml:
-metrics:
-  _target_: "MulticlassClassificationMetrics"
-  num_classes: 7
-  average: "macro"
-
-:python:
-from raitap.metrics import multiclass_classification
-
-metrics = multiclass_classification(num_classes=7, average="macro")
-```
-
-The hydra-zen builder is the recommended path here because `MulticlassClassificationMetrics` exposes many optional kwargs (`average`, `ignore_index`, …) that the bare `MetricsConfig` discriminator does not type explicitly. `populate_full_signature=True` lifts the full constructor signature onto the dataclass, so your editor will autocomplete every kwarg. Pick the matching builder (`binary_classification`, `multiclass_classification`, `multilabel_classification`, `detection`) for the task you're configuring.
-
-### Transparency
-
-`AppConfig.transparency` is a `dict[str, TransparencyConfig]`. The dict key (`captum_ig`, `shap_gradient`) is the *run name*; it shows up in reports and tracking artefacts so different explainer configurations stay distinguishable.
-
-```{config-tabs}
-:yaml:
-transparency:
-  captum_ig:
-    _target_: "CaptumExplainer"
-    algorithm: "IntegratedGradients"
-    constructor: {}
-    call:
-      target: 0
-      baselines:
-        source: "./data/baselines"
-        n_samples: 8
-    visualisers:
-      - _target_: "CaptumImageVisualiser"
-        constructor:
-          method: "blended_heat_map"
-          sign: "all"
-          show_colorbar: true
-          title: "Integrated gradients"
-          include_original_image: true
-        call:
-          max_samples: 4
-          show_sample_names: true
-  shap_gradient:
-    _target_: "ShapExplainer"
-    algorithm: "GradientExplainer"
-    constructor:
-      local_smoothing: 0.0
-    call:
-      target: 0
-      nsamples: 10
-      background_data:
-        source: "./data/background"
-        n_samples: 32
-    raitap:
-      batch_size: 1
-      progress_desc: "SHAP batches"
-    visualisers:
-      - _target_: "ShapImageVisualiser"
-        constructor:
-          max_samples: 2
-
-:python:
-from raitap.transparency import captum, captum_image, shap, shap_image
-
-transparency = {
-    "captum_ig": captum(
-        algorithm="IntegratedGradients",
-        call={
-            "target": 0,
-            "baselines": {"source": "./data/baselines", "n_samples": 8},
-        },
-        visualisers=[
-            captum_image(
-                method="blended_heat_map",
-                sign="all",
-                show_colorbar=True,
-                title="Integrated gradients",
-                include_original_image=True,
-                call={"max_samples": 4, "show_sample_names": True},
-            ),
-        ],
-    ),
-    "shap_gradient": shap(
-        algorithm="GradientExplainer",
-        constructor={"local_smoothing": 0.0},
-        call={
-            "target": 0,
-            "nsamples": 10,
-            "background_data": {"source": "./data/background", "n_samples": 32},
-        },
-        raitap={"batch_size": 1, "progress_desc": "SHAP batches"},
-        visualisers=[shap_image(max_samples=2)],
-    ),
-}
-```
-
-Visualisers expose a builder per class (`captum_image`, `shap_image`, `image_pair`, `perturbation_heatmap`, …). Flat constructor kwargs map to the wrapped `__init__`; pass `call={...}` for render-time options. No `_target_` strings needed.
-
-### Robustness
-
-Robustness uses the same shape: `dict[str, RobustnessConfig]`, named runs, list of visualisers.
-
-```{config-tabs}
-:yaml:
-robustness:
-  pgd:
-    _target_: "TorchattacksAssessor"
-    algorithm: "PGD"
-    constructor:
-      eps: 0.03
-      alpha: 0.0078
-      steps: 10
-    visualisers:
-      - _target_: "ImagePairVisualiser"
-        constructor:
-          max_samples: 4
-  linf_pgd:
-    _target_: "FoolboxAssessor"
-    algorithm: "LinfPGD"
-    constructor:
-      rel_stepsize: 0.025
-      steps: 40
-    call:
-      eps: 0.03
-    visualisers:
-      - _target_: "PerturbationHeatmapVisualiser"
-
-:python:
-from raitap.robustness import foolbox, image_pair, perturbation_heatmap, torchattacks
-
-robustness = {
-    "pgd": torchattacks(
-        algorithm="PGD",
-        constructor={"eps": 0.03, "alpha": 0.0078, "steps": 10},
-        visualisers=[image_pair(max_samples=4)],
-    ),
-    "linf_pgd": foolbox(
-        algorithm="LinfPGD",
-        constructor={"rel_stepsize": 0.025, "steps": 40},
-        call={"eps": 0.03},
-        visualisers=[perturbation_heatmap()],
-    ),
-}
-```
-
-### Reporting
-
-```{config-tabs}
-:yaml:
-reporting:
-  _target_: "HTMLReporter"
-  filename: "report"
-  multirun_report: true
-  show_original_per_explainer: false
-  show_redundant_robustness_panels: false
-
-:python:
-from raitap.reporting import html
-
-reporting = html(
-    filename="report",
-    multirun_report=True,
-    show_original_per_explainer=False,
-    show_redundant_robustness_panels=False,
-)
-```
-
-Leaving `reporting=None` on the `AppConfig` (or omitting the section in YAML) disables report generation entirely — useful from notebooks where you inspect the in-memory `RunOutputs` directly.
-
-### Tracking
-
-```{config-tabs}
-:yaml:
-tracking:
-  _target_: "MLFlowTracker"
-  output_forwarding_url: "http://127.0.0.1:5001"
-  log_model: false
-  open_when_done: true
-
-:python:
-from raitap.tracking import mlflow
-
-tracking = mlflow(
-    output_forwarding_url="http://127.0.0.1:5001",
-    log_model=False,
-    open_when_done=True,
-)
-```
-
-### Putting it together
-
-```python
-from raitap import AppConfig, Hardware, run
-
-cfg = AppConfig(
-    hardware=Hardware.gpu,
-    experiment_name="My Experiment",
-    model=model,
-    data=data,
-    transparency=transparency,
-    robustness=robustness,
-    metrics=metrics,
-    tracking=tracking,
-    reporting=reporting,
-)
-outputs = run(cfg)
-```
 
 ## Translation rules
 
@@ -417,28 +87,28 @@ outputs = run(cfg)
 | `MISSING` defaults                                               | Builder kwargs are required-or-optional based on the wrapped constructor signature; your editor surfaces the missing ones.                                                                                           |
 | CLI overrides (`+foo.bar=baz`)                                   | Mutate the dataclass: `cfg.transparency["my_run"].call["target"] = 1`. Builders return dataclasses, so attribute assignment works.                                                                                   |
 
+See {doc}`../examples/index` for translation examples.
+
 (type-safety-map)=
 
-## Type safety map
+## Type safety
 
-The schema is a deliberate mix of strict and forwarded. Knowing which fields are which avoids head-scratching about why one typo is caught immediately and another only at run time.
+Due to how Hydra works, only some fields are typed.
 
-**Fully typed**
+### Fully typed
 
-- `hardware: Hardware`, `data.labels.encoding: LabelEncoding`, `data.labels.id_strategy: IdStrategy`, `data.labels.kind: LabelKind` — all four are `enum.StrEnum` subclasses. Imports follow the module-ownership rule: `from raitap import Hardware`, `from raitap.data import LabelEncoding, IdStrategy`, `from raitap.data.types import LabelKind`. **Pass the enum member** (`Hardware.cpu`) — typos like `Hardware.cpuu` fail at import time and Pyright/your editor catch them immediately. The raw string form (`"cpu"`) still parses at runtime via OmegaConf coercion, but it bypasses static type-checking — defeating the main reason to use the Python path over YAML.
+- `hardware: Hardware`, `data.labels.encoding: LabelEncoding`, `data.labels.id_strategy: IdStrategy`, `data.labels.kind: LabelKind` — all four are `enum.StrEnum` subclasses.
 - The nested dataclass dicts on `AppConfig.transparency` and `AppConfig.robustness` — keys are arbitrary user-chosen strings, values must be `TransparencyConfig` / `RobustnessConfig` instances (or dicts with the right keys).
 - All scalar fields on `ModelConfig`, `DataConfig`, `LabelsConfig`, `MetricsConfig`, `TrackingConfig`, `ReportingConfig` are checked by OmegaConf's structured-config validation when the orchestrator boots.
 
-**Library-forwarded kwargs (unchecked at schema time)**
+Library-forwarded kwargs (unchecked at schema time):
 
 - `TransparencyConfig.constructor` / `.call` / `.raitap` — dicts forwarded verbatim to the underlying explainer library (Captum's `IntegratedGradients(...)`, SHAP's `GradientExplainer(...)`, the corresponding `.attribute()` / `.shap_values()` call).
 - `RobustnessConfig.constructor` / `.call` / `.raitap` — same story for torchattacks / Foolbox / Marabou.
 
-The hydra-zen builders in `raitap.api` (`captum`, `shap`, `torchattacks`, `foolbox`, plus the per-task metrics builders `binary_classification`, `multiclass_classification`, `multilabel_classification`, `detection`) inherit the corresponding schema dataclass via `builds_bases=`, so they accept every field on `TransparencyConfig` / `RobustnessConfig` / `MetricsConfig` (`algorithm`, `constructor`, `call`, `raitap`, `visualisers`). The classification and detection builders additionally use `populate_full_signature=True` to surface the full adapter `__init__` signature (`average`, `num_labels`, `ignore_index`, `iou`, …). For Captum / SHAP / torchattacks / Foolbox, the underlying constructor takes `**kwargs`, so per-library kwargs (`eps=`, `steps=`, `target=`) stay inside the `constructor` / `call` dict — your editor autocompletes the schema fields, not the library kwargs.
-
 (runoutputs-shape)=
 
-## RunOutputs shape
+## `RunOutputs` shape
 
 `raitap.run` returns a frozen `RunOutputs` dataclass:
 
@@ -454,30 +124,24 @@ The hydra-zen builders in `raitap.api` (`captum`, `shap`, `torchattacks`, `foolb
 | `robustness_results`        | `list[RobustnessResult]`              | One per `(robustness_run, sample_batch)`; carries adversarial tensors and per-sample success flags.  |
 | `robustness_visualisations` | `list[RobustnessVisualisationResult]` | Rendered robustness outputs (image pairs, heat maps).                                                |
 
-When `reporting` is configured these fields flow through `HTMLReporter` and end up on disk under the reporting output directory; when `tracking` is configured they are logged as MLflow artefacts. From Python you can read them straight out of the returned object without enabling either subsystem.
+## Multiruns in Python
 
-## CLI ↔ Python parity
-
-Single-run YAML configs round-trip cleanly: the Python `AppConfig` you build by hand and the dataclass that Hydra materialises from `demo.yaml` drive the orchestrator identically (the test suite asserts this — see `test_run_parity_with_yaml_demo` in `src/raitap/tests/test_api.py`).
-
-Multirun sweeps stay CLI-only. Hydra's `--multirun` machinery, sweep plugins, and the `${hydra.sweep.dir}` resolver have no in-Python equivalent. When you need a sweep from Python, build the configs yourself and call `run` per config:
+Only the CLi can benefit from Hydra's multirun feature (see {ref}`general:multirun`), but you can recreate the loop in Python directly:
 
 ```python
 from copy import deepcopy
 
 from raitap import run
 
-base = _build_base_config()  # an AppConfig from earlier in this page
+cfg = # omitted, see example above
 
 results = []
 for eps in (0.01, 0.03, 0.06, 0.1):
-    cfg = deepcopy(base)
-    cfg.robustness["pgd"].constructor["eps"] = eps
-    cfg.experiment_name = f"pgd-eps={eps}"
-    results.append((eps, run(cfg, verbose=False)))
+    copied_cfg = deepcopy(cfg)
+    copied_cfg.robustness["pgd"].constructor["eps"] = eps
+    copied_cfg.experiment_name = f"pgd-eps={eps}"
+    results.append((eps, run(copied_cfg, verbose=False)))
 
 for eps, outputs in results:
     print(eps, outputs.metrics.result.metrics if outputs.metrics else None)
 ```
-
-For anything more elaborate than a one-axis sweep — e.g. cross-product over `(eps, steps)`, conditional skips, dependency between consecutive runs — a Python `for` loop with `deepcopy` is both simpler and faster to read than the equivalent `--multirun` invocation. The trade-off is that you lose Hydra's automatic per-run output directories; manage those yourself if you need them.

--- a/docs/using-raitap/installing/manual.md
+++ b/docs/using-raitap/installing/manual.md
@@ -8,26 +8,19 @@ myst:
 
 # Using manual deps management
 
-This page explains how to turn off automatic deps management and handle dependencies yourself. 
+This page explains how to turn off automatic deps management and handle dependencies yourself.
 
-## 1. Turn off automatic deps management
+## 1. Install the hardware backend
 
-Pass <a href="../flags.html#flag-custom-deps"><code>--custom-deps</code></a>;
-install everything the config needs first.
+Install only the backend matching your setup.
 
 ```{install-tabs}
 :uv:
-uv run raitap --config-dir my-configs --config-name assessment --custom-deps
+uv add "raitap[torch-cuda]"
 
 :pip:
-raitap --config-dir my-configs --config-name assessment --custom-deps
+pip install "raitap[torch-cuda]"
 ```
-
-(execution-dependencies)=
-
-## 2. Pick a hardware backend
-
-Install only the backend matching your setup.
 
 |       | CPU         | CUDA         | Intel GPU     |
 | ----- | ----------- | ------------ | ------------- |
@@ -45,7 +38,9 @@ CUDA / Intel wheels do not live on PyPI. Re-declare the index routing per hardwa
 :::{include} _gotchas.md
 :::
 
-## 3. Pick assessment extras
+(execution-dependencies)=
+
+## 2. Pick assessment extras
 
 (assessment-extras)=
 
@@ -71,3 +66,16 @@ You can either:
   :pip:
   pip install "raitap[onnx-cpu,transparency,metrics]"
   ```
+
+## 3. Run the config with automatic deps management off
+
+Pass <a href="../flags.html#flag-custom-deps"><code>--custom-deps</code></a>;
+install everything the config needs first.
+
+```{install-tabs}
+:uv:
+uv run raitap --config-dir my-configs --config-name assessment --custom-deps
+
+:pip:
+raitap --config-dir my-configs --config-name assessment --custom-deps
+```

--- a/docs/using-raitap/using-plugins.md
+++ b/docs/using-raitap/using-plugins.md
@@ -1,0 +1,67 @@
+---
+title: "Using plugins"
+description: "Install third-party RAITAP adapters and use them like built-in ones."
+myst:
+  html_meta:
+    "description": "Install third-party RAITAP adapters and use them like built-in ones."
+---
+
+# Using plugins
+
+Third-party packages can add adapters (extra explainers, attacks, trackers, …)
+to RAITAP. Once installed alongside RAITAP, a plugin's adapter behaves like a
+first-party one — same YAML and Python API.
+
+:::{tip}
+Are you a library maintainer wanting to ship your own adapter as a plugin? See
+{doc}`../contributor/writing-a-plugin`.
+:::
+
+## Install
+
+Install the plugin next to RAITAP:
+
+```bash
+pip install raitap raitap-myattack
+```
+
+That's it — no config flag to "enable" it. Every installed plugin is discovered
+automatically.
+
+## Use it
+
+Reference the adapter by its `registry_name` (here, `myattack`), exactly like a
+built-in adapter.
+
+In YAML:
+
+```yaml
+robustness:
+  my_run:
+    _target_: MyAttackAssessor
+    algorithm: MyPGD
+    constructor:
+      eps: 0.03
+```
+
+In Python:
+
+```python
+from raitap.robustness import myattack
+
+robustness = {"my_run": myattack(algorithm="MyPGD", constructor={"eps": 0.03})}
+```
+
+The `+robustness=myattack` CLI shorthand also works **if** the plugin ships a
+matching preset; otherwise compose it inline as above.
+
+## If a plugin doesn't show up
+
+- **Version mismatch.** A plugin declares which RAITAP versions it supports. If
+  your installed RAITAP is outside that range (or the plugin declares no range),
+  RAITAP **skips it and logs a warning** — check your run's logs and upgrade the
+  plugin or RAITAP as needed.
+- **A plugin crashed on load.** A broken plugin is logged (by name) and skipped;
+  it never breaks your run. The warning names the culprit.
+- **Disable all plugins.** Set `RAITAP_DISABLE_PLUGINS=1` to ignore every
+  installed plugin — useful for reproducing an issue without third-party code.

--- a/docs/using-raitap/using-plugins.md
+++ b/docs/using-raitap/using-plugins.md
@@ -40,7 +40,7 @@ built-in adapter.
 :yaml:
 transparency:
   my_run:
-    _target_: "SuperXAIExplainer"
+    _target_: "raitap_superxai.SuperXAIExplainer"   # full import path — plugin classes live outside raitap.*
     algorithm: supertreeshap
 
 :python:
@@ -49,8 +49,11 @@ from raitap.transparency import superxai
 transparency = {"my_run": superxai(algorithm="supertreeshap")}
 ```
 
-The `+transparency=superxai` CLI shorthand also works **if** the plugin ships a
-matching preset; otherwise compose it inline as above.
+In YAML, use the plugin class's **full import path** (`raitap_superxai.SuperXAIExplainer`):
+a bare `_target_: SuperXAIExplainer` only resolves for built-in adapters. The
+Python form needs no path — `superxai` already carries it. The
+`+transparency=superxai` CLI shorthand also works **if** the plugin ships a
+matching preset.
 
 ## If a plugin doesn't show up
 

--- a/docs/using-raitap/using-plugins.md
+++ b/docs/using-raitap/using-plugins.md
@@ -8,43 +8,42 @@ myst:
 
 # Using plugins
 
-Third-party packages can add adapters (extra explainers, attacks, trackers, …)
-to RAITAP. Once installed alongside RAITAP, a plugin's adapter behaves like a
-first-party one — same YAML and Python API.
+This page explains how to seamlessly use a 3rd party lib's plugin in RAITAP.
+
+Some libraries are implemented as 1st party in RIAITAP directly, but some others simply ship a plugin. The user-facing behaviour is identical.
 
 :::{tip}
 Are you a library maintainer wanting to ship your own adapter as a plugin? See
 {doc}`../contributor/writing-a-plugin`.
 :::
 
-## Install
+## 1. Install
 
 Install the plugin next to RAITAP:
 
-```bash
+```{install-tabs}
+:uv:
+uv add raitap raitap-superxai
+
+:pip:
 pip install raitap raitap-superxai
 ```
 
-That's it — no config flag to "enable" it. Every installed plugin is discovered
-automatically.
+That's it. Every installed plugin is discovered automatically.
 
-## Use it
+## 2. Use it
 
 Reference the adapter by its `registry_name` (here, `superxai`), exactly like a
 built-in adapter.
 
-In YAML:
-
-```yaml
+```{config-tabs}
+:yaml:
 transparency:
   my_run:
-    _target_: SuperXAIExplainer
+    _target_: "SuperXAIExplainer"
     algorithm: supertreeshap
-```
 
-In Python:
-
-```python
+:python:
 from raitap.transparency import superxai
 
 transparency = {"my_run": superxai(algorithm="supertreeshap")}

--- a/docs/using-raitap/using-plugins.md
+++ b/docs/using-raitap/using-plugins.md
@@ -22,7 +22,7 @@ Are you a library maintainer wanting to ship your own adapter as a plugin? See
 Install the plugin next to RAITAP:
 
 ```bash
-pip install raitap raitap-myattack
+pip install raitap raitap-superxai
 ```
 
 That's it — no config flag to "enable" it. Every installed plugin is discovered
@@ -30,29 +30,27 @@ automatically.
 
 ## Use it
 
-Reference the adapter by its `registry_name` (here, `myattack`), exactly like a
+Reference the adapter by its `registry_name` (here, `superxai`), exactly like a
 built-in adapter.
 
 In YAML:
 
 ```yaml
-robustness:
+transparency:
   my_run:
-    _target_: MyAttackAssessor
-    algorithm: MyPGD
-    constructor:
-      eps: 0.03
+    _target_: SuperXAIExplainer
+    algorithm: supertreeshap
 ```
 
 In Python:
 
 ```python
-from raitap.robustness import myattack
+from raitap.transparency import superxai
 
-robustness = {"my_run": myattack(algorithm="MyPGD", constructor={"eps": 0.03})}
+transparency = {"my_run": superxai(algorithm="supertreeshap")}
 ```
 
-The `+robustness=myattack` CLI shorthand also works **if** the plugin ships a
+The `+transparency=superxai` CLI shorthand also works **if** the plugin ships a
 matching preset; otherwise compose it inline as above.
 
 ## If a plugin doesn't show up

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,7 +273,7 @@ include = [
   "src/raitap/reporting/templates/**/*",
   "src/hydra_plugins/**/*.py",
 ]
-exclude = ["src/raitap/**/test_*.py", "src/raitap/**/conftest.py", "src/raitap/tests/_fake_plugin/**", "src/raitap/configs/zhaw/*.yaml", "src/raitap/configs/zhaw/*.yml"]
+exclude = ["src/raitap/**/test_*.py", "src/raitap/**/conftest.py", "src/raitap/tests/_fake_*plugin/**", "src/raitap/configs/zhaw/*.yaml", "src/raitap/configs/zhaw/*.yml"]
 
 [tool.hatch.build.targets.wheel.force-include]
 # Ship pyproject.toml inside the wheel so the auto-deps bootstrap can read
@@ -297,7 +297,7 @@ include = [
 exclude = [
   "src/raitap/**/test_*.py",
   "src/raitap/**/conftest.py",
-  "src/raitap/tests/_fake_plugin/**",
+  "src/raitap/tests/_fake_*plugin/**",
   "src/raitap/configs/zhaw/*.yaml",
   "src/raitap/configs/zhaw/*.yml",
   "contributor-configs/**",
@@ -379,7 +379,7 @@ reportUnusedImport = true
 reportUnusedVariable = true
 
 [tool.pytest.ini_options]
-norecursedirs = ["assets", "usecases", "outputs", "mlartifacts", "src/raitap/tests/_fake_plugin"]
+norecursedirs = ["assets", "usecases", "outputs", "mlartifacts", "src/raitap/tests/_fake_plugin", "src/raitap/tests/_fake_broken_plugin"]
 testpaths = ["src"]
 pythonpath = ["src"]
 python_files = ["test_*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,7 +273,7 @@ include = [
   "src/raitap/reporting/templates/**/*",
   "src/hydra_plugins/**/*.py",
 ]
-exclude = ["src/raitap/**/test_*.py", "src/raitap/**/conftest.py", "src/raitap/configs/zhaw/*.yaml", "src/raitap/configs/zhaw/*.yml"]
+exclude = ["src/raitap/**/test_*.py", "src/raitap/**/conftest.py", "src/raitap/tests/_fake_plugin/**", "src/raitap/configs/zhaw/*.yaml", "src/raitap/configs/zhaw/*.yml"]
 
 [tool.hatch.build.targets.wheel.force-include]
 # Ship pyproject.toml inside the wheel so the auto-deps bootstrap can read
@@ -297,6 +297,7 @@ include = [
 exclude = [
   "src/raitap/**/test_*.py",
   "src/raitap/**/conftest.py",
+  "src/raitap/tests/_fake_plugin/**",
   "src/raitap/configs/zhaw/*.yaml",
   "src/raitap/configs/zhaw/*.yml",
   "contributor-configs/**",
@@ -378,7 +379,7 @@ reportUnusedImport = true
 reportUnusedVariable = true
 
 [tool.pytest.ini_options]
-norecursedirs = ["assets", "usecases", "outputs", "mlartifacts"]
+norecursedirs = ["assets", "usecases", "outputs", "mlartifacts", "src/raitap/tests/_fake_plugin"]
 testpaths = ["src"]
 pythonpath = ["src"]
 python_files = ["test_*.py"]

--- a/src/raitap/__init__.py
+++ b/src/raitap/__init__.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from raitap._adapters import AdapterDecoratorOptions
 from raitap.utils.log import raitap_log
 
 if TYPE_CHECKING:
@@ -48,6 +49,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "AdapterDecoratorOptions",
     "AppConfig",
     "Hardware",
     "raitap_log",

--- a/src/raitap/_adapters.py
+++ b/src/raitap/_adapters.py
@@ -2,8 +2,8 @@
 
 Every concrete adapter (explainer, assessor, metric computer, reporter,
 tracker, visualiser) is registered via its family decorator (e.g.
-``@register_transparency_adapter``, ``@register_robustness_adapter``,
-``@register_transparency_visualiser``). The decorator delegates to
+``@adapters.transparency``, ``@adapters.robustness``,
+``@visualisers.transparency``). The decorator delegates to
 :func:`_register_core` which:
 
 * generates the hydra-zen builder (``builds(...)``)
@@ -69,8 +69,8 @@ class FamilyConfig:
 
 class _AllAlgorithmsSentinel:
     """Singleton type for the :data:`ALL` marker — pass
-    ``onnx_compatible_algorithms=ALL`` to ``@register_transparency_adapter`` /
-    ``@register_robustness_adapter`` to mark every algorithm in the adapter's
+    ``onnx_compatible_algorithms=ALL`` to ``@adapters.transparency`` /
+    ``@adapters.robustness`` to mark every algorithm in the adapter's
     ``algorithm_registry`` as ONNX-compatible without re-listing them."""
 
     __slots__ = ()
@@ -104,7 +104,7 @@ class AdapterMixin:
     Concrete adapters never inherit ``AdapterMixin`` directly — they extend
     their family base class (e.g. ``AttributionOnlyExplainer``,
     ``EmpiricalAttackAssessor``) which mixes in ``AdapterMixin``. Registration
-    is done by the family decorator (e.g. ``@register_transparency_adapter``),
+    is done by the family decorator (e.g. ``@adapters.transparency``),
     not by inheritance.
     """
 

--- a/src/raitap/_adapters.py
+++ b/src/raitap/_adapters.py
@@ -82,10 +82,13 @@ class _AllAlgorithmsSentinel:
 ALL: Final[_AllAlgorithmsSentinel] = _AllAlgorithmsSentinel()
 
 
-class _CommonRegKwargs(TypedDict, total=False):
-    """Cross-family registration kwargs. Forwarded into every family decorator
-    via ``**common: Unpack[_CommonRegKwargs]`` so each decorator declares only
-    its own family-specific required kwargs."""
+class AdapterDecoratorOptions(TypedDict, total=False):
+    """Public: cross-family registration options every adapter decorator
+    accepts. Forwarded into each family decorator via
+    ``**common: Unpack[AdapterDecoratorOptions]``. Family-specific required
+    kwargs (e.g. ``algorithm_registry``) are declared on the individual
+    decorators. Plugin authors may import this type to re-type forwarded kwargs;
+    the decorator signatures are the public contract regardless."""
 
     registry_name: Required[str]
     extra: str
@@ -200,7 +203,7 @@ def _register_core(
     cls: type,
     *,
     family: FamilyConfig | None,
-    **common: Unpack[_CommonRegKwargs],
+    **common: Unpack[AdapterDecoratorOptions],
 ) -> type:
     """Cross-family registration mechanics. Returns ``cls`` unchanged.
 

--- a/src/raitap/_adapters.py
+++ b/src/raitap/_adapters.py
@@ -23,9 +23,11 @@ from __future__ import annotations
 import dataclasses
 import importlib
 import inspect
+import os
 import pkgutil
 from contextlib import contextmanager
 from dataclasses import dataclass
+from importlib import metadata as importlib_metadata
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal, Required, TypedDict, Unpack
 
 from hydra_zen import ZenStore, builds
@@ -286,6 +288,63 @@ def discover(package_path: list[str], package_name: str) -> None:
         if "tests" in name.split("."):
             continue
         importlib.import_module(name)
+
+
+def _plugin_raitap_specifier(distribution_name: str) -> str | None:
+    """Return the plugin distribution's declared ``raitap`` version specifier
+    (from its pip ``Requires-Dist``), or ``None`` if it declares no raitap pin."""
+    from packaging.requirements import Requirement
+
+    reqs = importlib_metadata.requires(distribution_name) or []
+    for raw in reqs:
+        req = Requirement(raw)
+        if req.name == "raitap":
+            return str(req.specifier)
+    return None
+
+
+def _plugin_version_ok(distribution_name: str) -> tuple[bool, str]:
+    """``(ok, message)``. Verify the running raitap version satisfies the
+    plugin's declared raitap specifier. A plugin with no raitap pin is treated
+    as malformed (not ok)."""
+    from packaging.specifiers import SpecifierSet
+
+    from raitap.__about__ import __version__
+
+    spec = _plugin_raitap_specifier(distribution_name)
+    if spec is None:
+        return False, f"{distribution_name!r} declares no 'raitap' dependency pin"
+    if __version__ not in SpecifierSet(spec, prereleases=True):
+        return False, f"{distribution_name!r} requires raitap{spec}; running {__version__}"
+    return True, ""
+
+
+def discover_third_party_adapters() -> None:
+    """Import every module under the ``raitap.adapters`` entry-point group so its
+    decorators fire, populating :data:`_BUILDERS` like in-tree adapters.
+
+    Default-allow; set ``RAITAP_DISABLE_PLUGINS=1`` to skip entirely. Each plugin
+    is version-checked against its pip ``raitap`` pin and isolated: one failure
+    is logged and skipped, never fatal.
+    """
+    if os.environ.get("RAITAP_DISABLE_PLUGINS"):
+        return
+    from raitap.utils.diagnostics import Module
+    from raitap.utils.log import raitap_log
+
+    for ep in importlib_metadata.entry_points(group="raitap.adapters"):
+        dist_name = ep.dist.name if ep.dist is not None else ep.name
+        try:
+            ok, why = _plugin_version_ok(dist_name)
+            if not ok:
+                raitap_log.warn(f"Skipping plugin {ep.name!r}: {why}", module=Module.deps)
+                continue
+            ep.load()  # decorators fire as import side-effect
+        except Exception as exc:
+            raitap_log.warn(
+                f"Plugin {ep.name!r} ({ep.value}) failed to load: {exc}",
+                module=Module.deps,
+            )
 
 
 def lookup(group: str, name: str) -> Any:

--- a/src/raitap/adapters.py
+++ b/src/raitap/adapters.py
@@ -1,0 +1,24 @@
+"""Public namespaced decorator surface for registering RAITAP adapters.
+
+Plugin authors and in-tree adapters decorate with ``@adapters.<family>(...)``::
+
+    from raitap import adapters
+
+    @adapters.robustness(registry_name="myattack", algorithm_registry={...})
+    class MyAttackAssessor(EmpiricalAttackAssessor): ...
+
+Each attribute is the real, fully-typed family decorator (not a dynamic
+attribute), so pyright checks kwargs at the decoration site. Importing this
+module stays torch-free: the underlying ``registration.py`` modules defer torch
+via ``raitap.utils.lazy.lazy_import``.
+"""
+
+from __future__ import annotations
+
+from raitap.metrics.registration import metrics_adapter as metrics
+from raitap.reporting.registration import reporter
+from raitap.robustness.assessors.registration import robustness_adapter as robustness
+from raitap.tracking.registration import tracker
+from raitap.transparency.explainers.registration import transparency_adapter as transparency
+
+__all__ = ["metrics", "reporter", "robustness", "tracker", "transparency"]

--- a/src/raitap/adapters.py
+++ b/src/raitap/adapters.py
@@ -1,11 +1,17 @@
 """Public namespaced decorator surface for registering RAITAP adapters.
 
-Plugin authors and in-tree adapters decorate with ``@adapters.<family>(...)``::
+This is the **public / plugin-author** surface. Third-party plugins decorate
+with ``@adapters.<family>(...)``::
 
     from raitap import adapters
 
     @adapters.robustness(registry_name="myattack", algorithm_registry={...})
     class MyAttackAssessor(EmpiricalAttackAssessor): ...
+
+In-tree adapters do **not** import this facade — they decorate with the bare
+family decorator imported directly from their sibling ``registration.py`` (e.g.
+``from .registration import robustness_adapter``) to avoid an import cycle
+(this module imports every family package, which imports its leaf adapters).
 
 Each attribute is the real, fully-typed family decorator (not a dynamic
 attribute), so pyright checks kwargs at the decoration site. Importing this

--- a/src/raitap/backends.py
+++ b/src/raitap/backends.py
@@ -1,0 +1,17 @@
+"""Public decorator surface for registering model backends.
+
+    from raitap import backends
+
+    @backends.register(supports_torch_autograd=True)
+    class MyBackend(ModelBackend): ...
+
+Backends are not Hydra-config adapters (no registry, no entry-point plugins);
+the decorator only sets + type-checks the required ``supports_torch_autograd``
+class constant at the decoration site.
+"""
+
+from __future__ import annotations
+
+from raitap.models.registration import register
+
+__all__ = ["register"]

--- a/src/raitap/configs/zen.py
+++ b/src/raitap/configs/zen.py
@@ -1,11 +1,11 @@
 """Force adapter registration + apply Hydra-only specialisations.
 
-Adapter classes register themselves via :class:`raitap._adapters.AdapterMixin`
-at class-creation time. That requires the class file to be imported.
-Importing each module's ``__init__.py`` here is enough — those packages
-re-export their leaf adapters, which triggers ``__init_subclass__``.
+Adapter classes register themselves via their family decorator (e.g.
+``@adapters.transparency`` → ``_register_core``) at import time. That requires
+the class file to be imported. Importing each module's ``__init__.py`` here is
+enough — those packages re-export their leaf adapters, firing the decorators.
 
-A handful of bundled Hydra group entries need shapes the mixin can't
+A handful of bundled Hydra group entries need shapes the decorators can't
 produce (``# @package _global_`` callback injection for reporting multirun,
 ``_target_: null`` for the ``disabled`` reporting variant). Those live
 below as direct :class:`hydra.core.config_store.ConfigStore` writes.
@@ -33,8 +33,9 @@ _REGISTERED = False
 
 
 def register_zen_groups() -> None:
-    """Idempotent. Triggers adapter ``__init_subclass__`` for every module,
-    then layers the Hydra-only specialisations on top.
+    """Idempotent. Imports every family package (firing their adapter
+    decorators) and discovers third-party plugins, then layers the Hydra-only
+    specialisations on top.
     """
     global _REGISTERED
     if _REGISTERED:
@@ -42,9 +43,9 @@ def register_zen_groups() -> None:
     _REGISTERED = True
 
     # Importing each subpackage runs its ``__init__.py``, which imports the
-    # leaf adapter modules → ``AdapterMixin.__init_subclass__`` fires. These
-    # are pure side-effect imports; we discard the module objects through
-    # ``importlib`` so both ruff and pyright stay quiet.
+    # leaf adapter modules → their family decorator fires. These are pure
+    # side-effect imports; we discard the module objects through ``importlib``
+    # so both ruff and pyright stay quiet.
     import importlib
 
     for pkg in (

--- a/src/raitap/configs/zen.py
+++ b/src/raitap/configs/zen.py
@@ -56,6 +56,10 @@ def register_zen_groups() -> None:
     ):
         importlib.import_module(pkg)
 
+    from raitap._adapters import discover_third_party_adapters
+
+    discover_third_party_adapters()
+
     # Flush the mixin-generated entries first; the special-cases below then
     # overwrite the reporting entries with the ``_global_`` + multirun shape.
     store.add_to_hydra_store(overwrite_ok=True)

--- a/src/raitap/data/preprocessing.py
+++ b/src/raitap/data/preprocessing.py
@@ -30,7 +30,6 @@ import hashlib
 import importlib.util
 import inspect
 import os
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
@@ -39,6 +38,8 @@ from raitap.data.types import Preprocessing
 from raitap.utils.lazy import lazy_import
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import torch
     from torch import nn
     from torchvision import models
@@ -61,7 +62,11 @@ _MODEL_BUNDLED_VALUE = Preprocessing.model_bundled.value
 
 Origin = Literal["off", "model-bundled", "custom-file"]
 Side = Literal["data", "model"]
-_FactoryT = TypeVar("_FactoryT", bound=Callable[[], nn.Module])
+# String forward-ref bound: a bare ``Callable[[], nn.Module]`` would evaluate
+# ``nn.Module`` at module-import time, and ``nn`` is the lazy torch proxy — that
+# forces ``import torch.nn`` and breaks the torch-free deps-bootstrap path. The
+# string defers it to pyright (resolved via the TYPE_CHECKING imports).
+_FactoryT = TypeVar("_FactoryT", bound="Callable[[], nn.Module]")
 
 
 class DataPreprocessingFactory(Protocol):

--- a/src/raitap/deps/static_scan.py
+++ b/src/raitap/deps/static_scan.py
@@ -1,9 +1,9 @@
 """Best-effort static scan of adapter ``extra=`` declarations.
 
 Walks the installed raitap source tree with :mod:`ast` and harvests every
-``@register_<family>_adapter(...)`` (or ``@register_<family>_visualiser(...)``)
-decorator above a ``class`` def, without importing the module (and therefore
-without pulling the wrapped third-party library).
+family decorator (``@<family>_adapter(...)`` / ``@<family>_visualiser(...)``)
+above a ``class`` def, without importing the module (and therefore without
+pulling the wrapped third-party library).
 
 Mirrors :func:`raitap._adapters._register_core`'s defaulting: when the
 decorator omits ``extra=``, the runtime defaults it to ``registry_name``, so
@@ -19,7 +19,7 @@ whenever it is populated; this scanner is a safety net for
 
 Preserves the "adding a new adapter = single-file add" invariant:
 nothing here is hand-maintained, and a new adapter's
-``@register_*_adapter(..., extra="...")`` is picked up automatically.
+``@<family>_adapter(..., extra="...")`` is picked up automatically.
 """
 
 from __future__ import annotations
@@ -28,11 +28,20 @@ import ast
 from functools import lru_cache
 from pathlib import Path
 
+# In-tree adapters decorate with the bare family decorator imported directly
+# from its ``registration`` module (e.g. ``@metrics_adapter(...)``). The public
+# ``@adapters.<family>`` facade is for external plugin authors and is not used
+# in-tree (it would create an import cycle), so the scanner matches bare names.
+_ADAPTER_DECORATORS = frozenset(
+    {"transparency_adapter", "robustness_adapter", "metrics_adapter", "reporter", "tracker"}
+)
+_VISUALISER_DECORATORS = frozenset({"transparency_visualiser", "robustness_visualiser"})
+
 
 def _decorator_name(deco: ast.expr) -> str | None:
-    """Return the bare name of a decorator call (e.g. ``register_metrics_adapter``)
-    regardless of whether it was imported as ``register_metrics_adapter`` or
-    accessed via ``module.register_metrics_adapter``."""
+    """Return the bare name of a decorator call (e.g. ``metrics_adapter``)
+    regardless of whether it was imported as ``metrics_adapter`` or accessed via
+    ``module.metrics_adapter``."""
     if not isinstance(deco, ast.Call):
         return None
     func = deco.func
@@ -43,16 +52,6 @@ def _decorator_name(deco: ast.expr) -> str | None:
     return None
 
 
-def _is_register_decorator(name: str | None) -> bool:
-    """Match every family registration decorator: ``register_transparency_adapter``,
-    ``register_robustness_adapter``, ``register_metrics_adapter``,
-    ``register_reporter``, ``register_tracker``,
-    ``register_transparency_visualiser``, ``register_robustness_visualiser``.
-    All share the ``register_`` prefix — broader match keeps this future-proof
-    when a new family adds its own decorator."""
-    return name is not None and name.startswith("register_")
-
-
 @lru_cache(maxsize=1)
 def scan_adapter_extras() -> dict[str, str]:
     """Return ``{class_name: extra}`` harvested from raitap's source tree."""
@@ -61,7 +60,7 @@ def scan_adapter_extras() -> dict[str, str]:
     root = Path(raitap.__file__).resolve().parent
     found: dict[str, str] = {}
     for path in root.rglob("*.py"):
-        # Tests can legitimately declare ``@register_*_adapter(..., extra="…")`` —
+        # Tests can legitimately declare ``@<family>_adapter(..., extra="…")`` —
         # they are not real adapters and should not pollute the map.
         if "tests" in path.parts:
             continue
@@ -74,7 +73,7 @@ def scan_adapter_extras() -> dict[str, str]:
                 continue
             for deco in node.decorator_list:
                 name = _decorator_name(deco)
-                if not _is_register_decorator(name):
+                if name not in _ADAPTER_DECORATORS and name not in _VISUALISER_DECORATORS:
                     continue
                 assert isinstance(deco, ast.Call)  # narrowed by _decorator_name
                 kwargs = {
@@ -87,14 +86,12 @@ def scan_adapter_extras() -> dict[str, str]:
                     )
                 }
                 # ``extra`` defaults to ``registry_name`` at runtime for every
-                # schema-backed decorator (``register_*_adapter``,
-                # ``register_reporter``, ``register_tracker``); visualiser
-                # decorators (``register_*_visualiser``) don't get an
-                # auto-extra — they ship with their parent adapter's extra.
+                # schema-backed adapter decorator; visualiser decorators don't
+                # get an auto-extra — they ship with their parent adapter's extra.
                 explicit_extra = kwargs.get("extra")
                 if explicit_extra:
                     found[node.name] = explicit_extra
-                elif name is not None and not name.endswith("_visualiser"):
+                elif name in _ADAPTER_DECORATORS:
                     registry_name = kwargs.get("registry_name")
                     if registry_name:
                         found[node.name] = registry_name

--- a/src/raitap/deps/tests/test_static_scan.py
+++ b/src/raitap/deps/tests/test_static_scan.py
@@ -3,7 +3,7 @@
 :func:`raitap.deps.static_scan.scan_adapter_extras` walks the raitap source
 tree without importing modules so the deps bootstrap can resolve adapter
 extras in partial-extras venvs. This test asserts the runtime
-``ADAPTER_EXTRAS`` populated by ``AdapterMixin.__init_subclass__`` is a
+``ADAPTER_EXTRAS`` populated by the family decorators (``_register_core``) is a
 *subset* of what the scanner finds — drift in either direction (a missing
 ``extra=`` kwarg on a new adapter, or scanner missing a new declaration
 syntax) shows up here.

--- a/src/raitap/metrics/__init__.py
+++ b/src/raitap/metrics/__init__.py
@@ -65,7 +65,13 @@ def __getattr__(name: str) -> Any:
         return MetricsConfig
     from raitap._adapters import lookup
 
-    return lookup("metrics", name)
+    try:
+        return lookup("metrics", name)
+    except AttributeError:
+        from raitap.configs import register_configs
+
+        register_configs()  # idempotent; fires in-tree imports + plugin discovery
+        return lookup("metrics", name)
 
 
 __all__ = [  # noqa: RUF022

--- a/src/raitap/metrics/classification_metrics.py
+++ b/src/raitap/metrics/classification_metrics.py
@@ -7,7 +7,7 @@ from raitap.configs.schema import (
     MulticlassClassificationMetricsConfig,
     MultilabelClassificationMetricsConfig,
 )
-from raitap.metrics.registration import register_metrics_adapter
+from raitap.metrics.registration import metrics_adapter
 from raitap.utils.lazy import lazy_import
 
 from .base_metric_computer import BaseMetricComputer, MetricResult
@@ -86,7 +86,7 @@ class _ClassificationBase(BaseMetricComputer):
         self.f1 = torchmetrics.F1Score(**tm_kwargs)
 
 
-@register_metrics_adapter(
+@metrics_adapter(
     registry_name="binary_classification",
     extra="metrics",
     schema=BinaryClassificationMetricsConfig,
@@ -110,7 +110,7 @@ class BinaryClassificationMetrics(_ClassificationBase):
         )
 
 
-@register_metrics_adapter(
+@metrics_adapter(
     registry_name="multiclass_classification",
     extra="metrics",
     schema=MulticlassClassificationMetricsConfig,
@@ -138,7 +138,7 @@ class MulticlassClassificationMetrics(_ClassificationBase):
         )
 
 
-@register_metrics_adapter(
+@metrics_adapter(
     registry_name="multilabel_classification",
     extra="metrics",
     schema=MultilabelClassificationMetricsConfig,

--- a/src/raitap/metrics/detection_metrics.py
+++ b/src/raitap/metrics/detection_metrics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal
 
 from raitap.configs.schema import DetectionMetricsConfig, IoUConfig
-from raitap.metrics.registration import register_metrics_adapter
+from raitap.metrics.registration import metrics_adapter
 from raitap.utils.lazy import lazy_import
 
 from .base_metric_computer import BaseMetricComputer, MetricResult
@@ -33,7 +33,7 @@ def _coerce_iou(iou: IoUConfig | dict[str, Any] | None) -> IoUConfig:
     return IoUConfig(**iou)
 
 
-@register_metrics_adapter(
+@metrics_adapter(
     registry_name="detection",
     extra="metrics",
     schema=DetectionMetricsConfig,

--- a/src/raitap/metrics/registration.py
+++ b/src/raitap/metrics/registration.py
@@ -3,14 +3,14 @@
 Adapter sites use ``@register_metrics_adapter(...)`` instead of the legacy
 ``class Foo(BaseMetricComputer, registry_name=..., extra=..., ...)`` class-kwargs
 syntax. ``registry_name`` is type-checked by pyright at the decoration site via
-``Required[str]`` in ``_CommonRegKwargs``.
+``Required[str]`` in ``AdapterDecoratorOptions``.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypeVar, Unpack
 
-from raitap._adapters import FamilyConfig, _CommonRegKwargs, _register_core
+from raitap._adapters import AdapterDecoratorOptions, FamilyConfig, _register_core
 from raitap.configs.schema import MetricsConfig
 
 if TYPE_CHECKING:
@@ -28,12 +28,12 @@ T = TypeVar("T", bound="BaseMetricComputer")
 
 
 def register_metrics_adapter(
-    **common: Unpack[_CommonRegKwargs],
+    **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a metrics adapter.
 
     ``registry_name`` is required (enforced via ``Required[str]`` in
-    ``_CommonRegKwargs``). Metrics has no per-family required metadata
+    ``AdapterDecoratorOptions``). Metrics has no per-family required metadata
     beyond the common kwargs.
     """
 

--- a/src/raitap/metrics/registration.py
+++ b/src/raitap/metrics/registration.py
@@ -1,6 +1,6 @@
 """Family decorator for metrics adapters.
 
-Adapter sites use ``@register_metrics_adapter(...)`` instead of the legacy
+Adapter sites use ``@adapters.metrics(...)`` instead of the legacy
 ``class Foo(BaseMetricComputer, registry_name=..., extra=..., ...)`` class-kwargs
 syntax. ``registry_name`` is type-checked by pyright at the decoration site via
 ``Required[str]`` in ``AdapterDecoratorOptions``.
@@ -27,7 +27,7 @@ METRICS = FamilyConfig(
 T = TypeVar("T", bound="BaseMetricComputer")
 
 
-def register_metrics_adapter(
+def metrics_adapter(
     **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a metrics adapter.

--- a/src/raitap/metrics/tests/test_registration.py
+++ b/src/raitap/metrics/tests/test_registration.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from raitap import adapters
 from raitap._adapters import _BUILDERS, ADAPTER_EXTRAS
 from raitap.metrics.base_metric_computer import BaseMetricComputer, MetricResult
-from raitap.metrics.registration import register_metrics_adapter
 
 
-@register_metrics_adapter(
+@adapters.metrics(
     registry_name="_stub_metric",
     extra="_stub_extra",
 )
@@ -35,5 +35,5 @@ class _StubMetric(BaseMetricComputer):
 ADAPTER_EXTRAS.pop("_StubMetric", None)
 
 
-def test_register_metrics_adapter_registers_under_metrics_group() -> None:
+def test_metrics_adapter_registers_under_metrics_group() -> None:
     assert "_stub_metric" in _BUILDERS["metrics"]

--- a/src/raitap/metrics/tests/test_registration_schema.py
+++ b/src/raitap/metrics/tests/test_registration_schema.py
@@ -4,9 +4,9 @@ import dataclasses
 from dataclasses import dataclass
 from typing import Any
 
+from raitap import adapters
 from raitap._adapters import _BUILDERS, ADAPTER_EXTRAS
 from raitap.metrics.base_metric_computer import BaseMetricComputer, MetricResult
-from raitap.metrics.registration import register_metrics_adapter
 
 
 @dataclass
@@ -15,7 +15,7 @@ class _DummyConfig:
     knob: int = 42
 
 
-@register_metrics_adapter(registry_name="dummy_schema_test", schema=_DummyConfig)
+@adapters.metrics(registry_name="dummy_schema_test", schema=_DummyConfig)
 class _DummyMetric(BaseMetricComputer):
     def __init__(self, *, knob: int = 0) -> None:
         self.knob = knob

--- a/src/raitap/models/backend.py
+++ b/src/raitap/models/backend.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
+from raitap.models.registration import register
 from raitap.types import TaskKind
 from raitap.utils.errors import ModelInputShapeError
 from raitap.utils.lazy import lazy_import
@@ -162,10 +163,9 @@ class ModelBackend(ABC):
         """Return the model object that explainers should consume."""
 
 
+@register(supports_torch_autograd=True)
 class TorchBackend(ModelBackend):
     """PyTorch-backed model runtime."""
-
-    supports_torch_autograd = True
 
     def __init__(
         self,
@@ -231,10 +231,9 @@ def _onnx_explanation_module_cls() -> type:
     return _OnnxExplanationModule
 
 
+@register(supports_torch_autograd=False)
 class OnnxBackend(ModelBackend):
     """ONNX Runtime-backed model runtime."""
-
-    supports_torch_autograd = False
 
     def __init__(
         self,

--- a/src/raitap/models/registration.py
+++ b/src/raitap/models/registration.py
@@ -12,9 +12,11 @@ from typing import TYPE_CHECKING, Required, TypedDict, TypeVar, Unpack
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from raitap.models.backend import ModelBackend
-
-B = TypeVar("B", bound="ModelBackend")
+# Unbounded: a runtime ``bound=ModelBackend`` would cycle (backend.py imports
+# this module for ``@register``), and a string bound keeps a TYPE_CHECKING
+# import that static scanners flag as unused. The decorator returns ``cls``
+# unchanged, so the bound only documents intent — not worth the churn.
+B = TypeVar("B")
 
 
 class _BackendRegKwargs(TypedDict):

--- a/src/raitap/models/registration.py
+++ b/src/raitap/models/registration.py
@@ -12,11 +12,15 @@ from typing import TYPE_CHECKING, Required, TypedDict, TypeVar, Unpack
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-# Unbounded: a runtime ``bound=ModelBackend`` would cycle (backend.py imports
-# this module for ``@register``), and a string bound keeps a TYPE_CHECKING
-# import that static scanners flag as unused. The decorator returns ``cls``
-# unchanged, so the bound only documents intent — not worth the churn.
-B = TypeVar("B")
+    # NOTE: ``ModelBackend`` looks unused to static scanners (CodeQL), but the
+    # string TypeVar bound below needs it — without the bound, ``cls`` is
+    # ``type[object]`` and ``cls.supports_torch_autograd = ...`` fails pyright
+    # (reportAttributeAccessIssue). A runtime import would cycle (backend.py
+    # imports this module for ``@register``), hence the string bound. Do not
+    # remove.
+    from raitap.models.backend import ModelBackend
+
+B = TypeVar("B", bound="ModelBackend")
 
 
 class _BackendRegKwargs(TypedDict):

--- a/src/raitap/models/registration.py
+++ b/src/raitap/models/registration.py
@@ -1,0 +1,26 @@
+"""Metadata-only decorator for model backends. (Body completed in Task A4.)"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Required, TypedDict, TypeVar, Unpack
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from raitap.models.backend import ModelBackend
+
+B = TypeVar("B", bound="ModelBackend")
+
+
+class _BackendRegKwargs(TypedDict):
+    supports_torch_autograd: Required[bool]
+
+
+def register(**kwargs: Unpack[_BackendRegKwargs]) -> Callable[[type[B]], type[B]]:
+    """Register a model backend. ``supports_torch_autograd`` is required."""
+
+    def wrap(cls: type[B]) -> type[B]:
+        cls.supports_torch_autograd = kwargs["supports_torch_autograd"]
+        return cls
+
+    return wrap

--- a/src/raitap/models/registration.py
+++ b/src/raitap/models/registration.py
@@ -1,4 +1,9 @@
-"""Metadata-only decorator for model backends. (Body completed in Task A4.)"""
+"""Metadata-only decorator for model backends.
+
+Backends are not Hydra-config adapters (no registry, no entry-point plugins);
+this decorator only sets and type-checks the required ``supports_torch_autograd``
+class constant at the decoration site.
+"""
 
 from __future__ import annotations
 

--- a/src/raitap/models/tests/test_backend.py
+++ b/src/raitap/models/tests/test_backend.py
@@ -38,3 +38,21 @@ def test_torch_backend_detects_torchvision_detection_model() -> None:
 def test_torch_backend_task_kind_can_be_overridden_in_constructor() -> None:
     backend = TorchBackend(_Linear(), task_kind=TaskKind.regression)
     assert backend.task_kind is TaskKind.regression
+
+
+def test_register_backend_sets_class_constant() -> None:
+    from raitap.models.backend import ModelBackend
+    from raitap.models.registration import register
+
+    @register(supports_torch_autograd=True)
+    class _B(ModelBackend):
+        @property
+        def hardware_label(self) -> str:
+            return "test"
+
+        def __call__(self, inputs: object) -> object:
+            return inputs
+
+        def as_model_for_explanation(self) -> object: ...
+
+    assert _B.supports_torch_autograd is True

--- a/src/raitap/models/tests/test_backend.py
+++ b/src/raitap/models/tests/test_backend.py
@@ -53,6 +53,7 @@ def test_register_backend_sets_class_constant() -> None:
         def __call__(self, inputs: object) -> object:
             return inputs
 
-        def as_model_for_explanation(self) -> nn.Module: ...
+        def as_model_for_explanation(self) -> nn.Module:
+            return nn.Identity()
 
     assert _B.supports_torch_autograd is True

--- a/src/raitap/models/tests/test_backend.py
+++ b/src/raitap/models/tests/test_backend.py
@@ -53,6 +53,6 @@ def test_register_backend_sets_class_constant() -> None:
         def __call__(self, inputs: object) -> object:
             return inputs
 
-        def as_model_for_explanation(self) -> object: ...
+        def as_model_for_explanation(self) -> nn.Module: ...
 
     assert _B.supports_torch_autograd is True

--- a/src/raitap/reporting/__init__.py
+++ b/src/raitap/reporting/__init__.py
@@ -24,7 +24,13 @@ def __getattr__(name: str) -> Any:
         return ReportingConfig
     from raitap._adapters import lookup
 
-    return lookup("reporting", name)
+    try:
+        return lookup("reporting", name)
+    except AttributeError:
+        from raitap.configs import register_configs
+
+        register_configs()  # idempotent; fires in-tree imports + plugin discovery
+        return lookup("reporting", name)
 
 
 __all__ = [

--- a/src/raitap/reporting/html_reporter.py
+++ b/src/raitap/reporting/html_reporter.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING, Any
 
 from raitap import __about__
 from raitap.configs import resolve_run_dir
+from raitap.reporting.registration import reporter
 
 from .base_reporter import BaseReporter
 from .filenames import report_output_filename
-from .registration import register_reporter
 from .template_filters import as_dict, asr_band, bucket_class, fmt_num, fmt_pct, slug
 from .view_model import build_view
 
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from .sections import ReportSection
 
 
-@register_reporter(registry_name="html")
+@reporter(registry_name="html")
 class HTMLReporter(BaseReporter):
     """Narrative HTML report generator using Jinja2."""
 

--- a/src/raitap/reporting/pdf_reporter.py
+++ b/src/raitap/reporting/pdf_reporter.py
@@ -16,10 +16,10 @@ if TYPE_CHECKING:
 
 from raitap import raitap_log
 from raitap.configs import resolve_run_dir
+from raitap.reporting.registration import reporter
 
 from .base_reporter import BaseReporter
 from .filenames import report_output_filename
-from .registration import register_reporter
 
 # A4 default in borb (points). SingleColumnLayout uses ~10% side margins.
 _A4_WIDTH_PT = 595
@@ -212,7 +212,7 @@ def _image_limits_for_figures(
     return max_w, max_h
 
 
-@register_reporter(registry_name="pdf")
+@reporter(registry_name="pdf")
 class PDFReporter(BaseReporter):
     """PDF report generator using borb library."""
 

--- a/src/raitap/reporting/registration.py
+++ b/src/raitap/reporting/registration.py
@@ -3,14 +3,14 @@
 Adapter sites use ``@register_reporter(...)`` instead of the legacy
 ``class Foo(BaseReporter, registry_name=..., extra=..., ...)`` class-kwargs
 syntax. ``registry_name`` is required (enforced via ``Required[str]`` in
-``_CommonRegKwargs``) so pyright errors at the decoration site if omitted.
+``AdapterDecoratorOptions``) so pyright errors at the decoration site if omitted.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypeVar, Unpack
 
-from raitap._adapters import FamilyConfig, _CommonRegKwargs, _register_core
+from raitap._adapters import AdapterDecoratorOptions, FamilyConfig, _register_core
 from raitap.configs.schema import ReportingConfig
 
 if TYPE_CHECKING:
@@ -28,7 +28,7 @@ T = TypeVar("T", bound="BaseReporter")
 
 
 def register_reporter(
-    **common: Unpack[_CommonRegKwargs],
+    **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a reporter.
 

--- a/src/raitap/reporting/registration.py
+++ b/src/raitap/reporting/registration.py
@@ -1,6 +1,6 @@
 """Family decorator for reporting adapters.
 
-Adapter sites use ``@register_reporter(...)`` instead of the legacy
+Adapter sites use ``@adapters.reporter(...)`` instead of the legacy
 ``class Foo(BaseReporter, registry_name=..., extra=..., ...)`` class-kwargs
 syntax. ``registry_name`` is required (enforced via ``Required[str]`` in
 ``AdapterDecoratorOptions``) so pyright errors at the decoration site if omitted.
@@ -27,7 +27,7 @@ REPORTING = FamilyConfig(
 T = TypeVar("T", bound="BaseReporter")
 
 
-def register_reporter(
+def reporter(
     **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a reporter.

--- a/src/raitap/reporting/tests/test_registration.py
+++ b/src/raitap/reporting/tests/test_registration.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from raitap import adapters
 from raitap.reporting.base_reporter import BaseReporter
-from raitap.reporting.registration import register_reporter
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
     from raitap.reporting.base_reporter import ReportSection
 
 
-def test_register_reporter_registers_under_reporting_group() -> None:
-    @register_reporter(
+def test_reporter_registers_under_reporting_group() -> None:
+    @adapters.reporter(
         registry_name="_stub_reporter",
         extra="_stub_extra",
         library="_stub_lib",

--- a/src/raitap/robustness/__init__.py
+++ b/src/raitap/robustness/__init__.py
@@ -135,7 +135,13 @@ def __getattr__(name: str) -> Any:
         return RobustnessConfig
     from raitap._adapters import lookup
 
-    return lookup("robustness", name)
+    try:
+        return lookup("robustness", name)
+    except AttributeError:
+        from raitap.configs import register_configs
+
+        register_configs()  # idempotent; fires in-tree imports + plugin discovery
+        return lookup("robustness", name)
 
 
 __all__ = [  # noqa: RUF022

--- a/src/raitap/robustness/assessors/base_assessor.py
+++ b/src/raitap/robustness/assessors/base_assessor.py
@@ -61,7 +61,7 @@ class BaseAssessor(AdapterMixin, ABC):
 
     Concrete subclasses must declare ``algorithm_registry`` as a class-body
     ClassVar — pyright errors at the decoration site if missing (the
-    ``@register_robustness_adapter`` decorator's ``algorithm_registry`` kwarg
+    ``@adapters.robustness`` decorator's ``algorithm_registry`` kwarg
     is ``Required``).
     """
 
@@ -79,7 +79,7 @@ class BaseAssessor(AdapterMixin, ABC):
     budget_kwarg_source: ClassVar[str] = "init_kwargs"
 
     #: Adapter-specific; defaults to "no ONNX support". The
-    #: ``@register_robustness_adapter`` decorator overrides per-adapter.
+    #: ``@adapters.robustness`` decorator overrides per-adapter.
     ONNX_COMPATIBLE_ALGORITHMS: ClassVar[frozenset[str]] = frozenset()
 
     def check_backend_compat(self, backend: object) -> None:

--- a/src/raitap/robustness/assessors/base_assessor.py
+++ b/src/raitap/robustness/assessors/base_assessor.py
@@ -36,7 +36,6 @@ from ..contracts import (
     PerturbationBudget,
     PerturbationNorm,
     RobustnessVerdict,
-    ThreatModel,
     VerificationOutcome,
 )
 from ..exceptions import AssessorBackendIncompatibilityError
@@ -67,8 +66,6 @@ class BaseAssessor(AdapterMixin, ABC):
 
     algorithm_registry: ClassVar[Mapping[str, AssessorSemanticsHints]]
     method_kind: ClassVar[MethodKind]
-    threat_model_default: ClassVar[ThreatModel] = ThreatModel.WHITE_BOX
-    objective_default: ClassVar[Objective] = Objective.UNTARGETED
 
     #: Which YAML block the underlying library actually consumes for budget
     #: kwargs (``eps`` / ``alpha`` / ``steps``). ``"init_kwargs"`` means the

--- a/src/raitap/robustness/assessors/foolbox_assessor.py
+++ b/src/raitap/robustness/assessors/foolbox_assessor.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from raitap.robustness.assessors.registration import robustness_adapter
 from raitap.utils.lazy import lazy_import
 
 from ..contracts import MethodKind, Objective, PerturbationNorm, ThreatModel
 from ..semantics import AssessorSemanticsHints
 from .base_assessor import EmpiricalAttackAssessor, _prepare_inputs_for_forward
-from .registration import register_robustness_adapter
 
 if TYPE_CHECKING:
     import torch
@@ -18,7 +18,7 @@ else:
     torch = lazy_import("torch")
 
 
-@register_robustness_adapter(
+@robustness_adapter(
     registry_name="foolbox",
     library="foolbox",
     algorithm_registry={

--- a/src/raitap/robustness/assessors/foolbox_assessor.py
+++ b/src/raitap/robustness/assessors/foolbox_assessor.py
@@ -21,6 +21,7 @@ else:
 @robustness_adapter(
     registry_name="foolbox",
     library="foolbox",
+    budget_kwarg_source="call_kwargs",
     algorithm_registry={
         "LinfPGD": AssessorSemanticsHints(
             MethodKind.EMPIRICAL_ATTACK,
@@ -87,8 +88,6 @@ class FoolboxAssessor(EmpiricalAttackAssessor):
     the uniform ``RobustnessResult`` contract.
     A future ``MultiEpsilonAssessor`` will own that surface.
     """
-
-    budget_kwarg_source = "call_kwargs"
 
     def __init__(
         self,

--- a/src/raitap/robustness/assessors/marabou_assessor.py
+++ b/src/raitap/robustness/assessors/marabou_assessor.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
 else:
     torch = lazy_import("torch")
 
+from raitap.robustness.assessors.registration import robustness_adapter
+
 from ..contracts import (
     MethodKind,
     Objective,
@@ -44,7 +46,6 @@ from ..contracts import (
 from ..exceptions import AssessorBackendIncompatibilityError
 from ..semantics import AssessorSemanticsHints
 from .base_assessor import FormalVerificationAssessor
-from .registration import register_robustness_adapter
 
 # Curated error patterns for confusing maraboupy errors. Matched against
 # ``str(exc)``; first hit wins. See :func:`raitap.utils.errors.rethrow`.
@@ -73,7 +74,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@register_robustness_adapter(
+@robustness_adapter(
     registry_name="marabou",
     library="maraboupy",
     error_patterns=_MARABOUPY_ERROR_MESSAGES,

--- a/src/raitap/robustness/assessors/marabou_assessor.py
+++ b/src/raitap/robustness/assessors/marabou_assessor.py
@@ -21,7 +21,7 @@ import tempfile
 import time
 from collections.abc import Mapping  # noqa: TC003 — runtime use in module-level annotation
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -102,10 +102,6 @@ class MarabouAssessor(FormalVerificationAssessor):
     user sees a clear "Marabou cannot handle this graph" message instead of
     a torch traceback.
     """
-
-    # Budget keys (epsilon, norm) live under ``constructor:`` in the YAML; the
-    # adapter applies them at verify-time but they're configured at __init__.
-    budget_kwarg_source: ClassVar[str] = "init_kwargs"
 
     def __init__(
         self,

--- a/src/raitap/robustness/assessors/registration.py
+++ b/src/raitap/robustness/assessors/registration.py
@@ -12,9 +12,9 @@ from typing import TYPE_CHECKING, TypeVar, Unpack
 
 from raitap._adapters import (
     ALL,
+    AdapterDecoratorOptions,
     FamilyConfig,
     _AllAlgorithmsSentinel,
-    _CommonRegKwargs,
     _register_core,
 )
 from raitap.configs.schema import RobustnessConfig
@@ -38,7 +38,7 @@ def register_robustness_adapter(
     *,
     algorithm_registry: Mapping[str, AssessorSemanticsHints],
     onnx_compatible_algorithms: frozenset[str] | _AllAlgorithmsSentinel = frozenset(),
-    **common: Unpack[_CommonRegKwargs],
+    **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a robustness assessor.
 

--- a/src/raitap/robustness/assessors/registration.py
+++ b/src/raitap/robustness/assessors/registration.py
@@ -8,7 +8,7 @@ pyright-checked at the decoration site.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, Unpack
+from typing import TYPE_CHECKING, Literal, TypeVar, Unpack
 
 from raitap._adapters import (
     ALL,
@@ -38,6 +38,7 @@ def robustness_adapter(
     *,
     algorithm_registry: Mapping[str, AssessorSemanticsHints],
     onnx_compatible_algorithms: frozenset[str] | _AllAlgorithmsSentinel = frozenset(),
+    budget_kwarg_source: Literal["init_kwargs", "call_kwargs"] = "init_kwargs",
     **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a robustness assessor.
@@ -51,10 +52,16 @@ def robustness_adapter(
         libraries require torch autograd, not ONNX). Pass an explicit
         ``frozenset({"name1", "name2"})`` or :data:`raitap.robustness.ALL`
         to enable all algorithms on ONNX backends.
+
+        ``budget_kwarg_source`` controls where semantics looks for the
+        perturbation budget: ``"init_kwargs"`` (default, budget passed at
+        construction time) or ``"call_kwargs"`` (budget passed at attack-call
+        time, e.g. foolbox-style ``epsilons=`` argument).
     """
 
     def wrap(cls: type[T]) -> type[T]:
         cls.algorithm_registry = algorithm_registry  # type: ignore[misc]
+        cls.budget_kwarg_source = budget_kwarg_source  # type: ignore[misc]
         cls.ONNX_COMPATIBLE_ALGORITHMS = (  # type: ignore[misc]
             frozenset(algorithm_registry.keys())
             if onnx_compatible_algorithms is ALL

--- a/src/raitap/robustness/assessors/registration.py
+++ b/src/raitap/robustness/assessors/registration.py
@@ -1,6 +1,6 @@
 """Family decorator for robustness assessors.
 
-Adapter sites use ``@register_robustness_adapter(...)`` instead of the legacy
+Adapter sites use ``@adapters.robustness(...)`` instead of the legacy
 ``class Foo(EmpiricalAttackAssessor, registry_name=..., extra=..., ...)``
 class-kwargs syntax. ``registry_name`` + ``algorithm_registry`` are
 pyright-checked at the decoration site.
@@ -34,7 +34,7 @@ ROBUSTNESS = FamilyConfig(
 T = TypeVar("T", bound="BaseAssessor")
 
 
-def register_robustness_adapter(
+def robustness_adapter(
     *,
     algorithm_registry: Mapping[str, AssessorSemanticsHints],
     onnx_compatible_algorithms: frozenset[str] | _AllAlgorithmsSentinel = frozenset(),

--- a/src/raitap/robustness/assessors/tests/test_registration.py
+++ b/src/raitap/robustness/assessors/tests/test_registration.py
@@ -60,3 +60,29 @@ def test_robustness_adapter_registers_under_robustness_group() -> None:
 
     assert "_stub_attack" in _BUILDERS["robustness"]
     assert ADAPTER_EXTRAS["_StubAssessor"] == "_stub_extra"
+
+
+def test_budget_kwarg_source_via_decorator() -> None:
+    from raitap.robustness.assessors.base_assessor import EmpiricalAttackAssessor
+    from raitap.robustness.assessors.registration import robustness_adapter
+    from raitap.robustness.contracts import MethodKind, Objective, PerturbationNorm, ThreatModel
+    from raitap.robustness.semantics import AssessorSemanticsHints
+
+    @robustness_adapter(
+        registry_name="_stub_budget",
+        budget_kwarg_source="call_kwargs",
+        algorithm_registry={
+            "x": AssessorSemanticsHints(
+                MethodKind.EMPIRICAL_ATTACK,
+                ThreatModel.WHITE_BOX,
+                Objective.UNTARGETED,
+                PerturbationNorm.LINF,
+                families=frozenset({"i"}),
+            ),
+        },
+    )
+    class _Stub(EmpiricalAttackAssessor):
+        def generate_adversarial(self, model, inputs, targets, *, backend=None, **kw):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN202
+            return inputs
+
+    assert _Stub.budget_kwarg_source == "call_kwargs"

--- a/src/raitap/robustness/assessors/tests/test_registration.py
+++ b/src/raitap/robustness/assessors/tests/test_registration.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
+from raitap import adapters
 from raitap.robustness.assessors.base_assessor import EmpiricalAttackAssessor
-from raitap.robustness.assessors.registration import register_robustness_adapter
 from raitap.robustness.contracts import (
     MethodKind,
     Objective,
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
     from torch import nn
 
 
-def test_register_robustness_adapter_registers_under_robustness_group() -> None:
-    @register_robustness_adapter(
+def test_robustness_adapter_registers_under_robustness_group() -> None:
+    @adapters.robustness(
         registry_name="_stub_attack",
         extra="_stub_extra",
         library="_stub_lib",

--- a/src/raitap/robustness/assessors/torchattacks_assessor.py
+++ b/src/raitap/robustness/assessors/torchattacks_assessor.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from raitap.robustness.assessors.registration import robustness_adapter
 from raitap.utils.lazy import lazy_import
 
 from ..contracts import MethodKind, Objective, PerturbationNorm, ThreatModel
 from ..semantics import AssessorSemanticsHints
 from .base_assessor import EmpiricalAttackAssessor, _prepare_inputs_for_forward
-from .registration import register_robustness_adapter
 
 if TYPE_CHECKING:
     import torch
@@ -18,7 +18,7 @@ else:
     torch = lazy_import("torch")
 
 
-@register_robustness_adapter(
+@robustness_adapter(
     registry_name="torchattacks",
     library="torchattacks",
     algorithm_registry={

--- a/src/raitap/robustness/semantics.py
+++ b/src/raitap/robustness/semantics.py
@@ -67,7 +67,7 @@ def hints_for_assessor(assessor: object) -> AssessorSemanticsHints:
     if not isinstance(registry, Mapping):
         raise TypeError(
             f"Assessor {type(assessor).__name__!r} must declare an "
-            "``algorithm_registry`` ClassVar (set by the @register_robustness_adapter "
+            "``algorithm_registry`` ClassVar (set by the @adapters.robustness "
             "decoration contract)."
         )
     try:

--- a/src/raitap/robustness/visualisers/empirical/image_pair_visualiser.py
+++ b/src/raitap/robustness/visualisers/empirical/image_pair_visualiser.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -26,15 +26,14 @@ if TYPE_CHECKING:
     from ...results import RobustnessResult
 
 
-@robustness_visualiser(registry_name="image_pair")
+@robustness_visualiser(
+    registry_name="image_pair",
+    supported_method_kinds=frozenset({MethodKind.EMPIRICAL_ATTACK}),
+    embeds_clean_input=True,
+    embeds_perturbation_map=True,
+)
 class ImagePairVisualiser(BaseRobustnessVisualiser):
     """Render N rows by 3 columns: clean, perturbed, signed perturbation."""
-
-    supported_method_kinds: ClassVar[frozenset[MethodKind]] = frozenset(
-        {MethodKind.EMPIRICAL_ATTACK}
-    )
-    embeds_clean_input: ClassVar[bool] = True
-    embeds_perturbation_map: ClassVar[bool] = True
 
     def __init__(
         self,

--- a/src/raitap/robustness/visualisers/empirical/image_pair_visualiser.py
+++ b/src/raitap/robustness/visualisers/empirical/image_pair_visualiser.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import matplotlib.pyplot as plt
 import numpy as np
 
-from raitap.robustness.visualisers.registration import register_robustness_visualiser
+from raitap.robustness.visualisers.registration import robustness_visualiser
 from raitap.transparency.contracts import InputKind
 from raitap.utils.lazy import lazy_import
 
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from ...results import RobustnessResult
 
 
-@register_robustness_visualiser(registry_name="image_pair")
+@robustness_visualiser(registry_name="image_pair")
 class ImagePairVisualiser(BaseRobustnessVisualiser):
     """Render N rows by 3 columns: clean, perturbed, signed perturbation."""
 

--- a/src/raitap/robustness/visualisers/empirical/perturbation_heatmap_visualiser.py
+++ b/src/raitap/robustness/visualisers/empirical/perturbation_heatmap_visualiser.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -29,7 +29,11 @@ if TYPE_CHECKING:
 _SUPPORTED_MODES = frozenset({"signed_dominant", "mean_abs", "mean", "max_abs"})
 
 
-@robustness_visualiser(registry_name="perturbation_heatmap")
+@robustness_visualiser(
+    registry_name="perturbation_heatmap",
+    supported_method_kinds=frozenset({MethodKind.EMPIRICAL_ATTACK}),
+    embeds_perturbation_map=True,
+)
 class PerturbationHeatmapVisualiser(BaseRobustnessVisualiser):
     """Render the perturbation tensor as a heatmap.
 
@@ -39,11 +43,6 @@ class PerturbationHeatmapVisualiser(BaseRobustnessVisualiser):
     signs across channels (e.g. ``+eps`` on R and ``-eps`` on G displaying as
     ~0). Other modes (``mean``, ``mean_abs``, ``max_abs``) are kept as opt-ins.
     """
-
-    supported_method_kinds: ClassVar[frozenset[MethodKind]] = frozenset(
-        {MethodKind.EMPIRICAL_ATTACK}
-    )
-    embeds_perturbation_map: ClassVar[bool] = True
 
     def __init__(
         self,

--- a/src/raitap/robustness/visualisers/empirical/perturbation_heatmap_visualiser.py
+++ b/src/raitap/robustness/visualisers/empirical/perturbation_heatmap_visualiser.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import matplotlib.pyplot as plt
 import numpy as np
 
-from raitap.robustness.visualisers.registration import register_robustness_visualiser
+from raitap.robustness.visualisers.registration import robustness_visualiser
 from raitap.utils.lazy import lazy_import
 
 if TYPE_CHECKING:
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 _SUPPORTED_MODES = frozenset({"signed_dominant", "mean_abs", "mean", "max_abs"})
 
 
-@register_robustness_visualiser(registry_name="perturbation_heatmap")
+@robustness_visualiser(registry_name="perturbation_heatmap")
 class PerturbationHeatmapVisualiser(BaseRobustnessVisualiser):
     """Render the perturbation tensor as a heatmap.
 

--- a/src/raitap/robustness/visualisers/formal/output_bounds_cohort.py
+++ b/src/raitap/robustness/visualisers/formal/output_bounds_cohort.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import matplotlib.pyplot as plt
 import numpy as np
 
-from raitap.robustness.visualisers.registration import register_robustness_visualiser
+from raitap.robustness.visualisers.registration import robustness_visualiser
 
 from ...contracts import MethodKind
 from ..base_visualiser import BaseRobustnessVisualiser
@@ -39,7 +39,7 @@ def _placeholder_figure(message: str) -> Figure:
     return fig
 
 
-@register_robustness_visualiser(registry_name="output_bounds_cohort")
+@robustness_visualiser(registry_name="output_bounds_cohort")
 class OutputBoundsCohortVisualiser(BaseRobustnessVisualiser):
     """Boxplot of certified per-class bound widths across the verified batch."""
 

--- a/src/raitap/robustness/visualisers/formal/output_bounds_cohort.py
+++ b/src/raitap/robustness/visualisers/formal/output_bounds_cohort.py
@@ -10,7 +10,7 @@ Declared compatible with :class:`MethodKind.FORMAL_VERIFICATION` only.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -39,13 +39,12 @@ def _placeholder_figure(message: str) -> Figure:
     return fig
 
 
-@robustness_visualiser(registry_name="output_bounds_cohort")
+@robustness_visualiser(
+    registry_name="output_bounds_cohort",
+    supported_method_kinds=frozenset({MethodKind.FORMAL_VERIFICATION}),
+)
 class OutputBoundsCohortVisualiser(BaseRobustnessVisualiser):
     """Boxplot of certified per-class bound widths across the verified batch."""
-
-    supported_method_kinds: ClassVar[frozenset[MethodKind]] = frozenset(
-        {MethodKind.FORMAL_VERIFICATION}
-    )
 
     def __init__(
         self,

--- a/src/raitap/robustness/visualisers/formal/output_bounds_margin_heatmap.py
+++ b/src/raitap/robustness/visualisers/formal/output_bounds_margin_heatmap.py
@@ -18,7 +18,7 @@ Declared compatible with :class:`MethodKind.FORMAL_VERIFICATION` only.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -53,13 +53,12 @@ def _auto_figsize(n: int, k: int) -> tuple[float, float]:
     return (max(k * 0.6 + 2, 6), max(n * 0.25 + 1.5, 3))
 
 
-@robustness_visualiser(registry_name="output_bounds_margin_heatmap")
+@robustness_visualiser(
+    registry_name="output_bounds_margin_heatmap",
+    supported_method_kinds=frozenset({MethodKind.FORMAL_VERIFICATION}),
+)
 class OutputBoundsMarginHeatmapVisualiser(BaseRobustnessVisualiser):
     """Heatmap of per-class lower-vs-upper margins relative to the target class."""
-
-    supported_method_kinds: ClassVar[frozenset[MethodKind]] = frozenset(
-        {MethodKind.FORMAL_VERIFICATION}
-    )
 
     def __init__(
         self,

--- a/src/raitap/robustness/visualisers/formal/output_bounds_margin_heatmap.py
+++ b/src/raitap/robustness/visualisers/formal/output_bounds_margin_heatmap.py
@@ -24,7 +24,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import TwoSlopeNorm
 
-from raitap.robustness.visualisers.registration import register_robustness_visualiser
+from raitap.robustness.visualisers.registration import robustness_visualiser
 
 from ...contracts import MethodKind
 from ..base_visualiser import BaseRobustnessVisualiser
@@ -53,7 +53,7 @@ def _auto_figsize(n: int, k: int) -> tuple[float, float]:
     return (max(k * 0.6 + 2, 6), max(n * 0.25 + 1.5, 3))
 
 
-@register_robustness_visualiser(registry_name="output_bounds_margin_heatmap")
+@robustness_visualiser(registry_name="output_bounds_margin_heatmap")
 class OutputBoundsMarginHeatmapVisualiser(BaseRobustnessVisualiser):
     """Heatmap of per-class lower-vs-upper margins relative to the target class."""
 

--- a/src/raitap/robustness/visualisers/formal/output_bounds_pinned.py
+++ b/src/raitap/robustness/visualisers/formal/output_bounds_pinned.py
@@ -21,7 +21,7 @@ Declared compatible with :class:`MethodKind.FORMAL_VERIFICATION` only.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -53,13 +53,12 @@ def _placeholder_figure(message: str) -> Figure:
     return fig
 
 
-@robustness_visualiser(registry_name="output_bounds_pinned")
+@robustness_visualiser(
+    registry_name="output_bounds_pinned",
+    supported_method_kinds=frozenset({MethodKind.FORMAL_VERIFICATION}),
+)
 class OutputBoundsPinnedVisualiser(BaseRobustnessVisualiser):
     """Per-pinned-sample plot of ``[lower_k, upper_k]`` certified intervals."""
-
-    supported_method_kinds: ClassVar[frozenset[MethodKind]] = frozenset(
-        {MethodKind.FORMAL_VERIFICATION}
-    )
 
     def __init__(
         self,

--- a/src/raitap/robustness/visualisers/formal/output_bounds_pinned.py
+++ b/src/raitap/robustness/visualisers/formal/output_bounds_pinned.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import matplotlib.pyplot as plt
 import numpy as np
 
-from raitap.robustness.visualisers.registration import register_robustness_visualiser
+from raitap.robustness.visualisers.registration import robustness_visualiser
 
 from ...contracts import MethodKind
 from ..base_visualiser import BaseRobustnessVisualiser
@@ -53,7 +53,7 @@ def _placeholder_figure(message: str) -> Figure:
     return fig
 
 
-@register_robustness_visualiser(registry_name="output_bounds_pinned")
+@robustness_visualiser(registry_name="output_bounds_pinned")
 class OutputBoundsPinnedVisualiser(BaseRobustnessVisualiser):
     """Per-pinned-sample plot of ``[lower_k, upper_k]`` certified intervals."""
 

--- a/src/raitap/robustness/visualisers/formal/output_bounds_width_heatmap.py
+++ b/src/raitap/robustness/visualisers/formal/output_bounds_width_heatmap.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import matplotlib.pyplot as plt
 import numpy as np
 
-from raitap.robustness.visualisers.registration import register_robustness_visualiser
+from raitap.robustness.visualisers.registration import robustness_visualiser
 
 from ...contracts import MethodKind
 from ..base_visualiser import BaseRobustnessVisualiser
@@ -43,7 +43,7 @@ def _auto_figsize(n: int, k: int) -> tuple[float, float]:
     return (max(k * 0.6 + 2, 6), max(n * 0.25 + 1.5, 3))
 
 
-@register_robustness_visualiser(registry_name="output_bounds_width_heatmap")
+@robustness_visualiser(registry_name="output_bounds_width_heatmap")
 class OutputBoundsWidthHeatmapVisualiser(BaseRobustnessVisualiser):
     """Heatmap of certified per-class output-bound widths across the batch."""
 

--- a/src/raitap/robustness/visualisers/formal/output_bounds_width_heatmap.py
+++ b/src/raitap/robustness/visualisers/formal/output_bounds_width_heatmap.py
@@ -10,7 +10,7 @@ Declared compatible with :class:`MethodKind.FORMAL_VERIFICATION` only.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -43,13 +43,12 @@ def _auto_figsize(n: int, k: int) -> tuple[float, float]:
     return (max(k * 0.6 + 2, 6), max(n * 0.25 + 1.5, 3))
 
 
-@robustness_visualiser(registry_name="output_bounds_width_heatmap")
+@robustness_visualiser(
+    registry_name="output_bounds_width_heatmap",
+    supported_method_kinds=frozenset({MethodKind.FORMAL_VERIFICATION}),
+)
 class OutputBoundsWidthHeatmapVisualiser(BaseRobustnessVisualiser):
     """Heatmap of certified per-class output-bound widths across the batch."""
-
-    supported_method_kinds: ClassVar[frozenset[MethodKind]] = frozenset(
-        {MethodKind.FORMAL_VERIFICATION}
-    )
 
     def __init__(
         self,

--- a/src/raitap/robustness/visualisers/formal/verdict_summary.py
+++ b/src/raitap/robustness/visualisers/formal/verdict_summary.py
@@ -13,7 +13,7 @@ Declared compatible with :class:`MethodKind.FORMAL_VERIFICATION` only.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -44,13 +44,12 @@ _VERDICT_COLORS = {
 }
 
 
-@robustness_visualiser(registry_name="verdict_summary")
+@robustness_visualiser(
+    registry_name="verdict_summary",
+    supported_method_kinds=frozenset({MethodKind.FORMAL_VERIFICATION}),
+)
 class VerdictSummaryVisualiser(BaseRobustnessVisualiser):
     """Bar chart of verdict counts plus a runtime histogram."""
-
-    supported_method_kinds: ClassVar[frozenset[MethodKind]] = frozenset(
-        {MethodKind.FORMAL_VERIFICATION}
-    )
 
     def __init__(self, *, runtime_bins: int = 20) -> None:
         self.runtime_bins = max(int(runtime_bins), 1)

--- a/src/raitap/robustness/visualisers/formal/verdict_summary.py
+++ b/src/raitap/robustness/visualisers/formal/verdict_summary.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import matplotlib.pyplot as plt
 import numpy as np
 
-from raitap.robustness.visualisers.registration import register_robustness_visualiser
+from raitap.robustness.visualisers.registration import robustness_visualiser
 
 from ...contracts import MethodKind, RobustnessVerdict
 from ..base_visualiser import BaseRobustnessVisualiser
@@ -44,7 +44,7 @@ _VERDICT_COLORS = {
 }
 
 
-@register_robustness_visualiser(registry_name="verdict_summary")
+@robustness_visualiser(registry_name="verdict_summary")
 class VerdictSummaryVisualiser(BaseRobustnessVisualiser):
     """Bar chart of verdict counts plus a runtime histogram."""
 

--- a/src/raitap/robustness/visualisers/registration.py
+++ b/src/raitap/robustness/visualisers/registration.py
@@ -1,27 +1,46 @@
-"""Family decorator for robustness visualisers (no Hydra group)."""
+"""Family decorator for robustness visualisers (no Hydra group). Capability
+fields use the UNSET sentinel so omitted kwargs keep the base default."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, Unpack
+from typing import TYPE_CHECKING, Final, TypeVar, Unpack
 
 from raitap._adapters import AdapterDecoratorOptions, _register_core
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from raitap.robustness.contracts import MethodKind
     from raitap.robustness.visualisers.base_visualiser import BaseRobustnessVisualiser
+
+
+class _Unset:
+    __slots__ = ()
+
+
+_UNSET: Final = _Unset()
 
 T = TypeVar("T", bound="BaseRobustnessVisualiser")
 
 
 def robustness_visualiser(
+    *,
+    supported_method_kinds: frozenset[MethodKind] | _Unset = _UNSET,
+    embeds_clean_input: bool | _Unset = _UNSET,
+    embeds_perturbation_map: bool | _Unset = _UNSET,
     **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
-    """Decorator: register a robustness visualiser. No family group; the
-    builder lands in ``_BUILDERS['_unscoped']`` and is embedded as a list
-    inside ``RobustnessConfig`` entries."""
+    """Register a robustness visualiser. ``registry_name`` required; capability
+    kwargs optional (omitted → base default)."""
 
     def wrap(cls: type[T]) -> type[T]:
+        for attr, value in (
+            ("supported_method_kinds", supported_method_kinds),
+            ("embeds_clean_input", embeds_clean_input),
+            ("embeds_perturbation_map", embeds_perturbation_map),
+        ):
+            if value is not _UNSET:  # identity check on the singleton sentinel
+                setattr(cls, attr, value)
         return _register_core(cls, family=None, **common)
 
     return wrap

--- a/src/raitap/robustness/visualisers/registration.py
+++ b/src/raitap/robustness/visualisers/registration.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound="BaseRobustnessVisualiser")
 
 
-def register_robustness_visualiser(
+def robustness_visualiser(
     **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a robustness visualiser. No family group; the

--- a/src/raitap/robustness/visualisers/registration.py
+++ b/src/raitap/robustness/visualisers/registration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypeVar, Unpack
 
-from raitap._adapters import _CommonRegKwargs, _register_core
+from raitap._adapters import AdapterDecoratorOptions, _register_core
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -15,7 +15,7 @@ T = TypeVar("T", bound="BaseRobustnessVisualiser")
 
 
 def register_robustness_visualiser(
-    **common: Unpack[_CommonRegKwargs],
+    **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a robustness visualiser. No family group; the
     builder lands in ``_BUILDERS['_unscoped']`` and is embedded as a list

--- a/src/raitap/robustness/visualisers/tests/test_registration.py
+++ b/src/raitap/robustness/visualisers/tests/test_registration.py
@@ -57,7 +57,10 @@ def test_robustness_capability_fields_via_decorator() -> None:
         embeds_clean_input=True,
     )
     class _StubRob(BaseRobustnessVisualiser):
-        def visualise(self, *a: object, **k: object) -> Figure: ...
+        def visualise(self, *a: object, **k: object) -> Figure:
+            from matplotlib.figure import Figure as _Figure
+
+            return _Figure()
 
     assert _StubRob.supported_method_kinds == frozenset({MethodKind.EMPIRICAL_ATTACK})
     assert _StubRob.embeds_clean_input is True

--- a/src/raitap/robustness/visualisers/tests/test_registration.py
+++ b/src/raitap/robustness/visualisers/tests/test_registration.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from raitap import visualisers
 from raitap.robustness.visualisers.base_visualiser import BaseRobustnessVisualiser
-from raitap.robustness.visualisers.registration import register_robustness_visualiser
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 # introspect a real import path. Function-local classes have a ``<locals>``
 # ``__qualname__`` that ``builds(...)`` rejects with ``TypeError``, which
 # ``_register_core`` then silently swallows.
-@register_robustness_visualiser(
+@visualisers.robustness(
     registry_name="_stub_rob_viz",
 )
 class _StubRobViz(BaseRobustnessVisualiser):
@@ -40,7 +40,7 @@ class _StubRobViz(BaseRobustnessVisualiser):
         return _Figure()
 
 
-def test_register_robustness_visualiser_lands_in_unscoped_pool() -> None:
+def test_robustness_visualiser_lands_in_unscoped_pool() -> None:
     from raitap._adapters import _BUILDERS
 
     assert "_stub_rob_viz" in _BUILDERS["_unscoped"]

--- a/src/raitap/robustness/visualisers/tests/test_registration.py
+++ b/src/raitap/robustness/visualisers/tests/test_registration.py
@@ -57,7 +57,7 @@ def test_robustness_capability_fields_via_decorator() -> None:
         embeds_clean_input=True,
     )
     class _StubRob(BaseRobustnessVisualiser):
-        def visualise(self, *a: object, **k: object) -> object: ...
+        def visualise(self, *a: object, **k: object) -> Figure: ...
 
     assert _StubRob.supported_method_kinds == frozenset({MethodKind.EMPIRICAL_ATTACK})
     assert _StubRob.embeds_clean_input is True

--- a/src/raitap/robustness/visualisers/tests/test_registration.py
+++ b/src/raitap/robustness/visualisers/tests/test_registration.py
@@ -44,3 +44,22 @@ def test_robustness_visualiser_lands_in_unscoped_pool() -> None:
     from raitap._adapters import _BUILDERS
 
     assert "_stub_rob_viz" in _BUILDERS["_unscoped"]
+
+
+def test_robustness_capability_fields_via_decorator() -> None:
+    from raitap.robustness.contracts import MethodKind
+    from raitap.robustness.visualisers.base_visualiser import BaseRobustnessVisualiser
+    from raitap.robustness.visualisers.registration import robustness_visualiser
+
+    @robustness_visualiser(
+        registry_name="_stub_rob_caps",
+        supported_method_kinds=frozenset({MethodKind.EMPIRICAL_ATTACK}),
+        embeds_clean_input=True,
+    )
+    class _StubRob(BaseRobustnessVisualiser):
+        def visualise(self, *a, **k):  # type: ignore[no-untyped-def]
+            ...
+
+    assert _StubRob.supported_method_kinds == frozenset({MethodKind.EMPIRICAL_ATTACK})
+    assert _StubRob.embeds_clean_input is True
+    assert _StubRob.embeds_perturbation_map == BaseRobustnessVisualiser.embeds_perturbation_map

--- a/src/raitap/robustness/visualisers/tests/test_registration.py
+++ b/src/raitap/robustness/visualisers/tests/test_registration.py
@@ -57,8 +57,7 @@ def test_robustness_capability_fields_via_decorator() -> None:
         embeds_clean_input=True,
     )
     class _StubRob(BaseRobustnessVisualiser):
-        def visualise(self, *a, **k):  # type: ignore[no-untyped-def]
-            ...
+        def visualise(self, *a: object, **k: object) -> object: ...
 
     assert _StubRob.supported_method_kinds == frozenset({MethodKind.EMPIRICAL_ATTACK})
     assert _StubRob.embeds_clean_input is True

--- a/src/raitap/tests/_fake_broken_plugin/pyproject.toml
+++ b/src/raitap/tests/_fake_broken_plugin/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "raitap-fakebrokenplugin"
+version = "0.0.1"
+requires-python = ">=3.11"
+dependencies = ["raitap>=0,<999"]
+
+[project.entry-points."raitap.adapters"]
+fakebroken = "raitap_fakebrokenplugin"
+
+[tool.hatch.build.targets.wheel]
+packages = ["raitap_fakebrokenplugin"]

--- a/src/raitap/tests/_fake_broken_plugin/raitap_fakebrokenplugin/__init__.py
+++ b/src/raitap/tests/_fake_broken_plugin/raitap_fakebrokenplugin/__init__.py
@@ -1,0 +1,8 @@
+"""Fixture plugin that crashes at import — exercises discovery failure isolation.
+
+Its ``raitap`` pin is satisfiable, so the version check passes and
+``discover_third_party_adapters`` proceeds to ``ep.load()``, which raises here.
+The discovery loop must catch this, log a warning, and keep going.
+"""
+
+raise RuntimeError("fake plugin boom at import time")

--- a/src/raitap/tests/_fake_plugin/pyproject.toml
+++ b/src/raitap/tests/_fake_plugin/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "raitap-fakeplugin"
+version = "0.0.1"
+requires-python = ">=3.11"
+dependencies = ["raitap>=0,<999"]
+
+[project.entry-points."raitap.adapters"]
+fakeplugin = "raitap_fakeplugin"
+
+[tool.hatch.build.targets.wheel]
+packages = ["raitap_fakeplugin"]

--- a/src/raitap/tests/_fake_plugin/raitap_fakeplugin/__init__.py
+++ b/src/raitap/tests/_fake_plugin/raitap_fakeplugin/__init__.py
@@ -1,0 +1,21 @@
+from raitap import adapters
+from raitap.robustness.assessors.base_assessor import EmpiricalAttackAssessor
+from raitap.robustness.contracts import MethodKind, Objective, PerturbationNorm, ThreatModel
+from raitap.robustness.semantics import AssessorSemanticsHints
+
+
+@adapters.robustness(
+    registry_name="fakeattack",
+    algorithm_registry={
+        "PGD": AssessorSemanticsHints(
+            MethodKind.EMPIRICAL_ATTACK,
+            ThreatModel.WHITE_BOX,
+            Objective.UNTARGETED,
+            PerturbationNorm.LINF,
+            families=frozenset({"iterative"}),
+        ),
+    },
+)
+class FakeAttackAssessor(EmpiricalAttackAssessor):
+    def generate_adversarial(self, model, inputs, targets, *, backend=None, **kw):  # noqa: ANN001, ANN201
+        return inputs

--- a/src/raitap/tests/test_facade_typing.py
+++ b/src/raitap/tests/test_facade_typing.py
@@ -1,0 +1,57 @@
+"""Guards that the namespaced facades preserve decoration-site type checking."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pyright = shutil.which("pyright")
+pytestmark = pytest.mark.skipif(pyright is None, reason="pyright not on PATH")
+
+
+def _errors(src: str, tmp_path: Path) -> list[str]:
+    f = tmp_path / "s.py"
+    f.write_text(textwrap.dedent(src))
+    assert pyright is not None
+    proc = subprocess.run(
+        [pyright, "--outputjson", str(f)], capture_output=True, text=True, check=False
+    )
+    data = json.loads(proc.stdout)
+    return [d["message"] for d in data.get("generalDiagnostics", []) if d["severity"] == "error"]
+
+
+def test_good_call_typechecks_clean(tmp_path: Path) -> None:
+    errs = _errors(
+        """
+        import torch
+        from raitap import adapters
+        from raitap.transparency.explainers.base_explainer import AttributionOnlyExplainer
+
+        @adapters.transparency(registry_name="x", algorithm_registry={})
+        class _M(AttributionOnlyExplainer):
+            def compute_attributions(self, model, inputs, **kwargs) -> torch.Tensor: ...
+        """,
+        tmp_path,
+    )
+    assert errs == [], errs
+
+
+def test_missing_required_kwarg_errors(tmp_path: Path) -> None:
+    errs = _errors(
+        """
+        from raitap import adapters
+
+        @adapters.transparency(algorithm_registry={})
+        class _M: ...
+        """,
+        tmp_path,
+    )
+    assert any("registry_name" in e for e in errs), errs

--- a/src/raitap/tests/test_register_adapter_typing.py
+++ b/src/raitap/tests/test_register_adapter_typing.py
@@ -1,7 +1,7 @@
 """Static-type assertions: pyright must error at the decoration site when an
 adapter author forgets the ``registry_name`` cross-family required kwarg.
 
-The whole point of ``_CommonRegKwargs.registry_name: Required[str]`` + PEP 692
+The whole point of ``AdapterDecoratorOptions.registry_name: Required[str]`` + PEP 692
 ``Unpack[...]`` on every family decorator is exactly this guarantee — verify
 it empirically so a future drift in the typing surface fails CI loudly.
 

--- a/src/raitap/tests/test_register_adapter_typing.py
+++ b/src/raitap/tests/test_register_adapter_typing.py
@@ -45,36 +45,17 @@ def _pyright_errors(source: str, tmp_path: Path) -> list[str]:
 def test_missing_registry_name_is_pyright_error_for_every_family_decorator(
     tmp_path: Path,
 ) -> None:
-    for decorator_import, decorator_call in [
-        (
-            "from raitap.transparency.explainers.registration import register_transparency_adapter",
-            "register_transparency_adapter(extra='x', library='x')",
-        ),
-        (
-            "from raitap.robustness.assessors.registration import register_robustness_adapter",
-            "register_robustness_adapter(extra='x', library='x')",
-        ),
-        (
-            "from raitap.metrics.registration import register_metrics_adapter",
-            "register_metrics_adapter(extra='x')",
-        ),
-        (
-            "from raitap.reporting.registration import register_reporter",
-            "register_reporter(extra='x')",
-        ),
-        (
-            "from raitap.tracking.registration import register_tracker",
-            "register_tracker(extra='x')",
-        ),
-        (
-            "from raitap.transparency.visualisers.registration import "
-            "register_transparency_visualiser",
-            "register_transparency_visualiser()",
-        ),
-        (
-            "from raitap.robustness.visualisers.registration import register_robustness_visualiser",
-            "register_robustness_visualiser()",
-        ),
+    _tr_call = "adapters.transparency(algorithm_registry={}, extra='x', library='x')"
+    _ro_call = "adapters.robustness(algorithm_registry={}, extra='x', library='x')"
+    for decorator_import, decorator_call, expected in [
+        ("from raitap import adapters", _tr_call, "registry_name"),
+        ("from raitap import adapters", _ro_call, "registry_name"),
+        ("from raitap import adapters", "adapters.metrics(extra='x')", "registry_name"),
+        ("from raitap import adapters", "adapters.reporter(extra='x')", "registry_name"),
+        ("from raitap import adapters", "adapters.tracker(extra='x')", "registry_name"),
+        ("from raitap import visualisers", "visualisers.transparency()", "registry_name"),
+        ("from raitap import visualisers", "visualisers.robustness()", "registry_name"),
+        ("from raitap import backends", "backends.register()", "supports_torch_autograd"),
     ]:
         errors = _pyright_errors(
             f"""
@@ -85,6 +66,6 @@ def test_missing_registry_name_is_pyright_error_for_every_family_decorator(
             """,
             tmp_path,
         )
-        assert any("registry_name" in e for e in errors), (
-            f"{decorator_call} did not produce a registry_name pyright error. Got: {errors}"
+        assert any(expected in e for e in errors), (
+            f"{decorator_call} did not produce a {expected!r} pyright error. Got: {errors}"
         )

--- a/src/raitap/tests/test_third_party_discovery.py
+++ b/src/raitap/tests/test_third_party_discovery.py
@@ -26,19 +26,19 @@ def _installed_broken_plugin():  # noqa: ANN202
 
 
 def test_plugin_adapter_registered(_installed_fake_plugin) -> None:  # noqa: ANN001
-    from raitap._adapters import _BUILDERS, discover_third_party_adapters
+    import raitap._adapters as adapters_mod
 
-    discover_third_party_adapters()
-    assert "fakeattack" in _BUILDERS["robustness"]
+    adapters_mod.discover_third_party_adapters()
+    assert "fakeattack" in adapters_mod._BUILDERS["robustness"]
 
 
 def test_disabled_env_skips(monkeypatch, _installed_fake_plugin) -> None:  # noqa: ANN001
-    from raitap._adapters import _BUILDERS, discover_third_party_adapters
+    import raitap._adapters as adapters_mod
 
-    _BUILDERS.get("robustness", {}).pop("fakeattack", None)
+    adapters_mod._BUILDERS.get("robustness", {}).pop("fakeattack", None)
     monkeypatch.setenv("RAITAP_DISABLE_PLUGINS", "1")
-    discover_third_party_adapters()
-    assert "fakeattack" not in _BUILDERS.get("robustness", {})
+    adapters_mod.discover_third_party_adapters()
+    assert "fakeattack" not in adapters_mod._BUILDERS.get("robustness", {})
 
 
 def test_crashing_plugin_is_isolated(_installed_broken_plugin) -> None:  # noqa: ANN001
@@ -48,16 +48,16 @@ def test_crashing_plugin_is_isolated(_installed_broken_plugin) -> None:  # noqa:
 
     register_configs()  # ensure in-tree adapters are registered
 
-    from raitap._adapters import _BUILDERS, discover_third_party_adapters
+    import raitap._adapters as adapters_mod
 
     # The broken plugin's import raises; discovery must not propagate it, and
     # must emit a warning naming the plugin.
     with pytest.warns(UserWarning, match="fakebroken"):
-        discover_third_party_adapters()
+        adapters_mod.discover_third_party_adapters()
 
-    assert "fakebroken" not in _BUILDERS.get("robustness", {})
+    assert "fakebroken" not in adapters_mod._BUILDERS.get("robustness", {})
     # In-tree adapter still resolvable — one bad plugin didn't break the registry.
-    assert "torchattacks" in _BUILDERS["robustness"]
+    assert "torchattacks" in adapters_mod._BUILDERS["robustness"]
 
 
 def test_version_skew_skips(monkeypatch) -> None:  # noqa: ANN001

--- a/src/raitap/tests/test_third_party_discovery.py
+++ b/src/raitap/tests/test_third_party_discovery.py
@@ -1,0 +1,51 @@
+"""End-to-end: a pip-installed entry-point plugin registers an adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_FAKE = Path(__file__).parent / "_fake_plugin"
+
+
+@pytest.fixture(scope="module")
+def _installed_fake_plugin():  # noqa: ANN202
+    subprocess.run(["uv", "pip", "install", str(_FAKE)], check=True)
+    yield
+    subprocess.run(["uv", "pip", "uninstall", "raitap-fakeplugin"], check=True)
+
+
+def test_plugin_adapter_registered(_installed_fake_plugin) -> None:  # noqa: ANN001
+    from raitap._adapters import _BUILDERS, discover_third_party_adapters
+
+    discover_third_party_adapters()
+    assert "fakeattack" in _BUILDERS["robustness"]
+
+
+def test_disabled_env_skips(monkeypatch, _installed_fake_plugin) -> None:  # noqa: ANN001
+    from raitap._adapters import _BUILDERS, discover_third_party_adapters
+
+    _BUILDERS.get("robustness", {}).pop("fakeattack", None)
+    monkeypatch.setenv("RAITAP_DISABLE_PLUGINS", "1")
+    discover_third_party_adapters()
+    assert "fakeattack" not in _BUILDERS.get("robustness", {})
+
+
+def test_version_skew_skips(monkeypatch) -> None:  # noqa: ANN001
+    import raitap._adapters as adapters_mod
+
+    monkeypatch.setattr(adapters_mod, "_plugin_raitap_specifier", lambda _d: ">=999,<1000")
+    ok, why = adapters_mod._plugin_version_ok("whatever")
+    assert ok is False
+    assert "requires raitap" in why
+
+
+def test_no_pin_is_malformed(monkeypatch) -> None:  # noqa: ANN001
+    import raitap._adapters as adapters_mod
+
+    monkeypatch.setattr(adapters_mod, "_plugin_raitap_specifier", lambda _d: None)
+    ok, why = adapters_mod._plugin_version_ok("whatever")
+    assert ok is False
+    assert "no 'raitap' dependency pin" in why

--- a/src/raitap/tests/test_third_party_discovery.py
+++ b/src/raitap/tests/test_third_party_discovery.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 _FAKE = Path(__file__).parent / "_fake_plugin"
+_FAKE_BROKEN = Path(__file__).parent / "_fake_broken_plugin"
 
 
 @pytest.fixture(scope="module")
@@ -15,6 +16,13 @@ def _installed_fake_plugin():  # noqa: ANN202
     subprocess.run(["uv", "pip", "install", str(_FAKE)], check=True)
     yield
     subprocess.run(["uv", "pip", "uninstall", "raitap-fakeplugin"], check=True)
+
+
+@pytest.fixture
+def _installed_broken_plugin():  # noqa: ANN202
+    subprocess.run(["uv", "pip", "install", str(_FAKE_BROKEN)], check=True)
+    yield
+    subprocess.run(["uv", "pip", "uninstall", "raitap-fakebrokenplugin"], check=True)
 
 
 def test_plugin_adapter_registered(_installed_fake_plugin) -> None:  # noqa: ANN001
@@ -31,6 +39,25 @@ def test_disabled_env_skips(monkeypatch, _installed_fake_plugin) -> None:  # noq
     monkeypatch.setenv("RAITAP_DISABLE_PLUGINS", "1")
     discover_third_party_adapters()
     assert "fakeattack" not in _BUILDERS.get("robustness", {})
+
+
+def test_crashing_plugin_is_isolated(_installed_broken_plugin) -> None:  # noqa: ANN001
+    """A plugin that raises at import is caught, warned about, and skipped —
+    discovery completes and in-tree adapters stay resolvable."""
+    from raitap.configs import register_configs
+
+    register_configs()  # ensure in-tree adapters are registered
+
+    from raitap._adapters import _BUILDERS, discover_third_party_adapters
+
+    # The broken plugin's import raises; discovery must not propagate it, and
+    # must emit a warning naming the plugin.
+    with pytest.warns(UserWarning, match="fakebroken"):
+        discover_third_party_adapters()
+
+    assert "fakebroken" not in _BUILDERS.get("robustness", {})
+    # In-tree adapter still resolvable — one bad plugin didn't break the registry.
+    assert "torchattacks" in _BUILDERS["robustness"]
 
 
 def test_version_skew_skips(monkeypatch) -> None:  # noqa: ANN001

--- a/src/raitap/tracking/__init__.py
+++ b/src/raitap/tracking/__init__.py
@@ -28,4 +28,10 @@ def __getattr__(name: str) -> Any:
         return TrackingConfig
     from raitap._adapters import lookup
 
-    return lookup("tracking", name)
+    try:
+        return lookup("tracking", name)
+    except AttributeError:
+        from raitap.configs import register_configs
+
+        register_configs()  # idempotent; fires in-tree imports + plugin discovery
+        return lookup("tracking", name)

--- a/src/raitap/tracking/mlflow_tracker.py
+++ b/src/raitap/tracking/mlflow_tracker.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from raitap import raitap_log
 from raitap.configs import cfg_to_dict, resolve_run_dir
 from raitap.models.backend import OnnxBackend, TorchBackend
+from raitap.tracking.registration import tracker
 from raitap.utils.diagnostics import Module
 
 from .base_tracker import BaseTracker
@@ -22,7 +23,6 @@ from .process_registry import (
     reinsert_entries,
     watch_port,
 )
-from .registration import register_tracker
 
 DEFAULT_MLFLOW_BACKEND_STORE_URI = "sqlite:///mlflow/mlflow.db"
 DEFAULT_MLFLOW_ARTIFACT_ROOT = "./mlflow/artifacts"
@@ -171,7 +171,7 @@ def _mlflow_summary_params(config_dict: dict[str, Any]) -> dict[str, str]:
     return out
 
 
-@register_tracker(registry_name="mlflow")
+@tracker(registry_name="mlflow")
 class MLFlowTracker(BaseTracker):
     @classmethod
     def stop_detached(cls, timeout: float = 5.0) -> tuple[int, int]:

--- a/src/raitap/tracking/registration.py
+++ b/src/raitap/tracking/registration.py
@@ -3,14 +3,14 @@
 Adapter sites use ``@register_tracker(...)`` instead of the legacy
 ``class Foo(BaseTracker, registry_name=..., extra=..., ...)`` class-kwargs
 syntax. ``registry_name`` is enforced as required at the call site via
-``Required[str]`` in ``_CommonRegKwargs`` — pyright errors if it is missing.
+``Required[str]`` in ``AdapterDecoratorOptions`` — pyright errors if it is missing.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypeVar, Unpack
 
-from raitap._adapters import FamilyConfig, _CommonRegKwargs, _register_core
+from raitap._adapters import AdapterDecoratorOptions, FamilyConfig, _register_core
 from raitap.configs.schema import TrackingConfig
 
 if TYPE_CHECKING:
@@ -28,7 +28,7 @@ T = TypeVar("T", bound="BaseTracker")
 
 
 def register_tracker(
-    **common: Unpack[_CommonRegKwargs],
+    **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a tracker.
 

--- a/src/raitap/tracking/registration.py
+++ b/src/raitap/tracking/registration.py
@@ -1,6 +1,6 @@
 """Family decorator for tracking adapters.
 
-Adapter sites use ``@register_tracker(...)`` instead of the legacy
+Adapter sites use ``@adapters.tracker(...)`` instead of the legacy
 ``class Foo(BaseTracker, registry_name=..., extra=..., ...)`` class-kwargs
 syntax. ``registry_name`` is enforced as required at the call site via
 ``Required[str]`` in ``AdapterDecoratorOptions`` — pyright errors if it is missing.
@@ -27,7 +27,7 @@ TRACKING = FamilyConfig(
 T = TypeVar("T", bound="BaseTracker")
 
 
-def register_tracker(
+def tracker(
     **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a tracker.

--- a/src/raitap/tracking/tests/test_partial_extras_safe.py
+++ b/src/raitap/tracking/tests/test_partial_extras_safe.py
@@ -39,3 +39,10 @@ def test_adapter_imports_without_wrapped_libs(
 ) -> None:
     monkeypatch.delitem(sys.modules, module_name, raising=False)
     importlib.import_module(module_name)
+
+
+def test_facades_import_without_torch() -> None:
+    import importlib
+
+    for mod in ("raitap.adapters", "raitap.visualisers", "raitap.backends"):
+        importlib.import_module(mod)

--- a/src/raitap/tracking/tests/test_partial_extras_safe.py
+++ b/src/raitap/tracking/tests/test_partial_extras_safe.py
@@ -42,7 +42,5 @@ def test_adapter_imports_without_wrapped_libs(
 
 
 def test_facades_import_without_torch() -> None:
-    import importlib
-
     for mod in ("raitap.adapters", "raitap.visualisers", "raitap.backends"):
         importlib.import_module(mod)

--- a/src/raitap/tracking/tests/test_registration.py
+++ b/src/raitap/tracking/tests/test_registration.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from raitap import adapters
 from raitap.tracking.base_tracker import BaseTracker
-from raitap.tracking.registration import register_tracker
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
     from raitap.models.backend import ModelBackend
 
 
-def test_register_tracker_registers_under_tracking_group() -> None:
-    @register_tracker(
+def test_tracker_registers_under_tracking_group() -> None:
+    @adapters.tracker(
         registry_name="_stub_tracker",
         extra="_stub_extra",
     )

--- a/src/raitap/transparency/__init__.py
+++ b/src/raitap/transparency/__init__.py
@@ -159,7 +159,13 @@ def __getattr__(name: str) -> Any:
         return TransparencyConfig
     from raitap._adapters import lookup
 
-    return lookup("transparency", name)
+    try:
+        return lookup("transparency", name)
+    except AttributeError:
+        from raitap.configs import register_configs
+
+        register_configs()  # idempotent; fires in-tree imports + plugin discovery
+        return lookup("transparency", name)
 
 
 __all__ = [  # noqa: RUF022

--- a/src/raitap/transparency/explainers/base_explainer.py
+++ b/src/raitap/transparency/explainers/base_explainer.py
@@ -54,7 +54,7 @@ class BaseExplainer(AdapterMixin, ABC):
     output_scope: ClassVar[ExplanationScope] = ExplanationScope.LOCAL
     algorithm_registry: ClassVar[Mapping[str, frozenset[MethodFamily]]]
     # Adapter-specific; defaults to "no ONNX support". The
-    # ``@register_transparency_adapter`` decorator overrides per-adapter.
+    # ``@adapters.transparency`` decorator overrides per-adapter.
     ONNX_COMPATIBLE_ALGORITHMS: ClassVar[frozenset[str]] = frozenset()
 
     def check_backend_compat(self, backend: object) -> None:

--- a/src/raitap/transparency/explainers/captum_explainer.py
+++ b/src/raitap/transparency/explainers/captum_explainer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from raitap.transparency.contracts import MethodFamily
-from raitap.transparency.explainers.registration import register_transparency_adapter
+from raitap.transparency.explainers.registration import transparency_adapter
 
 from .base_explainer import AttributionOnlyExplainer
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     import torch.nn as nn
 
 
-@register_transparency_adapter(
+@transparency_adapter(
     registry_name="captum",
     library="captum",
     # Captum emits the ``required_grads`` UserWarning on every run when inputs

--- a/src/raitap/transparency/explainers/registration.py
+++ b/src/raitap/transparency/explainers/registration.py
@@ -1,6 +1,6 @@
 """Family decorator for transparency explainers.
 
-Adapter sites use ``@register_transparency_adapter(...)`` instead of the
+Adapter sites use ``@adapters.transparency(...)`` instead of the
 legacy ``class Foo(AttributionOnlyExplainer, registry_name=..., extra=..., ...)``
 class-kwargs syntax. Required per-family metadata (``algorithm_registry``) is
 type-checked by pyright at the decoration site. ``output_payload_kind``
@@ -37,7 +37,7 @@ TRANSPARENCY = FamilyConfig(
 T = TypeVar("T", bound="BaseExplainer")
 
 
-def register_transparency_adapter(
+def transparency_adapter(
     *,
     algorithm_registry: Mapping[str, frozenset[MethodFamily]],
     output_payload_kind: ExplanationPayloadKind = ExplanationPayloadKind.ATTRIBUTIONS,

--- a/src/raitap/transparency/explainers/registration.py
+++ b/src/raitap/transparency/explainers/registration.py
@@ -14,9 +14,9 @@ from typing import TYPE_CHECKING, TypeVar, Unpack
 
 from raitap._adapters import (
     ALL,
+    AdapterDecoratorOptions,
     FamilyConfig,
     _AllAlgorithmsSentinel,
-    _CommonRegKwargs,
     _register_core,
 )
 from raitap.configs.schema import TransparencyConfig
@@ -42,12 +42,12 @@ def register_transparency_adapter(
     algorithm_registry: Mapping[str, frozenset[MethodFamily]],
     output_payload_kind: ExplanationPayloadKind = ExplanationPayloadKind.ATTRIBUTIONS,
     onnx_compatible_algorithms: frozenset[str] | _AllAlgorithmsSentinel = frozenset(),
-    **common: Unpack[_CommonRegKwargs],
+    **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a transparency explainer.
 
     Required:
-        ``registry_name`` (via ``_CommonRegKwargs.Required[str]``) and
+        ``registry_name`` (via ``AdapterDecoratorOptions.Required[str]``) and
         ``algorithm_registry``.
 
     Optional:

--- a/src/raitap/transparency/explainers/shap_explainer.py
+++ b/src/raitap/transparency/explainers/shap_explainer.py
@@ -15,7 +15,7 @@ else:
     torch = lazy_import("torch")
     nn = lazy_import("torch.nn")
 from raitap.transparency.contracts import MethodFamily
-from raitap.transparency.explainers.registration import register_transparency_adapter
+from raitap.transparency.explainers.registration import transparency_adapter
 
 from .base_explainer import AttributionOnlyExplainer
 
@@ -68,7 +68,7 @@ def _select_target_attributions(
     return shap_values[batch_indices, ..., target_tensor]
 
 
-@register_transparency_adapter(
+@transparency_adapter(
     registry_name="shap",
     library="shap",
     error_patterns={

--- a/src/raitap/transparency/explainers/tests/test_registration.py
+++ b/src/raitap/transparency/explainers/tests/test_registration.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 
+from raitap import adapters
 from raitap.transparency.contracts import ExplanationPayloadKind, MethodFamily
 from raitap.transparency.explainers.base_explainer import AttributionOnlyExplainer
-from raitap.transparency.explainers.registration import register_transparency_adapter
 
 
-def test_register_transparency_adapter_registers_and_assigns_classvars() -> None:
-    @register_transparency_adapter(
+def test_transparency_adapter_registers_and_assigns_classvars() -> None:
+    @adapters.transparency(
         registry_name="_stub_xai",
         extra="_stub_extra",
         library="_stub_lib",

--- a/src/raitap/transparency/semantics.py
+++ b/src/raitap/transparency/semantics.py
@@ -30,7 +30,7 @@ def method_families_for_explainer(explainer: object) -> frozenset[MethodFamily]:
 
     1. ``type(explainer).algorithm_registry`` — required class-body ClassVar
        on every transparency adapter (validated at decoration time by
-       ``@register_transparency_adapter``'s required kwarg).
+       ``@adapters.transparency``'s required kwarg).
     2. Framework label on the explainer (``framework="shap"`` /
        ``"captum"``) → matching adapter class's registry.
     3. Cross-framework algorithm-name lookup (used by minimal test stubs

--- a/src/raitap/transparency/tests/test_detection_image_visualiser.py
+++ b/src/raitap/transparency/tests/test_detection_image_visualiser.py
@@ -107,7 +107,7 @@ def test_visualiser_raises_when_detection_box_missing() -> None:
 
 def test_detection_image_visualiser_is_importable_from_visualisers_package() -> None:
     """Fresh-process surface: importing raitap.transparency.visualisers must
-    eagerly load detection_image_visualiser so the @register_transparency_visualiser
+    eagerly load detection_image_visualiser so the @visualisers.transparency
     side effect runs and the hydra-zen store knows about ``_target_:
     detection_image``."""
     import importlib

--- a/src/raitap/transparency/visualisers/captum_visualisers.py
+++ b/src/raitap/transparency/visualisers/captum_visualisers.py
@@ -13,9 +13,9 @@ from raitap.transparency.contracts import (
     ExplanationScope,
     MethodFamily,
 )
+from raitap.transparency.visualisers.registration import transparency_visualiser
 
 from .base_visualiser import BaseVisualiser
-from .registration import register_transparency_visualiser
 
 if TYPE_CHECKING:
     import torch
@@ -179,7 +179,7 @@ def _has_token_layout(explanation: object, attributions: object) -> bool:
     return shape is not None and len(shape) == 1
 
 
-@register_transparency_visualiser(registry_name="captum_image")
+@transparency_visualiser(registry_name="captum_image")
 class CaptumImageVisualiser(BaseVisualiser):
     """
     Visualise image attributions using ``captum.attr.visualization.visualize_image_attr``.
@@ -421,7 +421,7 @@ class CaptumImageVisualiser(BaseVisualiser):
         return fig
 
 
-@register_transparency_visualiser(registry_name="captum_time_series")
+@transparency_visualiser(registry_name="captum_time_series")
 class CaptumTimeSeriesVisualiser(BaseVisualiser):
     """
     Visualise time-series attributions via
@@ -529,7 +529,7 @@ class CaptumTimeSeriesVisualiser(BaseVisualiser):
         return fig
 
 
-@register_transparency_visualiser(registry_name="captum_text")
+@transparency_visualiser(registry_name="captum_text")
 class CaptumTextVisualiser(BaseVisualiser):
     """
     Visualise per-token text attributions as a horizontal bar chart.

--- a/src/raitap/transparency/visualisers/captum_visualisers.py
+++ b/src/raitap/transparency/visualisers/captum_visualisers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -179,7 +179,27 @@ def _has_token_layout(explanation: object, attributions: object) -> bool:
     return shape is not None and len(shape) == 1
 
 
-@transparency_visualiser(registry_name="captum_image")
+@transparency_visualiser(
+    registry_name="captum_image",
+    supported_scopes=frozenset({ExplanationScope.LOCAL}),
+    supported_output_spaces=frozenset(
+        {
+            ExplanationOutputSpace.INPUT_FEATURES,
+            ExplanationOutputSpace.IMAGE_SPATIAL_MAP,
+        }
+    ),
+    supported_method_families=frozenset(
+        {
+            MethodFamily.GRADIENT,
+            MethodFamily.PERTURBATION,
+            MethodFamily.SHAPLEY,
+            MethodFamily.CAM,
+            MethodFamily.MODEL_AGNOSTIC,
+            MethodFamily.SURROGATE,
+        }
+    ),
+    embeds_original_input=True,
+)
 class CaptumImageVisualiser(BaseVisualiser):
     """
     Visualise image attributions using ``captum.attr.visualization.visualize_image_attr``.
@@ -189,25 +209,6 @@ class CaptumImageVisualiser(BaseVisualiser):
 
     Compatible with ALL Captum attribution algorithms.
     """
-
-    supported_scopes: ClassVar[frozenset[ExplanationScope]] = frozenset({ExplanationScope.LOCAL})
-    supported_output_spaces: ClassVar[frozenset[ExplanationOutputSpace]] = frozenset(
-        {
-            ExplanationOutputSpace.INPUT_FEATURES,
-            ExplanationOutputSpace.IMAGE_SPATIAL_MAP,
-        }
-    )
-    supported_method_families: ClassVar[frozenset[MethodFamily]] = frozenset(
-        {
-            MethodFamily.GRADIENT,
-            MethodFamily.PERTURBATION,
-            MethodFamily.SHAPLEY,
-            MethodFamily.CAM,
-            MethodFamily.MODEL_AGNOSTIC,
-            MethodFamily.SURROGATE,
-        }
-    )
-    embeds_original_input: ClassVar[bool] = True
 
     def renders_attribution_only_when_original_hidden(self) -> bool:
         return self.method != "masked_image"
@@ -421,7 +422,12 @@ class CaptumImageVisualiser(BaseVisualiser):
         return fig
 
 
-@transparency_visualiser(registry_name="captum_time_series")
+@transparency_visualiser(
+    registry_name="captum_time_series",
+    supported_scopes=frozenset({ExplanationScope.LOCAL}),
+    supported_output_spaces=frozenset({ExplanationOutputSpace.INPUT_FEATURES}),
+    supported_method_families=_CAPTUM_SEQUENCE_METHOD_FAMILIES,
+)
 class CaptumTimeSeriesVisualiser(BaseVisualiser):
     """
     Visualise time-series attributions via
@@ -429,12 +435,6 @@ class CaptumTimeSeriesVisualiser(BaseVisualiser):
 
     Compatible with ALL Captum attribution algorithms.
     """
-
-    supported_scopes: ClassVar[frozenset[ExplanationScope]] = frozenset({ExplanationScope.LOCAL})
-    supported_output_spaces: ClassVar[frozenset[ExplanationOutputSpace]] = frozenset(
-        {ExplanationOutputSpace.INPUT_FEATURES}
-    )
-    supported_method_families: ClassVar[frozenset[MethodFamily]] = _CAPTUM_SEQUENCE_METHOD_FAMILIES
 
     def validate_explanation(
         self,
@@ -529,7 +529,12 @@ class CaptumTimeSeriesVisualiser(BaseVisualiser):
         return fig
 
 
-@transparency_visualiser(registry_name="captum_text")
+@transparency_visualiser(
+    registry_name="captum_text",
+    supported_scopes=frozenset({ExplanationScope.LOCAL}),
+    supported_output_spaces=frozenset({ExplanationOutputSpace.TOKEN_SEQUENCE}),
+    supported_method_families=_CAPTUM_SEQUENCE_METHOD_FAMILIES,
+)
 class CaptumTextVisualiser(BaseVisualiser):
     """
     Visualise per-token text attributions as a horizontal bar chart.
@@ -542,12 +547,6 @@ class CaptumTextVisualiser(BaseVisualiser):
     Note: ``attributions`` should be a 1-D array of per-token scores for a
     single input. Pass ``token_labels`` via kwargs for readable output.
     """
-
-    supported_scopes: ClassVar[frozenset[ExplanationScope]] = frozenset({ExplanationScope.LOCAL})
-    supported_output_spaces: ClassVar[frozenset[ExplanationOutputSpace]] = frozenset(
-        {ExplanationOutputSpace.TOKEN_SEQUENCE}
-    )
-    supported_method_families: ClassVar[frozenset[MethodFamily]] = _CAPTUM_SEQUENCE_METHOD_FAMILIES
 
     def validate_explanation(
         self,

--- a/src/raitap/transparency/visualisers/detection_image_visualiser.py
+++ b/src/raitap/transparency/visualisers/detection_image_visualiser.py
@@ -20,10 +20,10 @@ from raitap.transparency.contracts import (
     ExplanationScope,
     MethodFamily,
 )
+from raitap.transparency.visualisers.registration import transparency_visualiser
 from raitap.types import TaskKind
 
 from .base_visualiser import BaseVisualiser
-from .registration import register_transparency_visualiser
 
 if TYPE_CHECKING:
     import torch
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from raitap.transparency.contracts import VisualisationContext
 
 
-@register_transparency_visualiser(registry_name="detection_image")
+@transparency_visualiser(registry_name="detection_image")
 class DetectionImageVisualiser(BaseVisualiser):
     """Render one fig per box: original image + bbox rectangle + heatmap.
 

--- a/src/raitap/transparency/visualisers/detection_image_visualiser.py
+++ b/src/raitap/transparency/visualisers/detection_image_visualiser.py
@@ -8,7 +8,7 @@ model_agnostic / surrogate). Issue #146 Phase 3.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
@@ -32,23 +32,12 @@ if TYPE_CHECKING:
     from raitap.transparency.contracts import VisualisationContext
 
 
-@transparency_visualiser(registry_name="detection_image")
-class DetectionImageVisualiser(BaseVisualiser):
-    """Render one fig per box: original image + bbox rectangle + heatmap.
-
-    Reads the per-box metadata from ``context.detection_box`` (populated by
-    the detection explain phase). The visualiser does not know which box k
-    it is rendering until the context is passed in.
-    """
-
-    supported_payload_kinds: ClassVar[frozenset[ExplanationPayloadKind]] = frozenset(
-        {ExplanationPayloadKind.ATTRIBUTIONS}
-    )
-    supported_output_spaces: ClassVar[frozenset[ExplanationOutputSpace]] = frozenset(
-        {ExplanationOutputSpace.DETECTION_BOXES}
-    )
-    supported_scopes: ClassVar[frozenset[ExplanationScope]] = frozenset({ExplanationScope.LOCAL})
-    supported_method_families: ClassVar[frozenset[MethodFamily]] = frozenset(
+@transparency_visualiser(
+    registry_name="detection_image",
+    supported_payload_kinds=frozenset({ExplanationPayloadKind.ATTRIBUTIONS}),
+    supported_output_spaces=frozenset({ExplanationOutputSpace.DETECTION_BOXES}),
+    supported_scopes=frozenset({ExplanationScope.LOCAL}),
+    supported_method_families=frozenset(
         {
             MethodFamily.GRADIENT,
             MethodFamily.PERTURBATION,
@@ -57,9 +46,17 @@ class DetectionImageVisualiser(BaseVisualiser):
             MethodFamily.MODEL_AGNOSTIC,
             MethodFamily.SURROGATE,
         }
-    )
-    supported_tasks: ClassVar[frozenset[TaskKind]] = frozenset({TaskKind.detection})
-    embeds_original_input: ClassVar[bool] = True
+    ),
+    supported_tasks=frozenset({TaskKind.detection}),
+    embeds_original_input=True,
+)
+class DetectionImageVisualiser(BaseVisualiser):
+    """Render one fig per box: original image + bbox rectangle + heatmap.
+
+    Reads the per-box metadata from ``context.detection_box`` (populated by
+    the detection explain phase). The visualiser does not know which box k
+    it is rendering until the context is passed in.
+    """
 
     def visualise(
         self,

--- a/src/raitap/transparency/visualisers/input_thumbnail.py
+++ b/src/raitap/transparency/visualisers/input_thumbnail.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -62,12 +62,13 @@ def _display_image(ax: Any, image: np.ndarray) -> None:
     ax.imshow(image, cmap="gray" if image.ndim == 2 else None)
 
 
-@transparency_visualiser(registry_name="input_thumbnail")
+@transparency_visualiser(
+    registry_name="input_thumbnail",
+    supported_scopes=frozenset({ExplanationScope.LOCAL}),
+    embeds_original_input=False,
+)
 class InputThumbnailVisualiser(BaseVisualiser):
     """Render a compact preview of the original input for report sample headers."""
-
-    supported_scopes: ClassVar[frozenset[ExplanationScope]] = frozenset({ExplanationScope.LOCAL})
-    embeds_original_input: ClassVar[bool] = False
 
     def __init__(self, title: str = "Input"):
         self.title = title

--- a/src/raitap/transparency/visualisers/input_thumbnail.py
+++ b/src/raitap/transparency/visualisers/input_thumbnail.py
@@ -11,9 +11,9 @@ from matplotlib.figure import (
 )
 
 from raitap.transparency.contracts import ExplanationScope, VisualisationContext
+from raitap.transparency.visualisers.registration import transparency_visualiser
 
 from .base_visualiser import BaseVisualiser
-from .registration import register_transparency_visualiser
 
 
 def _to_numpy(x: Any) -> np.ndarray:
@@ -62,7 +62,7 @@ def _display_image(ax: Any, image: np.ndarray) -> None:
     ax.imshow(image, cmap="gray" if image.ndim == 2 else None)
 
 
-@register_transparency_visualiser(registry_name="input_thumbnail")
+@transparency_visualiser(registry_name="input_thumbnail")
 class InputThumbnailVisualiser(BaseVisualiser):
     """Render a compact preview of the original input for report sample headers."""
 

--- a/src/raitap/transparency/visualisers/registration.py
+++ b/src/raitap/transparency/visualisers/registration.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypeVar, Unpack
 
-from raitap._adapters import _CommonRegKwargs, _register_core
+from raitap._adapters import AdapterDecoratorOptions, _register_core
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -22,12 +22,12 @@ T = TypeVar("T", bound="BaseVisualiser")
 
 
 def register_transparency_visualiser(
-    **common: Unpack[_CommonRegKwargs],
+    **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a transparency visualiser.
 
     ``registry_name`` is required (enforced via ``Required[str]`` in
-    ``_CommonRegKwargs``). There is no Hydra group; the builder lands in
+    ``AdapterDecoratorOptions``). There is no Hydra group; the builder lands in
     ``_BUILDERS['_unscoped']``.
     """
 

--- a/src/raitap/transparency/visualisers/registration.py
+++ b/src/raitap/transparency/visualisers/registration.py
@@ -1,37 +1,73 @@
 """Family decorator for transparency visualisers (no Hydra group).
 
-Adapter sites use ``@visualisers.transparency(...)`` instead of the
-legacy ``class Foo(BaseVisualiser, registry_name=..., ...)`` class-kwargs
-syntax. Visualisers do not own a Hydra family group — the resulting builder is
-stored in ``_BUILDERS['_unscoped']`` and embedded as a list inside
-``TransparencyConfig`` entries.
+Capability fields are passed as kwargs and set on the class only when provided
+(UNSET sentinel), so values inherited from an intermediate base (e.g.
+``_TabularSummaryContractMixin``) are preserved — behaviour stays identical to
+the previous class-body declarations.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, Unpack
+from typing import TYPE_CHECKING, Final, TypeVar, Unpack
 
 from raitap._adapters import AdapterDecoratorOptions, _register_core
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from raitap.transparency.contracts import (
+        ExplanationOutputSpace,
+        ExplanationPayloadKind,
+        ExplanationScope,
+        MethodFamily,
+        ScopeDefinitionStep,
+        VisualSummarySpec,
+    )
     from raitap.transparency.visualisers.base_visualiser import BaseVisualiser
+    from raitap.types import TaskKind
+
+
+class _Unset:
+    __slots__ = ()
+
+
+_UNSET: Final = _Unset()
 
 T = TypeVar("T", bound="BaseVisualiser")
 
 
 def transparency_visualiser(
+    *,
+    supported_payload_kinds: frozenset[ExplanationPayloadKind] | _Unset = _UNSET,
+    supported_scopes: frozenset[ExplanationScope] | _Unset = _UNSET,
+    supported_output_spaces: frozenset[ExplanationOutputSpace] | _Unset = _UNSET,
+    supported_method_families: frozenset[MethodFamily] | _Unset = _UNSET,
+    supported_tasks: frozenset[TaskKind] | _Unset = _UNSET,
+    compatible_algorithms: frozenset[str] | _Unset = _UNSET,
+    embeds_original_input: bool | _Unset = _UNSET,
+    produces_scope: ExplanationScope | None | _Unset = _UNSET,
+    scope_definition_step: ScopeDefinitionStep | None | _Unset = _UNSET,
+    visual_summary: VisualSummarySpec | None | _Unset = _UNSET,
     **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
-    """Decorator: register a transparency visualiser.
-
-    ``registry_name`` is required (enforced via ``Required[str]`` in
-    ``AdapterDecoratorOptions``). There is no Hydra group; the builder lands in
-    ``_BUILDERS['_unscoped']``.
-    """
+    """Register a transparency visualiser. ``registry_name`` required; all
+    capability kwargs optional (omitted → inherit base/mixin default)."""
 
     def wrap(cls: type[T]) -> type[T]:
+        for attr, value in (
+            ("supported_payload_kinds", supported_payload_kinds),
+            ("supported_scopes", supported_scopes),
+            ("supported_output_spaces", supported_output_spaces),
+            ("supported_method_families", supported_method_families),
+            ("supported_tasks", supported_tasks),
+            ("compatible_algorithms", compatible_algorithms),
+            ("embeds_original_input", embeds_original_input),
+            ("produces_scope", produces_scope),
+            ("scope_definition_step", scope_definition_step),
+            ("visual_summary", visual_summary),
+        ):
+            if value is not _UNSET:  # identity check on the singleton sentinel
+                setattr(cls, attr, value)
         return _register_core(cls, family=None, **common)
 
     return wrap

--- a/src/raitap/transparency/visualisers/registration.py
+++ b/src/raitap/transparency/visualisers/registration.py
@@ -1,6 +1,6 @@
 """Family decorator for transparency visualisers (no Hydra group).
 
-Adapter sites use ``@register_transparency_visualiser(...)`` instead of the
+Adapter sites use ``@visualisers.transparency(...)`` instead of the
 legacy ``class Foo(BaseVisualiser, registry_name=..., ...)`` class-kwargs
 syntax. Visualisers do not own a Hydra family group — the resulting builder is
 stored in ``_BUILDERS['_unscoped']`` and embedded as a list inside
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound="BaseVisualiser")
 
 
-def register_transparency_visualiser(
+def transparency_visualiser(
     **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a transparency visualiser.

--- a/src/raitap/transparency/visualisers/shap_visualisers.py
+++ b/src/raitap/transparency/visualisers/shap_visualisers.py
@@ -21,9 +21,9 @@ from raitap.transparency.contracts import (
     ScopeDefinitionStep,
     VisualSummarySpec,
 )
+from raitap.transparency.visualisers.registration import transparency_visualiser
 
 from .base_visualiser import BaseVisualiser
-from .registration import register_transparency_visualiser
 
 if TYPE_CHECKING:
     import torch
@@ -211,7 +211,7 @@ class _TabularSummaryContractMixin(BaseVisualiser):
 # ---------------------------------------------------------------------------
 
 
-@register_transparency_visualiser(registry_name="shap_bar")
+@transparency_visualiser(registry_name="shap_bar")
 class ShapBarVisualiser(_TabularSummaryContractMixin):
     """
     Mean absolute SHAP value bar chart via ``shap.summary_plot(plot_type='bar')``.
@@ -268,7 +268,7 @@ class ShapBarVisualiser(_TabularSummaryContractMixin):
         return fig
 
 
-@register_transparency_visualiser(registry_name="shap_beeswarm")
+@transparency_visualiser(registry_name="shap_beeswarm")
 class ShapBeeswarmVisualiser(_TabularSummaryContractMixin):
     """
     SHAP beeswarm summary plot via ``shap.summary_plot()``.
@@ -317,7 +317,7 @@ class ShapBeeswarmVisualiser(_TabularSummaryContractMixin):
         return fig
 
 
-@register_transparency_visualiser(registry_name="shap_waterfall")
+@transparency_visualiser(registry_name="shap_waterfall")
 class ShapWaterfallVisualiser(BaseVisualiser):
     """
     Per-sample SHAP waterfall chart via ``shap.plots.waterfall``.
@@ -385,7 +385,7 @@ class ShapWaterfallVisualiser(BaseVisualiser):
         return _close_and_return(fig)
 
 
-@register_transparency_visualiser(registry_name="shap_force")
+@transparency_visualiser(registry_name="shap_force")
 class ShapForceVisualiser(BaseVisualiser):
     """
     Per-sample SHAP force plot via ``shap.plots.force`` (matplotlib backend).
@@ -448,7 +448,7 @@ class ShapForceVisualiser(BaseVisualiser):
 # ---------------------------------------------------------------------------
 
 
-@register_transparency_visualiser(registry_name="shap_image")
+@transparency_visualiser(registry_name="shap_image")
 class ShapImageVisualiser(BaseVisualiser):
     """
     Render image-level SHAP attributions with Matplotlib.

--- a/src/raitap/transparency/visualisers/shap_visualisers.py
+++ b/src/raitap/transparency/visualisers/shap_visualisers.py
@@ -211,19 +211,20 @@ class _TabularSummaryContractMixin(BaseVisualiser):
 # ---------------------------------------------------------------------------
 
 
-@transparency_visualiser(registry_name="shap_bar")
+@transparency_visualiser(
+    registry_name="shap_bar",
+    visual_summary=VisualSummarySpec(
+        summary_type="bar",
+        aggregation="mean_absolute_attribution",
+        description="Mean absolute attribution by feature.",
+    ),
+)
 class ShapBarVisualiser(_TabularSummaryContractMixin):
     """
     Mean absolute SHAP value bar chart via ``shap.summary_plot(plot_type='bar')``.
 
     Compatible with all SHAP explainer algorithms.
     """
-
-    visual_summary: ClassVar[VisualSummarySpec | None] = VisualSummarySpec(
-        summary_type="bar",
-        aggregation="mean_absolute_attribution",
-        description="Mean absolute attribution by feature.",
-    )
 
     def __init__(self, feature_names: list[str] | None = None, max_display: int = 20):
         self.feature_names = feature_names
@@ -268,19 +269,20 @@ class ShapBarVisualiser(_TabularSummaryContractMixin):
         return fig
 
 
-@transparency_visualiser(registry_name="shap_beeswarm")
+@transparency_visualiser(
+    registry_name="shap_beeswarm",
+    visual_summary=VisualSummarySpec(
+        summary_type="beeswarm",
+        aggregation="distribution_summary",
+        description="Distribution of local attributions by feature.",
+    ),
+)
 class ShapBeeswarmVisualiser(_TabularSummaryContractMixin):
     """
     SHAP beeswarm summary plot via ``shap.summary_plot()``.
 
     Compatible with all SHAP explainer algorithms.
     """
-
-    visual_summary: ClassVar[VisualSummarySpec | None] = VisualSummarySpec(
-        summary_type="beeswarm",
-        aggregation="distribution_summary",
-        description="Distribution of local attributions by feature.",
-    )
 
     def __init__(self, feature_names: list[str] | None = None, max_display: int = 20):
         self.feature_names = feature_names
@@ -448,7 +450,14 @@ class ShapForceVisualiser(BaseVisualiser):
 # ---------------------------------------------------------------------------
 
 
-@transparency_visualiser(registry_name="shap_image")
+@transparency_visualiser(
+    registry_name="shap_image",
+    compatible_algorithms=frozenset({"GradientExplainer", "DeepExplainer"}),
+    supported_scopes=frozenset({ExplanationScope.LOCAL}),
+    supported_output_spaces=frozenset({ExplanationOutputSpace.INPUT_FEATURES}),
+    supported_method_families=frozenset({MethodFamily.GRADIENT}),
+    embeds_original_input=True,
+)
 class ShapImageVisualiser(BaseVisualiser):
     """
     Render image-level SHAP attributions with Matplotlib.
@@ -467,18 +476,6 @@ class ShapImageVisualiser(BaseVisualiser):
     Positive contributions are shown in warm colours and negative
     contributions in cool colours, using the configured Matplotlib colormap.
     """
-
-    compatible_algorithms: ClassVar[frozenset[str]] = frozenset(
-        {"GradientExplainer", "DeepExplainer"}
-    )
-    supported_scopes: ClassVar[frozenset[ExplanationScope]] = frozenset({ExplanationScope.LOCAL})
-    supported_output_spaces: ClassVar[frozenset[ExplanationOutputSpace]] = frozenset(
-        {ExplanationOutputSpace.INPUT_FEATURES}
-    )
-    supported_method_families: ClassVar[frozenset[MethodFamily]] = frozenset(
-        {MethodFamily.GRADIENT}
-    )
-    embeds_original_input: ClassVar[bool] = True
 
     def validate_explanation(
         self,

--- a/src/raitap/transparency/visualisers/tabular_visualiser.py
+++ b/src/raitap/transparency/visualisers/tabular_visualiser.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -25,31 +25,30 @@ if TYPE_CHECKING:
     from raitap.transparency.contracts import VisualisationContext
 
 
-@transparency_visualiser(registry_name="tabular_bar_chart")
+@transparency_visualiser(
+    registry_name="tabular_bar_chart",
+    supported_scopes=frozenset({ExplanationScope.LOCAL}),
+    supported_output_spaces=frozenset(
+        {
+            ExplanationOutputSpace.INPUT_FEATURES,
+            ExplanationOutputSpace.INTERPRETABLE_FEATURES,
+        }
+    ),
+    supported_method_families=frozenset(MethodFamily),
+    produces_scope=ExplanationScope.COHORT,
+    scope_definition_step=ScopeDefinitionStep.VISUALISER_SUMMARY,
+    visual_summary=VisualSummarySpec(
+        summary_type="tabular_bar",
+        aggregation="mean_absolute_attribution",
+        description="Mean absolute attribution by tabular feature.",
+    ),
+)
 class TabularBarChartVisualiser(BaseVisualiser):
     """
     Visualise attributions for tabular data as bar charts.
 
     Works with any attribution method (Captum, SHAP, etc.)
     """
-
-    supported_scopes: ClassVar[frozenset[ExplanationScope]] = frozenset({ExplanationScope.LOCAL})
-    supported_output_spaces: ClassVar[frozenset[ExplanationOutputSpace]] = frozenset(
-        {
-            ExplanationOutputSpace.INPUT_FEATURES,
-            ExplanationOutputSpace.INTERPRETABLE_FEATURES,
-        }
-    )
-    supported_method_families: ClassVar[frozenset[MethodFamily]] = frozenset(MethodFamily)
-    produces_scope: ClassVar[ExplanationScope | None] = ExplanationScope.COHORT
-    scope_definition_step: ClassVar[ScopeDefinitionStep | None] = (
-        ScopeDefinitionStep.VISUALISER_SUMMARY
-    )
-    visual_summary: ClassVar[VisualSummarySpec | None] = VisualSummarySpec(
-        summary_type="tabular_bar",
-        aggregation="mean_absolute_attribution",
-        description="Mean absolute attribution by tabular feature.",
-    )
 
     def __init__(self, feature_names: list[str] | None = None):
         """

--- a/src/raitap/transparency/visualisers/tabular_visualiser.py
+++ b/src/raitap/transparency/visualisers/tabular_visualiser.py
@@ -14,9 +14,9 @@ from raitap.transparency.contracts import (
     ScopeDefinitionStep,
     VisualSummarySpec,
 )
+from raitap.transparency.visualisers.registration import transparency_visualiser
 
 from .base_visualiser import BaseVisualiser
-from .registration import register_transparency_visualiser
 
 if TYPE_CHECKING:
     import torch
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from raitap.transparency.contracts import VisualisationContext
 
 
-@register_transparency_visualiser(registry_name="tabular_bar_chart")
+@transparency_visualiser(registry_name="tabular_bar_chart")
 class TabularBarChartVisualiser(BaseVisualiser):
     """
     Visualise attributions for tabular data as bar charts.

--- a/src/raitap/transparency/visualisers/tests/test_registration.py
+++ b/src/raitap/transparency/visualisers/tests/test_registration.py
@@ -42,3 +42,24 @@ def test_transparency_visualiser_lands_in_unscoped_pool() -> None:
     from raitap._adapters import _BUILDERS
 
     assert "_stub_viz" in _BUILDERS["_unscoped"]
+
+
+def test_capability_fields_settable_via_decorator() -> None:
+    from matplotlib.figure import Figure
+
+    from raitap.transparency.contracts import ExplanationScope
+    from raitap.transparency.visualisers.base_visualiser import BaseVisualiser
+    from raitap.transparency.visualisers.registration import transparency_visualiser
+
+    @transparency_visualiser(
+        registry_name="_stub_caps",
+        supported_scopes=frozenset({ExplanationScope.LOCAL}),
+        embeds_original_input=True,
+    )
+    class _StubCaps(BaseVisualiser):
+        def visualise(self, attributions, inputs=None, *, context=None, **kwargs) -> Figure:  # type: ignore[no-untyped-def]  # noqa: ANN001
+            return Figure()
+
+    assert _StubCaps.supported_scopes == frozenset({ExplanationScope.LOCAL})
+    assert _StubCaps.embeds_original_input is True
+    assert _StubCaps.supported_payload_kinds == BaseVisualiser.supported_payload_kinds

--- a/src/raitap/transparency/visualisers/tests/test_registration.py
+++ b/src/raitap/transparency/visualisers/tests/test_registration.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any
 
 from matplotlib.figure import Figure
 
+from raitap import visualisers
 from raitap.transparency.visualisers.base_visualiser import BaseVisualiser
-from raitap.transparency.visualisers.registration import register_transparency_visualiser
 
 if TYPE_CHECKING:
     import torch
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 # Defined at module scope so ``hydra_zen.builds(...)`` can resolve the class's
 # ``__module__`` — nested-in-function classes would not be importable and the
 # ``_register_core`` swallow would silently skip registration.
-@register_transparency_visualiser(
+@visualisers.transparency(
     registry_name="_stub_viz",
 )
 class _StubViz(BaseVisualiser):
@@ -38,7 +38,7 @@ class _StubViz(BaseVisualiser):
         return Figure()
 
 
-def test_register_transparency_visualiser_lands_in_unscoped_pool() -> None:
+def test_transparency_visualiser_lands_in_unscoped_pool() -> None:
     from raitap._adapters import _BUILDERS
 
     assert "_stub_viz" in _BUILDERS["_unscoped"]

--- a/src/raitap/visualisers.py
+++ b/src/raitap/visualisers.py
@@ -1,0 +1,14 @@
+"""Public namespaced decorator surface for registering visualisers.
+
+from raitap import visualisers
+
+@visualisers.transparency(registry_name="my_viz", supported_scopes=...)
+class MyVisualiser(BaseVisualiser): ...
+"""
+
+from __future__ import annotations
+
+from raitap.robustness.visualisers.registration import robustness_visualiser as robustness
+from raitap.transparency.visualisers.registration import transparency_visualiser as transparency
+
+__all__ = ["robustness", "transparency"]


### PR DESCRIPTION
## Summary

Closes #173. Two-part change on one branch.

**Part A — decorator parity.** Finishes the rushed decorator rollout so all adapter registration/identity metadata lives on the family decorator, not class bodies:
- `_CommonRegKwargs` → public `AdapterDecoratorOptions` (importable: `from raitap import AdapterDecoratorOptions`).
- Family decorators exposed via a public namespaced surface: `@adapters.transparency/.robustness/.metrics/.reporter/.tracker`, `@visualisers.transparency/.robustness`, `@backends.register`, through new facade modules (`raitap/adapters.py`, `visualisers.py`, `backends.py`). In-tree adapters use the bare decorator imported from their sibling `registration.py` (the facade is the public/plugin surface only — avoids an import cycle).
- Visualiser capability `ClassVar`s moved onto the decorators via an UNSET sentinel that preserves inherited values (e.g. `_TabularSummaryContractMixin`); behaviour byte-identical.
- New `@backends.register(supports_torch_autograd=...)` gives a decoration-site type gate for the one required backend class constant.
- Assessor `budget_kwarg_source` moved to `@adapters.robustness` (typed `Literal`); dead `threat_model_default`/`objective_default` removed.

**Part B — third-party plugin system.** External pip packages register adapters via the `raitap.adapters` entry-point group:
- `discover_third_party_adapters()` iterates the group, version-checks each plugin against its pip `Requires-Dist` raitap pin (skip+warn on mismatch/missing pin), isolates per-plugin failures, honours `RAITAP_DISABLE_PLUGINS=1`.
- Wired into `register_zen_groups()` (config-registration time — a bare `import raitap` runs no plugin code); family `__getattr__` lazily registers on lookup miss so `from raitap.<family> import <plugin>` works standalone.
- Fake-plugin fixtures + e2e tests (registration, disabled-env, version-skew, missing-pin, crash isolation).
- Plugin author guide: `docs/contributor/writing-a-plugin.md`.

Also fixes a latent torch-free-bootstrap bug: a `nn.Module` `TypeVar` bound in `data/preprocessing.py` evaluated torch eagerly (pre-existing; broke the partial-extras path).

## Test Plan
- [x] Full suite: 1118 passed, 9 skipped. 2 failures are pre-existing XPU-env detection flakes (verified identical on base `469f067`; pass on CPU/CI).
- [x] `pyright` clean; `ruff check`/`format` clean.
- [x] Facade typing guards (good call type-checks, missing-kwarg errors); facades verified torch-free.
- [x] Plugin discovery e2e via real `uv pip install` of fixture plugins; crash isolation + version-skew skip covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)