### PR TITLE
fix(data): resolve detection model-bundled preprocessing by builder name

### DIFF
--- a/src/raitap/data/preprocessing.py
+++ b/src/raitap/data/preprocessing.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     import torch
     from torch import nn
     from torchvision import models
+    from torchvision.models import detection as _detection_models
     from torchvision.transforms import _presets, v2
 
     from raitap.configs.schema import DataConfig, ModelConfig
@@ -50,6 +51,7 @@ else:
     torch = lazy_import("torch")
     nn = lazy_import("torch.nn")
     models = lazy_import("torchvision.models")
+    _detection_models = lazy_import("torchvision.models.detection")
     v2 = lazy_import("torchvision.transforms.v2")
     _presets = lazy_import("torchvision.transforms._presets")
 
@@ -403,8 +405,13 @@ def _arch_from_model_cfg(model_cfg: ModelConfig) -> str | None:
     source = getattr(model_cfg, "source", None)
     if isinstance(source, str):
         candidate = source.strip().lower()
-        if candidate and hasattr(models, candidate):
-            attr = getattr(models, candidate)
+        if candidate:
+            # Top-level torchvision.models covers classification/segmentation
+            # builders; detection builders (fasterrcnn_*, retinanet_*, ssd*)
+            # live under torchvision.models.detection. Check top-level first,
+            # then fall back — same precedence as the model loader's
+            # _resolve_torchvision_factory (models/model.py). #196.
+            attr = getattr(models, candidate, None) or getattr(_detection_models, candidate, None)
             if callable(attr):
                 return candidate
     return None

--- a/src/raitap/data/tests/test_preprocessing.py
+++ b/src/raitap/data/tests/test_preprocessing.py
@@ -218,6 +218,27 @@ def test_model_bundled_via_source(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "ResNet50_Weights" in result.description
 
 
+def test_model_bundled_via_detection_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Detection builders live under torchvision.models.detection, not top-level
+    # torchvision.models. Resolution must fall back there (mirrors the model
+    # loader's _resolve_torchvision_factory). Regression guard for #196.
+    monkeypatch.delenv(_ENV, raising=False)
+    result = resolve_preprocessing(
+        ModelConfig(source="fasterrcnn_resnet50_fpn_v2"),
+        DataConfig(
+            preprocessing="model-bundled",
+            model_input_transformation="model-bundled",
+        ),
+    )
+    assert result.data_origin == "model-bundled"
+    assert result.model_origin == "model-bundled"
+    assert "FasterRCNN" in result.description
+    # ObjectDetection preset is a no-op split: detectors normalise internally,
+    # so neither side carries a transform.
+    assert result.data_module is None
+    assert result.model_module is None
+
+
 def test_model_bundled_semantic_segmentation_preset_splits_cleanly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

`_arch_from_model_cfg` (`src/raitap/data/preprocessing.py`) only checked top-level `torchvision.models`, so detection builders (`fasterrcnn_resnet50_fpn_v2`, `retinanet_*`, `ssd*`) that live under `torchvision.models.detection` resolved to `None` and `data.preprocessing: model-bundled` raised `ValueError: requires a torchvision arch`. This adds the same detection-submodule fallback the model loader already uses (`_resolve_torchvision_factory` in `src/raitap/models/model.py`). Top-level is checked first, so classification/segmentation behaviour is unchanged — the change is strictly additive, resolving only source names that previously returned `None`.

Closes #196.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — If this PR breaks compatibility (API, configs, file formats, etc.), the title uses `!` after the type or scope (e.g. `feat!:` or `feat(transparency)!:`). I understand that this change will have a **direct, disruptive impact** on package users. I ensured that **this change is absolutely necessary and cannot be delayed**. _(Non-breaking: additive fallback only; title is `fix:`.)_
- [x] **Contributor guide** — I’ve read [**Pull requests and commit messages**](https://caiivs.github.io/raitap/contributor/pull-requests.html) before requesting review.

## Optional

- [x] **Issue** — A GitHub issues is linked to this PR ("Development" section in the right sidebar). _(#196, via "Closes".)_
- [x] **Docs** — User or contributor docs updated where needed.
- [x] **Tests** — New or updated tests cover the change. _(`test_model_bundled_via_detection_source`; preprocessing suite 34 passed, data suite 135 passed.)_
