### PR TITLE
refactor(robustness)!: rename confusing enums (ATTACK verdicts, MethodKind→AssessmentKind)

### DIFF
--- a/docs/contributor/adding-an-algorithm.md
+++ b/docs/contributor/adding-an-algorithm.md
@@ -62,7 +62,7 @@ class TorchattacksAssessor(EmpiricalAttackAssessor): ...
 
 The map value carries the semantics RAITAP tracks and reports on:
 - **Transparency** → `frozenset[MethodFamily]`. New `MethodFamily` values go in `src/raitap/transparency/contracts.py`.
-- **Robustness** → `AssessorSemanticsHints` (method kind, threat model, objective, norm, family tags). Defined in `src/raitap/robustness/semantics.py`.
+- **Robustness** → `AssessorSemanticsHints` (assessment kind, threat model, objective, norm, family tags). Defined in `src/raitap/robustness/semantics.py`.
 
 A missing entry means the algorithm cannot be selected via config — the family's runtime check fails fast.
 

--- a/docs/contributor/adding-an-algorithm.md
+++ b/docs/contributor/adding-an-algorithm.md
@@ -49,7 +49,7 @@ from raitap import adapters
     algorithm_registry={
         # ... existing entries ...
         "NewAttack": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.LINF,

--- a/docs/contributor/robustness.md
+++ b/docs/contributor/robustness.md
@@ -77,7 +77,7 @@ no changes.
 ## Typed semantics
 
 `RobustnessResult.semantics` is a typed contract, not a narrative description.
-It records method kind, threat model, objective, families, budget, target
+It records assessment kind, threat model, objective, families, budget, target
 classes (for targeted attacks), sample selection, and input metadata.
 
 `AssessmentKind` distinguishes the two ways to assess robustness:
@@ -120,7 +120,7 @@ reported `perturbation_distance` always matches the configured threat model.
 
 1. `RobustnessAssessment(config, name, model, inputs, targets)` creates the
    assessor and its visualisers via the factory.
-2. The factory checks method-kind / visualiser compatibility at parse time.
+2. The factory checks assessment-kind / visualiser compatibility at parse time.
 3. `assessor.assess(...)` runs the framework-owned pipeline for the assessor's
    `assessment_kind` and returns a `RobustnessResult`.
 4. `result.write_artifacts()` saves `robustness_data.pt` plus typed metadata.
@@ -135,7 +135,7 @@ well-defined reference (a warning is logged).
 
 - **New algorithm in an existing adapter (torchattacks, foolbox, ...)** —
   see {doc}`adding-an-algorithm`. For robustness, the `algorithm_registry`
-  value is an `AssessorSemanticsHints` (method kind, threat model, objective,
+  value is an `AssessorSemanticsHints` (assessment kind, threat model, objective,
   norm, family tags) from `semantics.py`.
 - **New robustness library** — see {doc}`adding-an-adapter`. Pick
   `EmpiricalAttackAssessor` or `FormalVerificationAssessor` as the base,

--- a/docs/contributor/robustness.md
+++ b/docs/contributor/robustness.md
@@ -18,7 +18,7 @@ Robustness assessors form a three-level hierarchy in
 `src/raitap/robustness/assessors/base_assessor.py`:
 
 ```text
-BaseAssessor                            # root — declares method_kind + budget_kwarg_source
+BaseAssessor                            # root — declares assessment_kind + budget_kwarg_source
 ├── EmpiricalAttackAssessor             # you implement generate_adversarial(); framework owns assess()
 │   ├── TorchattacksAssessor
 │   └── FoolboxAssessor
@@ -26,7 +26,7 @@ BaseAssessor                            # root — declares method_kind + budget
     └── (alpha-beta-CROWN, auto_LiRPA — follow-up adapters)
 ```
 
-- **`BaseAssessor`** — root. Declares `method_kind: ClassVar[MethodKind]`,
+- **`BaseAssessor`** — root. Declares `assessment_kind: ClassVar[AssessmentKind]`,
   `budget_kwarg_source`, and the no-op `check_backend_compat`. Never subclass directly.
 - **`EmpiricalAttackAssessor`** — subclasses implement only
   `generate_adversarial(model, inputs, targets, ...) → Tensor`. Batching,
@@ -55,16 +55,16 @@ Every assessor declares two `ClassVar`s the framework relies on:
 All robustness visualisers implement `BaseRobustnessVisualiser`:
 
 - `visualise(result, *, context, **kwargs) → Figure` — abstract, required.
-- `supported_method_kinds: ClassVar[frozenset[MethodKind]]` — empty means
+- `supported_assessment_kinds: ClassVar[frozenset[AssessmentKind]]` — empty means
   "all". The factory's `check_assessor_visualiser_compat` enforces this at
-  YAML parse time and raises `MethodKindVisualiserIncompatibilityError` on
+  YAML parse time and raises `AssessmentKindVisualiserIncompatibilityError` on
   mismatch.
 - `embeds_clean_input` / `embeds_perturbation_map` — class-level report layout
   hints for empirical visualisers. A visualiser that sets either flag to
   `True` must accept the matching runtime kwarg (`include_clean_input` /
   `include_perturbation_map`) and omit that facet when it is `False`.
 - `validate_result(result)` — render-time check that the assessor's
-  `method_kind` is in `supported_method_kinds`. Image visualisers additionally
+  `assessment_kind` is in `supported_assessment_kinds`. Image visualisers additionally
   refuse non-image results via `_require_image_modality`.
 
 The facet flags are consumed only by **compact robustness reporting** to
@@ -80,11 +80,11 @@ no changes.
 It records method kind, threat model, objective, families, budget, target
 classes (for targeted attacks), sample selection, and input metadata.
 
-`MethodKind` distinguishes the two ways to assess robustness:
+`AssessmentKind` distinguishes the two ways to assess robustness:
 
 | Kind | Meaning |
 | --- | --- |
-| `EMPIRICAL_ATTACK` | Try to find an adversarial example within the budget. A `NOT_ATTACKED` verdict does **not** prove robustness. |
+| `EMPIRICAL_ATTACK` | Try to find an adversarial example within the budget. A `ATTACK_FAILED` verdict does **not** prove robustness. |
 | `FORMAL_VERIFICATION` | Prove (or refute) that no adversarial example exists in the budget. Produces `VERIFIED` / `FALSIFIED` / `UNKNOWN`. |
 
 `RobustnessVerdict` codes the per-sample outcome (encoded as a `long` tensor
@@ -107,7 +107,7 @@ reported `perturbation_distance` always matches the configured threat model.
   `@adapters.robustness` decorator — no manual path table to maintain.
 - `results.py` — `RobustnessResult`, `RobustnessMetrics`, verdict encoding.
 - `visualisers/base_visualiser.py` — `BaseRobustnessVisualiser` +
-  `MethodKind` compatibility check.
+  `AssessmentKind` compatibility check.
 - `visualisers/empirical/` — image-pair and perturbation-heatmap visualisers
   for empirical attacks. The shared `_signed_perturbation_heatmap` helper
   reduces a signed per-channel delta to a 2D scalar map (matplotlib treats
@@ -122,7 +122,7 @@ reported `perturbation_distance` always matches the configured threat model.
    assessor and its visualisers via the factory.
 2. The factory checks method-kind / visualiser compatibility at parse time.
 3. `assessor.assess(...)` runs the framework-owned pipeline for the assessor's
-   `method_kind` and returns a `RobustnessResult`.
+   `assessment_kind` and returns a `RobustnessResult`.
 4. `result.write_artifacts()` saves `robustness_data.pt` plus typed metadata.
 5. `result.visualise()` iterates configured visualisers, validates each, calls
    `visualise()`, and saves the figures.
@@ -152,7 +152,7 @@ Subclass `BaseRobustnessVisualiser` and decorate with
 `@visualisers.robustness(...)` (see {doc}`adding-an-adapter` for the
 decorator scaffolding). Robustness-specific notes:
 
-- Set `supported_method_kinds` so the factory rejects mismatched assessor
+- Set `supported_assessment_kinds` so the factory rejects mismatched assessor
   pairings at parse time.
 - For image visualisers, call
   `_require_image_modality(result, type(self).__name__)` inside `visualise()`

--- a/docs/modules/robustness/configuration.md
+++ b/docs/modules/robustness/configuration.md
@@ -101,7 +101,7 @@ myst:
 :default: [ImagePairVisualiser]
 :description: Visualiser definitions. Each entry must include at least
   `_target_`. Each visualiser can also define its own `constructor` and `call`
-  blocks. Visualisers declare which `MethodKind` (`empirical_attack` /
+  blocks. Visualisers declare which `AssessmentKind` (`empirical_attack` /
   `formal_verification`) they support; the factory rejects mismatches at parse
   time.
 

--- a/docs/modules/robustness/frameworks-and-libraries.md
+++ b/docs/modules/robustness/frameworks-and-libraries.md
@@ -36,15 +36,15 @@ is visible in the run log.
 
 ## Typed semantics and visualiser compatibility
 
-RAITAP uses typed `MethodKind`, `ThreatModel`, `Objective`, and
+RAITAP uses typed `AssessmentKind`, `ThreatModel`, `Objective`, and
 `PerturbationBudget` semantics to validate visualisers against the result
 they receive. In short:
 
 - assessors produce typed `RobustnessResult.semantics`
-- visualisers declare which `MethodKind` they can render via the
-  `supported_method_kinds: ClassVar[frozenset[MethodKind]]` attribute
+- visualisers declare which `AssessmentKind` they can render via the
+  `supported_assessment_kinds: ClassVar[frozenset[AssessmentKind]]` attribute
 - the factory rejects incompatible pairings at YAML parse time
-  (`MethodKindVisualiserIncompatibilityError`)
+  (`AssessmentKindVisualiserIncompatibilityError`)
 - image visualisers additionally refuse non-image results
   (`input_spec.kind != IMAGE`)
 

--- a/docs/modules/robustness/output.md
+++ b/docs/modules/robustness/output.md
@@ -27,7 +27,7 @@ compact robustness layout. The `metadata.json` `visualisers` list always
 references the canonical persisted layouts, not report-only variants.
 
 `robustness_data.pt` is a torch checkpoint dict with the following keys (some
-are present only for the matching method kind):
+are present only for the matching assessment kind):
 
 | Key | Always present | Description |
 | --- | --- | --- |

--- a/docs/modules/robustness/output.md
+++ b/docs/modules/robustness/output.md
@@ -34,7 +34,7 @@ are present only for the matching method kind):
 | `clean_inputs` | yes | Inputs as fed to the model. |
 | `targets` | yes | Per-sample reference labels (ground truth or, when no labels were available, model predictions used as the untargeted reference). |
 | `clean_predictions` | yes | `argmax(model(clean_inputs))`. |
-| `verdicts` | yes | Per-sample integer codes. The mapping is also stored in `metadata.json` under `verdict_codes` (e.g. `attacked → 1`, `not_attacked → 2`, `verified → 3`, `falsified → 4`, `unknown → 5`, `error → 6`). |
+| `verdicts` | yes | Per-sample integer codes. The mapping is also stored in `metadata.json` under `verdict_codes` (e.g. `attack_succeeded → 1`, `attack_failed → 2`, `verified → 3`, `falsified → 4`, `unknown → 5`, `error → 6`). |
 | `perturbed_inputs` | empirical / falsified rows | Adversarial example tensor. NaN-padded for verifier rows that did not produce a counter-example. |
 | `perturbed_predictions` | empirical / falsified rows | `argmax(model(perturbed_inputs))`; `-1` for verifier rows without a counter-example. |
 | `perturbation_distance` | empirical / falsified rows | Per-sample distance under `semantics.budget.norm`. |
@@ -44,7 +44,7 @@ are present only for the matching method kind):
 `metadata.json` carries assessor metadata, aggregate metrics, and the typed
 robustness semantics:
 
-- `method_kind` — `empirical_attack` or `formal_verification`.
+- `assessment_kind` — `empirical_attack` or `formal_verification`.
 - `semantics.threat_model` — `white_box`, `black_box_score`, `black_box_decision`.
 - `semantics.objective` — `untargeted` or `targeted`.
 - `semantics.budget` — norm + epsilon + (optional) step size + steps.

--- a/docs/modules/robustness/visualisers.md
+++ b/docs/modules/robustness/visualisers.md
@@ -29,7 +29,7 @@ robustness = {
 }
 ```
 
-Visualisers declare which `MethodKind` they support; the factory rejects mismatches at YAML parse time.
+Visualisers declare which `AssessmentKind` they support; the factory rejects mismatches at YAML parse time.
 
 ## Empirical attack
 
@@ -47,7 +47,7 @@ attack run.
 | `cmap` | `"RdBu_r"` | Diverging colormap used for the signed perturbation panel. |
 | `diff_scale` | `None` | Fixed symmetric vmin/vmax for the perturbation panel. `None` means auto-fit per-figure. |
 
-Supports `MethodKind.EMPIRICAL_ATTACK`. Rejects non-image results
+Supports `AssessmentKind.EMPIRICAL_ATTACK`. Rejects non-image results
 (`InputSpec.kind != IMAGE`).
 
 ![ImagePairVisualiser preview](../../_static/visualisers/image_pair_visualiser.png)
@@ -67,7 +67,7 @@ rather than collapsing to zero on cancelling channels.
 | `cmap` | `"seismic"` | Diverging colormap for the perturbation. |
 | `aggregate_channels` | `"signed_dominant"` | Channel reduction: `signed_dominant`, `mean`, `mean_abs`, or `max_abs`. |
 
-Supports `MethodKind.EMPIRICAL_ATTACK`. Rejects non-image results.
+Supports `AssessmentKind.EMPIRICAL_ATTACK`. Rejects non-image results.
 
 ![PerturbationHeatmapVisualiser preview](../../_static/visualisers/perturbation_heatmap_visualiser.png)
 
@@ -84,7 +84,7 @@ run to see how the verifier performed before drilling into bound widths.
 |---|---|---|
 | `runtime_bins` | `20` | Histogram bin count for the runtime panel. |
 
-Supports `MethodKind.FORMAL_VERIFICATION`.
+Supports `AssessmentKind.FORMAL_VERIFICATION`.
 
 ![VerdictSummaryVisualiser preview](../../_static/visualisers/verdict_summary_visualiser.png)
 
@@ -100,7 +100,7 @@ tight for most samples but has a long tail at logit 3".
 | `whis` | `1.5` | Matplotlib whisker length (multiple of IQR). |
 | `show_outliers` | `True` | Whether to render flier points beyond the whiskers. |
 
-Supports `MethodKind.FORMAL_VERIFICATION`. Renders a placeholder figure when
+Supports `AssessmentKind.FORMAL_VERIFICATION`. Renders a placeholder figure when
 `result.output_bounds is None` or every row is NaN.
 
 ![OutputBoundsCohortVisualiser preview](../../_static/visualisers/output_bounds_cohort_visualiser.png)
@@ -119,7 +119,7 @@ the bound for sample 17 look like?"
 | `bar_color` | `"#1f77b4"` | Bar colour for non-target classes. |
 | `sample_indices` | `None` | Optional explicit list of row indices to pin. |
 
-Supports `MethodKind.FORMAL_VERIFICATION`. Falls back to a placeholder when
+Supports `AssessmentKind.FORMAL_VERIFICATION`. Falls back to a placeholder when
 bounds are absent.
 
 ![OutputBoundsPinnedVisualiser preview](../../_static/visualisers/output_bounds_pinned_visualiser.png)
@@ -138,7 +138,7 @@ visibility is more useful than per-class aggregate stats.
 | `max_samples` | `None` | Truncate to the first N rows. `None` renders every row. |
 | `figsize` | `None` | Manual override; `None` picks an auto size from sample / class counts. |
 
-Supports `MethodKind.FORMAL_VERIFICATION`.
+Supports `AssessmentKind.FORMAL_VERIFICATION`.
 
 ![OutputBoundsWidthHeatmapVisualiser preview](../../_static/visualisers/output_bounds_width_heatmap_visualiser.png)
 
@@ -157,7 +157,7 @@ target. The target column is masked grey. Use it for "is this batch
 | `max_samples` | `None` | Truncate to the first N rows. `None` renders every row. |
 | `figsize` | `None` | Manual override; `None` picks an auto size. |
 
-Supports `MethodKind.FORMAL_VERIFICATION`. Falls back to a placeholder when
+Supports `AssessmentKind.FORMAL_VERIFICATION`. Falls back to a placeholder when
 `result.targets` is missing or shaped wrong.
 
 ![OutputBoundsMarginHeatmapVisualiser preview](../../_static/visualisers/output_bounds_margin_heatmap_visualiser.png)

--- a/scripts/generate_visualiser_previews.py
+++ b/scripts/generate_visualiser_previews.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
 
 from raitap.robustness.contracts import (
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationBudget,
     PerturbationNorm,
@@ -123,7 +123,7 @@ def _formal_fixture() -> RobustnessResult:
         output_bounds={"lower": lower, "upper": upper},
         runtime_per_sample=runtimes,
         semantics=RobustnessSemantics(
-            method_kind=MethodKind.FORMAL_VERIFICATION,
+            assessment_kind=AssessmentKind.FORMAL_VERIFICATION,
             threat_model=ThreatModel.WHITE_BOX,
             objective=Objective.UNTARGETED,
             families=frozenset({"smt"}),
@@ -141,10 +141,10 @@ def _empirical_fixture() -> RobustnessResult:
     perturbed = (clean + perturbation).clamp(0.0, 1.0)
     targets = torch.tensor([0, 1, 2, 3])
     verdicts = [
-        RobustnessVerdict.ATTACKED,
-        RobustnessVerdict.ATTACKED,
-        RobustnessVerdict.NOT_ATTACKED,
-        RobustnessVerdict.ATTACKED,
+        RobustnessVerdict.ATTACK_SUCCEEDED,
+        RobustnessVerdict.ATTACK_SUCCEEDED,
+        RobustnessVerdict.ATTACK_FAILED,
+        RobustnessVerdict.ATTACK_SUCCEEDED,
     ]
     distance = torch.tensor([0.05, 0.04, float("nan"), 0.06])
     perturbed_predictions = torch.tensor([1, 0, 2, 0])
@@ -170,7 +170,7 @@ def _empirical_fixture() -> RobustnessResult:
         algorithm="PGD",
         assessor_name="pgd",
         semantics=RobustnessSemantics(
-            method_kind=MethodKind.EMPIRICAL_ATTACK,
+            assessment_kind=AssessmentKind.EMPIRICAL_ATTACK,
             threat_model=ThreatModel.WHITE_BOX,
             objective=Objective.UNTARGETED,
             families=frozenset({"gradient"}),
@@ -180,10 +180,10 @@ def _empirical_fixture() -> RobustnessResult:
     )
 
 
-def _ctx(method_kind: MethodKind, algorithm: str) -> RobustnessVisualisationContext:
+def _ctx(assessment_kind: AssessmentKind, algorithm: str) -> RobustnessVisualisationContext:
     return RobustnessVisualisationContext(
         algorithm=algorithm,
-        method_kind=method_kind,
+        assessment_kind=assessment_kind,
         sample_names=None,
         show_sample_names=False,
     )
@@ -382,8 +382,8 @@ def main() -> None:
     empirical = _empirical_fixture()
     formal = _formal_fixture()
 
-    empirical_ctx = _ctx(MethodKind.EMPIRICAL_ATTACK, "PGD")
-    formal_ctx = _ctx(MethodKind.FORMAL_VERIFICATION, "marabou-linf")
+    empirical_ctx = _ctx(AssessmentKind.EMPIRICAL_ATTACK, "PGD")
+    formal_ctx = _ctx(AssessmentKind.FORMAL_VERIFICATION, "marabou-linf")
 
     saved: list[Path] = []
     saved.append(

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -19,7 +19,7 @@ else:
     torch = lazy_import("torch")
 from raitap.configs import resolve_run_dir
 from raitap.pipeline.outputs import PredictionSummary, RunOutputs
-from raitap.robustness.contracts import MethodKind
+from raitap.robustness.contracts import AssessmentKind
 from raitap.transparency.contracts import ExplanationScope, VisualisationContext
 from raitap.transparency.visualisers import BaseVisualiser, InputThumbnailVisualiser
 
@@ -302,8 +302,8 @@ def _build_robustness_section(
     groups: list[ReportGroup] = []
     for index, result in enumerate(outputs.robustness_results):
         assessor_name = result.assessor_name or result.run_dir.name
-        method_kind_value = result.method_kind.value
-        if result.method_kind == MethodKind.EMPIRICAL_ATTACK:
+        assessment_kind_value = result.assessment_kind.value
+        if result.assessment_kind == AssessmentKind.EMPIRICAL_ATTACK:
             heading = f"Adversarial attack - {result.algorithm} ({assessor_name})"
         else:
             heading = f"Robustness certification - {result.algorithm} ({assessor_name})"
@@ -312,7 +312,7 @@ def _build_robustness_section(
         table_rows: list[tuple[str, str]] = [
             ("assessor", assessor_name),
             ("algorithm", result.algorithm),
-            ("method_kind", method_kind_value),
+            ("assessment_kind", assessment_kind_value),
             ("threat_model", result.semantics.threat_model.value),
             ("objective", result.semantics.objective.value),
             ("norm", budget.norm.value),
@@ -348,7 +348,7 @@ def _build_robustness_section(
             "role": "robustness",
             "assessor_name": assessor_name,
             "algorithm": result.algorithm,
-            "method_kind": method_kind_value,
+            "assessment_kind": assessment_kind_value,
         }
         if not show_redundant_robustness_panels:
             metadata["sample_indices"] = robustness_sample_indices
@@ -370,7 +370,7 @@ def _build_robustness_section(
 
 
 def _output_bounds_table_rows(result: Any) -> list[tuple[str, str]]:
-    if result.method_kind != MethodKind.FORMAL_VERIFICATION:
+    if result.assessment_kind != AssessmentKind.FORMAL_VERIFICATION:
         return []
 
     output_bounds = getattr(result, "output_bounds", None)
@@ -510,7 +510,7 @@ def _robustness_report_sample_indices(
     *,
     selected_samples: list[SelectedSample],
 ) -> tuple[int, ...]:
-    if result.method_kind != MethodKind.EMPIRICAL_ATTACK:
+    if result.assessment_kind != AssessmentKind.EMPIRICAL_ATTACK:
         return ()
     batch_size = int(result.clean_inputs.shape[0])
     return tuple(

--- a/src/raitap/reporting/templates/_robustness.html.j2
+++ b/src/raitap/reporting/templates/_robustness.html.j2
@@ -9,7 +9,7 @@
       <article class="assessor-block" id="robustness-{{ assessor.assessor_name|slug }}">
         <header class="assessor-header">
           <div>
-            <span class="badge">{{ assessor.method_kind }}</span>
+            <span class="badge">{{ assessor.assessment_kind }}</span>
             <h3>{{ assessor.assessor_name }}</h3>
           </div>
           <div class="badge-row">

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -29,7 +29,7 @@ from raitap.reporting.manifest import ReportManifest
 from raitap.reporting.sample_selection import ReportSampleSelectionEntry
 from raitap.reporting.sections import ReportGroup, ReportSection
 from raitap.robustness.contracts import (
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationBudget,
     PerturbationNorm,
@@ -237,7 +237,7 @@ def _local_tabular_semantics(shape: tuple[int, ...]) -> ExplanationSemantics:
 
 def _robustness_semantics() -> RobustnessSemantics:
     return RobustnessSemantics(
-        method_kind=MethodKind.EMPIRICAL_ATTACK,
+        assessment_kind=AssessmentKind.EMPIRICAL_ATTACK,
         threat_model=ThreatModel.WHITE_BOX,
         objective=Objective.UNTARGETED,
         families=frozenset({"gradient_sign"}),
@@ -263,7 +263,7 @@ def _make_robustness_result(
         clean_inputs=clean,
         targets=torch.arange(batch_size),
         clean_predictions=torch.arange(batch_size),
-        verdicts=encode_verdicts([RobustnessVerdict.ATTACKED] * batch_size),
+        verdicts=encode_verdicts([RobustnessVerdict.ATTACK_SUCCEEDED] * batch_size),
         metrics=RobustnessMetrics(
             clean_accuracy=1.0,
             adversarial_accuracy=0.0,

--- a/src/raitap/reporting/tests/test_formal_section.py
+++ b/src/raitap/reporting/tests/test_formal_section.py
@@ -14,7 +14,7 @@ from raitap.configs.schema import AppConfig, ReportingConfig
 from raitap.pipeline.outputs import ForwardOutput, RunOutputs
 from raitap.reporting.builder import build_report
 from raitap.robustness.contracts import (
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationBudget,
     PerturbationNorm,
@@ -63,7 +63,7 @@ def _formal_result(run_dir: Path) -> RobustnessResult:
         assessor_name="marabou_linf",
         runtime_per_sample=torch.tensor([0.2, 0.4, 0.6]),
         semantics=RobustnessSemantics(
-            method_kind=MethodKind.FORMAL_VERIFICATION,
+            assessment_kind=AssessmentKind.FORMAL_VERIFICATION,
             threat_model=ThreatModel.WHITE_BOX,
             objective=Objective.UNTARGETED,
             families=frozenset({"smt", "complete", "sound"}),
@@ -205,7 +205,7 @@ def test_build_report_skips_bound_rows_for_empirical_attack_results(
     result = _formal_result(run_dir)
     # Mutate to an EMPIRICAL_ATTACK result while keeping output_bounds set.
     result.semantics = RobustnessSemantics(
-        method_kind=MethodKind.EMPIRICAL_ATTACK,
+        assessment_kind=AssessmentKind.EMPIRICAL_ATTACK,
         threat_model=ThreatModel.WHITE_BOX,
         objective=Objective.UNTARGETED,
         families=frozenset({"attack"}),

--- a/src/raitap/reporting/tests/test_html_reporter.py
+++ b/src/raitap/reporting/tests/test_html_reporter.py
@@ -274,7 +274,7 @@ def _synthetic_sections() -> tuple[ReportSection, ...]:
                     table_rows=(
                         ("assessor", "fgsm_linf_fast"),
                         ("algorithm", "FGSM"),
-                        ("method_kind", "empirical_attack"),
+                        ("assessment_kind", "empirical_attack"),
                         ("clean_accuracy", "0.9000"),
                         ("adversarial_accuracy", "0.5000"),
                         ("attack_success_rate", "0.4000"),
@@ -283,7 +283,7 @@ def _synthetic_sections() -> tuple[ReportSection, ...]:
                         "role": "robustness",
                         "assessor_name": "fgsm_linf_fast",
                         "algorithm": "FGSM",
-                        "method_kind": "empirical_attack",
+                        "assessment_kind": "empirical_attack",
                         "sample_indices": [3],
                     },
                 )

--- a/src/raitap/reporting/tests/test_view_model.py
+++ b/src/raitap/reporting/tests/test_view_model.py
@@ -268,7 +268,7 @@ def _robustness_assessor(assessor_name: str, result_index: int) -> ReportGroup:
         table_rows=(
             ("assessor", assessor_name),
             ("algorithm", assessor_name),
-            ("method_kind", "empirical"),
+            ("assessment_kind", "empirical"),
             ("clean_accuracy", "0.9000"),
             ("adversarial_accuracy", "0.8000"),
         ),
@@ -276,7 +276,7 @@ def _robustness_assessor(assessor_name: str, result_index: int) -> ReportGroup:
             "role": "robustness",
             "assessor_name": assessor_name,
             "algorithm": assessor_name,
-            "method_kind": "empirical",
+            "assessment_kind": "empirical",
             "sample_indices": [3, 8, 19],
         },
     )

--- a/src/raitap/reporting/view_model.py
+++ b/src/raitap/reporting/view_model.py
@@ -29,7 +29,7 @@ _TECHNICAL_KEYS = frozenset(
     }
 )
 _ROBUSTNESS_SETTING_KEYS = frozenset(
-    {"assessor", "algorithm", "method_kind", "threat_model", "objective", "norm", "epsilon"}
+    {"assessor", "algorithm", "assessment_kind", "threat_model", "objective", "norm", "epsilon"}
 )
 
 
@@ -85,7 +85,7 @@ class RobustnessSampleEvidence:
 class RobustnessAssessorView:
     assessor_name: str
     algorithm: str
-    method_kind: str
+    assessment_kind: str
     heading: str
     rows: tuple[tuple[str, str], ...]
     settings: dict[str, str]
@@ -431,8 +431,8 @@ def _build_robustness_assessors(section: ReportSection) -> tuple[RobustnessAsses
             RobustnessAssessorView(
                 assessor_name=assessor_name,
                 algorithm=str(group.metadata.get("algorithm") or rows.get("algorithm") or "n/a"),
-                method_kind=str(
-                    group.metadata.get("method_kind") or rows.get("method_kind") or "n/a"
+                assessment_kind=str(
+                    group.metadata.get("assessment_kind") or rows.get("assessment_kind") or "n/a"
                 ),
                 heading=group.heading,
                 rows=group.table_rows,

--- a/src/raitap/robustness/__init__.py
+++ b/src/raitap/robustness/__init__.py
@@ -26,8 +26,8 @@ from raitap._adapters import ALL as ALL
 from .contracts import (
     VERDICT_CODES,
     VERDICT_FROM_CODE,
+    AssessmentKind,
     AssessorAdapter,
-    MethodKind,
     Objective,
     PerturbationBudget,
     PerturbationNorm,
@@ -40,8 +40,8 @@ from .contracts import (
     encode_verdict,
 )
 from .exceptions import (
+    AssessmentKindVisualiserIncompatibilityError,
     AssessorBackendIncompatibilityError,
-    MethodKindVisualiserIncompatibilityError,
     MissingTargetsError,
     RobustnessVisualiserIncompatibilityError,
 )
@@ -166,7 +166,7 @@ __all__ = [  # noqa: RUF022
     "encode_verdicts",
     # Contracts
     "AssessorAdapter",
-    "MethodKind",
+    "AssessmentKind",
     "Objective",
     "PerturbationBudget",
     "PerturbationNorm",
@@ -181,7 +181,7 @@ __all__ = [  # noqa: RUF022
     "encode_verdict",
     # Exceptions
     "AssessorBackendIncompatibilityError",
-    "MethodKindVisualiserIncompatibilityError",
+    "AssessmentKindVisualiserIncompatibilityError",
     "MissingTargetsError",
     "RobustnessVisualiserIncompatibilityError",
     # Semantics

--- a/src/raitap/robustness/assessors/base_assessor.py
+++ b/src/raitap/robustness/assessors/base_assessor.py
@@ -3,7 +3,7 @@
 Three layers, mirroring transparency's split between framework-owned and
 adapter-owned pipelines:
 
-* ``BaseAssessor`` - root: declares ``method_kind`` and the no-op
+* ``BaseAssessor`` - root: declares ``assessment_kind`` and the no-op
   ``check_backend_compat`` default.
 * ``EmpiricalAttackAssessor`` - framework owns ``assess()``; subclasses
   implement only ``generate_adversarial``.
@@ -31,7 +31,7 @@ else:
     torch = lazy_import("torch")
 
 from ..contracts import (
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationBudget,
     PerturbationNorm,
@@ -65,7 +65,7 @@ class BaseAssessor(AdapterMixin, ABC):
     """
 
     algorithm_registry: ClassVar[Mapping[str, AssessorSemanticsHints]]
-    method_kind: ClassVar[MethodKind]
+    assessment_kind: ClassVar[AssessmentKind]
 
     #: Which YAML block the underlying library actually consumes for budget
     #: kwargs (``eps`` / ``alpha`` / ``steps``). ``"init_kwargs"`` means the
@@ -148,7 +148,7 @@ def _per_sample_norm(delta: torch.Tensor, norm: PerturbationNorm) -> torch.Tenso
 class EmpiricalAttackAssessor(BaseAssessor, ABC):
     """Empirical attack adapter: subclass implements one method, framework does the rest."""
 
-    method_kind: ClassVar[MethodKind] = MethodKind.EMPIRICAL_ATTACK
+    assessment_kind: ClassVar[AssessmentKind] = AssessmentKind.EMPIRICAL_ATTACK
 
     @abstractmethod
     def generate_adversarial(
@@ -327,7 +327,7 @@ class EmpiricalAttackAssessor(BaseAssessor, ABC):
 class FormalVerificationAssessor(BaseAssessor, ABC):
     """Formal-verification adapter: subclass implements per-sample ``verify_sample``."""
 
-    method_kind: ClassVar[MethodKind] = MethodKind.FORMAL_VERIFICATION
+    assessment_kind: ClassVar[AssessmentKind] = AssessmentKind.FORMAL_VERIFICATION
 
     @abstractmethod
     def verify_sample(
@@ -560,7 +560,7 @@ def _empirical_verdicts(
     else:
         success = adversarial_predictions != reference_targets
     verdicts = [
-        RobustnessVerdict.ATTACKED if hit else RobustnessVerdict.NOT_ATTACKED
+        RobustnessVerdict.ATTACK_SUCCEEDED if hit else RobustnessVerdict.ATTACK_FAILED
         for hit in success.tolist()
     ]
     return verdicts, success

--- a/src/raitap/robustness/assessors/foolbox_assessor.py
+++ b/src/raitap/robustness/assessors/foolbox_assessor.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from raitap.robustness.assessors.registration import robustness_adapter
 from raitap.utils.lazy import lazy_import
 
-from ..contracts import MethodKind, Objective, PerturbationNorm, ThreatModel
+from ..contracts import AssessmentKind, Objective, PerturbationNorm, ThreatModel
 from ..semantics import AssessorSemanticsHints
 from .base_assessor import EmpiricalAttackAssessor, _prepare_inputs_for_forward
 
@@ -24,49 +24,49 @@ else:
     budget_kwarg_source="call_kwargs",
     algorithm_registry={
         "LinfPGD": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.LINF,
             families=frozenset({"gradient_sign", "iterative"}),
         ),
         "L2PGD": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.L2,
             families=frozenset({"gradient_sign", "iterative"}),
         ),
         "LinfFastGradientAttack": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.LINF,
             families=frozenset({"gradient_sign"}),
         ),
         "L2FastGradientAttack": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.L2,
             families=frozenset({"gradient_sign"}),
         ),
         "L2CarliniWagnerAttack": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.L2,
             families=frozenset({"optimization"}),
         ),
         "L2DeepFoolAttack": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.L2,
             families=frozenset({"optimization"}),
         ),
         "BoundaryAttack": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.BLACK_BOX_DECISION,
             Objective.UNTARGETED,
             PerturbationNorm.L2,

--- a/src/raitap/robustness/assessors/marabou_assessor.py
+++ b/src/raitap/robustness/assessors/marabou_assessor.py
@@ -35,7 +35,7 @@ else:
 from raitap.robustness.assessors.registration import robustness_adapter
 
 from ..contracts import (
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationBudget,
     PerturbationNorm,
@@ -80,7 +80,7 @@ logger = logging.getLogger(__name__)
     error_patterns=_MARABOUPY_ERROR_MESSAGES,
     algorithm_registry={
         "linf-box": AssessorSemanticsHints(
-            MethodKind.FORMAL_VERIFICATION,
+            AssessmentKind.FORMAL_VERIFICATION,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.LINF,

--- a/src/raitap/robustness/assessors/tests/test_registration.py
+++ b/src/raitap/robustness/assessors/tests/test_registration.py
@@ -10,7 +10,7 @@ import torch
 from raitap import adapters
 from raitap.robustness.assessors.base_assessor import EmpiricalAttackAssessor
 from raitap.robustness.contracts import (
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationNorm,
     ThreatModel,
@@ -28,7 +28,7 @@ def test_robustness_adapter_registers_under_robustness_group() -> None:
         library="_stub_lib",
         algorithm_registry={
             "_stub_alg": AssessorSemanticsHints(
-                MethodKind.EMPIRICAL_ATTACK,
+                AssessmentKind.EMPIRICAL_ATTACK,
                 ThreatModel.WHITE_BOX,
                 Objective.UNTARGETED,
                 PerturbationNorm.LINF,
@@ -65,7 +65,7 @@ def test_robustness_adapter_registers_under_robustness_group() -> None:
 def test_budget_kwarg_source_via_decorator() -> None:
     from raitap.robustness.assessors.base_assessor import EmpiricalAttackAssessor
     from raitap.robustness.assessors.registration import robustness_adapter
-    from raitap.robustness.contracts import MethodKind, Objective, PerturbationNorm, ThreatModel
+    from raitap.robustness.contracts import AssessmentKind, Objective, PerturbationNorm, ThreatModel
     from raitap.robustness.semantics import AssessorSemanticsHints
 
     @robustness_adapter(
@@ -73,7 +73,7 @@ def test_budget_kwarg_source_via_decorator() -> None:
         budget_kwarg_source="call_kwargs",
         algorithm_registry={
             "x": AssessorSemanticsHints(
-                MethodKind.EMPIRICAL_ATTACK,
+                AssessmentKind.EMPIRICAL_ATTACK,
                 ThreatModel.WHITE_BOX,
                 Objective.UNTARGETED,
                 PerturbationNorm.LINF,

--- a/src/raitap/robustness/assessors/torchattacks_assessor.py
+++ b/src/raitap/robustness/assessors/torchattacks_assessor.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from raitap.robustness.assessors.registration import robustness_adapter
 from raitap.utils.lazy import lazy_import
 
-from ..contracts import MethodKind, Objective, PerturbationNorm, ThreatModel
+from ..contracts import AssessmentKind, Objective, PerturbationNorm, ThreatModel
 from ..semantics import AssessorSemanticsHints
 from .base_assessor import EmpiricalAttackAssessor, _prepare_inputs_for_forward
 
@@ -23,70 +23,70 @@ else:
     library="torchattacks",
     algorithm_registry={
         "FGSM": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.LINF,
             families=frozenset({"gradient_sign"}),
         ),
         "BIM": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.LINF,
             families=frozenset({"gradient_sign", "iterative"}),
         ),
         "PGD": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.LINF,
             families=frozenset({"gradient_sign", "iterative"}),
         ),
         "PGDL2": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.L2,
             families=frozenset({"gradient_sign", "iterative"}),
         ),
         "MIFGSM": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.LINF,
             families=frozenset({"gradient_sign", "iterative", "momentum"}),
         ),
         "CW": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.L2,
             families=frozenset({"optimization"}),
         ),
         "DeepFool": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.L2,
             families=frozenset({"optimization"}),
         ),
         "AutoAttack": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.LINF,
             families=frozenset({"ensemble", "auto"}),
         ),
         "Square": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.BLACK_BOX_SCORE,
             Objective.UNTARGETED,
             PerturbationNorm.LINF,
             families=frozenset({"score_based"}),
         ),
         "OnePixel": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.BLACK_BOX_SCORE,
             Objective.UNTARGETED,
             PerturbationNorm.L0,

--- a/src/raitap/robustness/contracts.py
+++ b/src/raitap/robustness/contracts.py
@@ -1,19 +1,19 @@
 """
-Shared robustness contracts: method-kind taxonomy, threat model, and verdict typing.
+Shared robustness contracts: assessment-kind taxonomy, threat model, and verdict typing.
 
 The robustness module distinguishes two fundamentally different ways to assess a
 model's robustness against perturbations:
 
-* ``MethodKind.EMPIRICAL_ATTACK`` — try to find an adversarial example within a
+* ``AssessmentKind.EMPIRICAL_ATTACK`` — try to find an adversarial example within a
   perturbation budget (torchattacks, foolbox, …). A "non-attack" outcome does
   *not* prove robustness; it just means the configured attack failed.
-* ``MethodKind.FORMAL_VERIFICATION`` — prove (or refute) that no adversarial
+* ``AssessmentKind.FORMAL_VERIFICATION`` — prove (or refute) that no adversarial
   example exists within the budget (auto_LiRPA, alpha-beta-CROWN, ...). Outcomes are
   verified / falsified / unknown.
 
 A single ``RobustnessSemantics`` carries this distinction so that downstream
 result handling, reporting, and visualiser-compatibility checks can branch on
-``method_kind`` instead of duck-typing.
+``assessment_kind`` instead of duck-typing.
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ Module = Any
 Tensor = Any
 
 
-class MethodKind(StrEnum):
+class AssessmentKind(StrEnum):
     """High-level taxonomy distinguishing empirical attacks from formal verification."""
 
     EMPIRICAL_ATTACK = "empirical_attack"
@@ -42,14 +42,15 @@ class MethodKind(StrEnum):
 class RobustnessVerdict(StrEnum):
     """Per-sample assessment outcome.
 
-    Empirical assessors emit ``ATTACKED`` / ``NOT_ATTACKED`` (the latter does NOT
-    prove robustness — it only means the configured attack failed).
+    Empirical assessors emit ``ATTACK_SUCCEEDED`` / ``ATTACK_FAILED`` (the latter
+    does NOT prove robustness — it only means the configured attack failed to find
+    an adversarial example within the budget).
     Formal verification assessors emit ``VERIFIED`` / ``FALSIFIED`` / ``UNKNOWN``
     (and ``ERROR`` for per-sample crashes / timeouts).
     """
 
-    ATTACKED = "attacked"
-    NOT_ATTACKED = "not_attacked"
+    ATTACK_SUCCEEDED = "attack_succeeded"
+    ATTACK_FAILED = "attack_failed"
     VERIFIED = "verified"
     FALSIFIED = "falsified"
     UNKNOWN = "unknown"
@@ -59,8 +60,8 @@ class RobustnessVerdict(StrEnum):
 # Stable integer encoding for storing verdicts inside a torch tensor.
 # Map order is the public contract; do not renumber existing entries.
 VERDICT_CODES: dict[RobustnessVerdict, int] = {
-    RobustnessVerdict.ATTACKED: 1,
-    RobustnessVerdict.NOT_ATTACKED: 2,
+    RobustnessVerdict.ATTACK_SUCCEEDED: 1,
+    RobustnessVerdict.ATTACK_FAILED: 2,
     RobustnessVerdict.VERIFIED: 3,
     RobustnessVerdict.FALSIFIED: 4,
     RobustnessVerdict.UNKNOWN: 5,
@@ -118,7 +119,7 @@ class PerturbationBudget:
 class RobustnessSemantics:
     """Typed contract describing the meaning of a robustness assessment artifact."""
 
-    method_kind: MethodKind
+    assessment_kind: AssessmentKind
     threat_model: ThreatModel
     objective: Objective
     families: frozenset[str]
@@ -133,7 +134,7 @@ class RobustnessVisualisationContext:
     """Standard pipeline-controlled metadata provided to robustness visualisers."""
 
     algorithm: str
-    method_kind: MethodKind
+    assessment_kind: AssessmentKind
     sample_names: list[str] | None
     show_sample_names: bool
 
@@ -147,7 +148,7 @@ class AssessorAdapter(Protocol):
     ``explain(model, inputs, …)``.
     """
 
-    method_kind: ClassVar[MethodKind]
+    assessment_kind: ClassVar[AssessmentKind]
 
     def check_backend_compat(self, backend: object) -> None:
         pass

--- a/src/raitap/robustness/exceptions.py
+++ b/src/raitap/robustness/exceptions.py
@@ -21,7 +21,7 @@ class AssessorBackendIncompatibilityError(Exception):
         )
 
 
-class MethodKindVisualiserIncompatibilityError(Exception):
+class AssessmentKindVisualiserIncompatibilityError(Exception):
     """Raised when a visualiser does not support the assessor's method kind."""
 
     def __init__(
@@ -29,18 +29,18 @@ class MethodKindVisualiserIncompatibilityError(Exception):
         *,
         assessor_target: str,
         visualiser: str,
-        assessor_method_kind: str,
-        supported_method_kinds: list[str],
+        assessor_assessment_kind: str,
+        supported_assessment_kinds: list[str],
     ) -> None:
         self.assessor_target = assessor_target
         self.visualiser = visualiser
-        self.assessor_method_kind = assessor_method_kind
-        self.supported_method_kinds = supported_method_kinds
-        supported = ", ".join(supported_method_kinds) if supported_method_kinds else "none"
+        self.assessor_assessment_kind = assessor_assessment_kind
+        self.supported_assessment_kinds = supported_assessment_kinds
+        supported = ", ".join(supported_assessment_kinds) if supported_assessment_kinds else "none"
         super().__init__(
             f"Visualiser {visualiser!r} does not support assessor method kind "
-            f"{assessor_method_kind!r} (from {assessor_target}). "
-            f"That visualiser's supported_method_kinds are: {supported}."
+            f"{assessor_assessment_kind!r} (from {assessor_target}). "
+            f"That visualiser's supported_assessment_kinds are: {supported}."
         )
 
 

--- a/src/raitap/robustness/exceptions.py
+++ b/src/raitap/robustness/exceptions.py
@@ -22,7 +22,7 @@ class AssessorBackendIncompatibilityError(Exception):
 
 
 class AssessmentKindVisualiserIncompatibilityError(Exception):
-    """Raised when a visualiser does not support the assessor's method kind."""
+    """Raised when a visualiser does not support the assessor's assessment kind."""
 
     def __init__(
         self,
@@ -38,7 +38,7 @@ class AssessmentKindVisualiserIncompatibilityError(Exception):
         self.supported_assessment_kinds = supported_assessment_kinds
         supported = ", ".join(supported_assessment_kinds) if supported_assessment_kinds else "none"
         super().__init__(
-            f"Visualiser {visualiser!r} does not support assessor method kind "
+            f"Visualiser {visualiser!r} does not support assessor assessment kind "
             f"{assessor_assessment_kind!r} (from {assessor_target}). "
             f"That visualiser's supported_assessment_kinds are: {supported}."
         )

--- a/src/raitap/robustness/factory.py
+++ b/src/raitap/robustness/factory.py
@@ -21,7 +21,7 @@ from raitap.models.backend import ModelBackend
 from raitap.utils.errors import SampleNamesLengthError
 
 from .contracts import AssessorAdapter
-from .exceptions import MethodKindVisualiserIncompatibilityError, MissingTargetsError
+from .exceptions import AssessmentKindVisualiserIncompatibilityError, MissingTargetsError
 from .results import ConfiguredRobustnessVisualiser
 
 if TYPE_CHECKING:
@@ -87,19 +87,19 @@ def check_assessor_visualiser_compat(
     assessor_target: str,
     visualisers: list[ConfiguredRobustnessVisualiser],
 ) -> None:
-    """Enforce ``MethodKind`` ↔ ``supported_method_kinds`` at parse time."""
-    method_kind = assessor.method_kind
+    """Enforce ``AssessmentKind`` ↔ ``supported_assessment_kinds`` at parse time."""
+    assessment_kind = assessor.assessment_kind
     for configured in visualisers:
         visualiser = configured.visualiser
-        supported = getattr(type(visualiser), "supported_method_kinds", frozenset())
+        supported = getattr(type(visualiser), "supported_assessment_kinds", frozenset())
         if not supported:
             continue
-        if method_kind not in supported:
-            raise MethodKindVisualiserIncompatibilityError(
+        if assessment_kind not in supported:
+            raise AssessmentKindVisualiserIncompatibilityError(
                 assessor_target=assessor_target,
                 visualiser=type(visualiser).__name__,
-                assessor_method_kind=method_kind.value,
-                supported_method_kinds=[k.value for k in sorted(supported)],
+                assessor_assessment_kind=assessment_kind.value,
+                supported_assessment_kinds=[k.value for k in sorted(supported)],
             )
 
 
@@ -195,7 +195,7 @@ def create_assessor(assessor_config: Any) -> tuple[AssessorAdapter, str]:
         ),
         type_error_hint=(
             "Configured assessors must have callable assess() and check_backend_compat() methods, "
-            "and a ``method_kind`` attribute."
+            "and a ``assessment_kind`` attribute."
         ),
         instantiate_fn=instantiate,
     )

--- a/src/raitap/robustness/factory.py
+++ b/src/raitap/robustness/factory.py
@@ -195,7 +195,7 @@ def create_assessor(assessor_config: Any) -> tuple[AssessorAdapter, str]:
         ),
         type_error_hint=(
             "Configured assessors must have callable assess() and check_backend_compat() methods, "
-            "and a ``assessment_kind`` attribute."
+            "and an ``assessment_kind`` attribute."
         ),
         instantiate_fn=instantiate,
     )

--- a/src/raitap/robustness/results.py
+++ b/src/raitap/robustness/results.py
@@ -22,7 +22,7 @@ else:
 
 from .contracts import (
     VERDICT_CODES,
-    MethodKind,
+    AssessmentKind,
     RobustnessSemantics,
     RobustnessVerdict,
     RobustnessVisualisationContext,
@@ -229,8 +229,8 @@ class RobustnessResult(Trackable):
             }
 
     @property
-    def method_kind(self) -> MethodKind:
-        return self.semantics.method_kind
+    def assessment_kind(self) -> AssessmentKind:
+        return self.semantics.assessment_kind
 
     def write_artifacts(self) -> None:
         self.run_dir.mkdir(parents=True, exist_ok=True)
@@ -260,7 +260,7 @@ class RobustnessResult(Trackable):
             "target": self.assessor_target,
             "algorithm": self.algorithm,
             "assessor_name": self.assessor_name,
-            "method_kind": self.method_kind.value,
+            "assessment_kind": self.assessment_kind.value,
             "visualisers": targets,
             "metrics": self.metrics.as_dict(),
             "verdict_codes": {v.value: code for v, code in VERDICT_CODES.items()},
@@ -300,7 +300,7 @@ class RobustnessResult(Trackable):
 
             context = RobustnessVisualisationContext(
                 algorithm=self.algorithm,
-                method_kind=self.method_kind,
+                assessment_kind=self.assessment_kind,
                 sample_names=sample_names,
                 show_sample_names=show_sample_names,
             )
@@ -421,7 +421,7 @@ class RobustnessResult(Trackable):
 
         context = RobustnessVisualisationContext(
             algorithm=self.algorithm,
-            method_kind=self.method_kind,
+            assessment_kind=self.assessment_kind,
             sample_names=sample_names,
             show_sample_names=show_sample_names,
         )

--- a/src/raitap/robustness/semantics.py
+++ b/src/raitap/robustness/semantics.py
@@ -18,7 +18,7 @@ from raitap.transparency.contracts import InputSpec, SampleSelection
 from raitap.transparency.semantics import infer_input_spec
 
 from .contracts import (
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationBudget,
     PerturbationNorm,
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 class AssessorSemanticsHints:
     """Per-algorithm metadata read by ``assessor_semantics``."""
 
-    method_kind: MethodKind
+    assessment_kind: AssessmentKind
     threat_model: ThreatModel
     objective: Objective
     norm: PerturbationNorm
@@ -225,7 +225,7 @@ def assessor_semantics(
         sample_display_names=sample_names,
     )
     return RobustnessSemantics(
-        method_kind=hints.method_kind,
+        assessment_kind=hints.assessment_kind,
         threat_model=hints.threat_model,
         objective=objective,
         families=hints.families,

--- a/src/raitap/robustness/tests/test_contracts.py
+++ b/src/raitap/robustness/tests/test_contracts.py
@@ -7,7 +7,7 @@ import pytest
 
 from raitap.robustness.contracts import (
     VERDICT_CODES,
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationBudget,
     PerturbationNorm,
@@ -33,7 +33,7 @@ def test_decode_unknown_code_raises() -> None:
 
 def test_robustness_semantics_is_frozen() -> None:
     semantics = RobustnessSemantics(
-        method_kind=MethodKind.EMPIRICAL_ATTACK,
+        assessment_kind=AssessmentKind.EMPIRICAL_ATTACK,
         threat_model=ThreatModel.WHITE_BOX,
         objective=Objective.UNTARGETED,
         families=frozenset({"gradient_sign"}),

--- a/src/raitap/robustness/tests/test_factory.py
+++ b/src/raitap/robustness/tests/test_factory.py
@@ -10,8 +10,8 @@ from omegaconf import OmegaConf
 
 from raitap.models.backend import ModelBackend
 from raitap.robustness.assessors import TorchattacksAssessor
-from raitap.robustness.contracts import MethodKind
-from raitap.robustness.exceptions import MethodKindVisualiserIncompatibilityError
+from raitap.robustness.contracts import AssessmentKind
+from raitap.robustness.exceptions import AssessmentKindVisualiserIncompatibilityError
 from raitap.robustness.factory import (
     RobustnessAssessment,
     _parse_assessor_config,
@@ -52,7 +52,7 @@ class _BackendStub(ModelBackend):
 
 
 class _OnlyFormalVisualiser(BaseRobustnessVisualiser):
-    supported_method_kinds = frozenset({MethodKind.FORMAL_VERIFICATION})
+    supported_assessment_kinds = frozenset({AssessmentKind.FORMAL_VERIFICATION})
 
     def visualise(self, result, *, context, **kwargs) -> Any:  # noqa: ANN001
         raise NotImplementedError
@@ -133,11 +133,11 @@ def test_resolve_call_data_sources_passes_through_non_source_dicts() -> None:
     assert out == {"target_labels": [0, 1]}
 
 
-def test_check_visualiser_compat_raises_on_method_kind_mismatch() -> None:
+def test_check_visualiser_compat_raises_on_assessment_kind_mismatch() -> None:
     assessor = TorchattacksAssessor(algorithm="PGD")  # EMPIRICAL_ATTACK
     visualiser = _OnlyFormalVisualiser()
     configured = [ConfiguredRobustnessVisualiser(visualiser=visualiser)]
-    with pytest.raises(MethodKindVisualiserIncompatibilityError):
+    with pytest.raises(AssessmentKindVisualiserIncompatibilityError):
         check_assessor_visualiser_compat(
             assessor,
             "raitap.robustness.assessors.TorchattacksAssessor",
@@ -156,7 +156,7 @@ def test_robustness_uses_model_resolved_preprocessing_for_call_data(
             return torch.zeros(3, 5, 5, dtype=image.dtype)
 
     class RecordingAssessor:
-        method_kind = MethodKind.EMPIRICAL_ATTACK
+        assessment_kind = AssessmentKind.EMPIRICAL_ATTACK
 
         def __init__(self) -> None:
             self.last_assess_kwargs: dict[str, Any] = {}

--- a/src/raitap/robustness/tests/test_results.py
+++ b/src/raitap/robustness/tests/test_results.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 from raitap.robustness.contracts import (
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationBudget,
     PerturbationNorm,
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 def _semantics_for_test() -> RobustnessSemantics:
     return RobustnessSemantics(
-        method_kind=MethodKind.EMPIRICAL_ATTACK,
+        assessment_kind=AssessmentKind.EMPIRICAL_ATTACK,
         threat_model=ThreatModel.WHITE_BOX,
         objective=Objective.UNTARGETED,
         families=frozenset({"gradient_sign"}),
@@ -66,7 +66,9 @@ def test_robustness_result_writes_pt_and_metadata(tmp_path: Path) -> None:
     targets = torch.tensor([0, 1])
     clean_preds = torch.tensor([0, 1])
     adv_preds = torch.tensor([1, 1])
-    verdicts = encode_verdicts([RobustnessVerdict.ATTACKED, RobustnessVerdict.NOT_ATTACKED])
+    verdicts = encode_verdicts(
+        [RobustnessVerdict.ATTACK_SUCCEEDED, RobustnessVerdict.ATTACK_FAILED]
+    )
 
     result = RobustnessResult(
         clean_inputs=inputs,
@@ -91,10 +93,10 @@ def test_robustness_result_writes_pt_and_metadata(tmp_path: Path) -> None:
     assert payload["verdicts"].tolist() == [1, 2]
 
     metadata = json.loads((result.run_dir / "metadata.json").read_text())
-    assert metadata["method_kind"] == "empirical_attack"
+    assert metadata["assessment_kind"] == "empirical_attack"
     assert metadata["semantics"]["budget"]["norm"] == "Linf"
     assert metadata["metrics"]["attack_success_rate"] == 0.75
-    assert metadata["verdict_codes"]["attacked"] == 1
+    assert metadata["verdict_codes"]["attack_succeeded"] == 1
 
 
 def _result_for_visualiser_tests(tmp_path: Path) -> RobustnessResult:
@@ -103,7 +105,9 @@ def _result_for_visualiser_tests(tmp_path: Path) -> RobustnessResult:
         clean_inputs=inputs,
         targets=torch.tensor([0, 1]),
         clean_predictions=torch.tensor([0, 1]),
-        verdicts=encode_verdicts([RobustnessVerdict.ATTACKED, RobustnessVerdict.NOT_ATTACKED]),
+        verdicts=encode_verdicts(
+            [RobustnessVerdict.ATTACK_SUCCEEDED, RobustnessVerdict.ATTACK_FAILED]
+        ),
         metrics=_empirical_metrics(),
         run_dir=tmp_path / "robustness/pgd",
         experiment_name="unit-test",
@@ -188,7 +192,9 @@ def test_render_visualisation_for_report_slices_to_requested_sample(
     result.targets = torch.tensor([4, 7])
     result.clean_predictions = torch.tensor([4, 5])
     result.perturbed_predictions = torch.tensor([6, 8])
-    result.verdicts = encode_verdicts([RobustnessVerdict.NOT_ATTACKED, RobustnessVerdict.ATTACKED])
+    result.verdicts = encode_verdicts(
+        [RobustnessVerdict.ATTACK_FAILED, RobustnessVerdict.ATTACK_SUCCEEDED]
+    )
     result.perturbation_distance = torch.tensor([0.1, 0.2])
     result.runtime_per_sample = torch.tensor([1.5, 2.5])
     result.output_bounds = {
@@ -260,7 +266,7 @@ def _result_with_sample_names(
         clean_inputs=inputs,
         targets=torch.zeros(batch, dtype=torch.long),
         clean_predictions=torch.zeros(batch, dtype=torch.long),
-        verdicts=encode_verdicts([RobustnessVerdict.NOT_ATTACKED] * batch),
+        verdicts=encode_verdicts([RobustnessVerdict.ATTACK_FAILED] * batch),
         metrics=_empirical_metrics(),
         run_dir=tmp_path / "robustness/pgd",
         experiment_name="test_sample_names",

--- a/src/raitap/robustness/tests/test_semantics.py
+++ b/src/raitap/robustness/tests/test_semantics.py
@@ -5,7 +5,7 @@ import torch
 
 from raitap.robustness.assessors import FoolboxAssessor, TorchattacksAssessor
 from raitap.robustness.contracts import (
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationNorm,
     ThreatModel,
@@ -18,7 +18,7 @@ from raitap.robustness.semantics import (
 
 def test_torchattacks_registry_covers_pgd() -> None:
     hints = TorchattacksAssessor.algorithm_registry["PGD"]
-    assert hints.method_kind == MethodKind.EMPIRICAL_ATTACK
+    assert hints.assessment_kind == AssessmentKind.EMPIRICAL_ATTACK
     assert hints.norm == PerturbationNorm.LINF
     assert "iterative" in hints.families
 
@@ -37,7 +37,7 @@ def test_hints_for_assessor_routes_to_torchattacks() -> None:
 def test_hints_for_assessor_routes_to_foolbox() -> None:
     assessor = FoolboxAssessor(algorithm="LinfPGD")
     hints = hints_for_assessor(assessor)
-    assert hints.method_kind == MethodKind.EMPIRICAL_ATTACK
+    assert hints.assessment_kind == AssessmentKind.EMPIRICAL_ATTACK
 
 
 def test_assessor_semantics_reads_budget_from_constructor_kwargs() -> None:
@@ -70,7 +70,7 @@ def test_assessor_semantics_extracts_targeted_objective_from_call_kwargs() -> No
         inputs=inputs,
         targets=targets,
     )
-    assert semantics.method_kind == MethodKind.EMPIRICAL_ATTACK
+    assert semantics.assessment_kind == AssessmentKind.EMPIRICAL_ATTACK
     assert semantics.objective == Objective.TARGETED
     assert semantics.target_classes == (3, 4)
     # Budget reflects the constructor (where torchattacks actually reads from).

--- a/src/raitap/robustness/visualisers/base_visualiser.py
+++ b/src/raitap/robustness/visualisers/base_visualiser.py
@@ -5,15 +5,22 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar
 
+# Runtime imports: these names appear in public annotations on this base class, so
+# typing.get_type_hints() must resolve them from module globals.
+from matplotlib.figure import Figure  # noqa: TC002
+
 from raitap._adapters import AdapterMixin
 
+from ..contracts import AssessmentKind, RobustnessVisualisationContext  # noqa: TC001
 from ..exceptions import AssessmentKindVisualiserIncompatibilityError
 
 if TYPE_CHECKING:
-    from matplotlib.figure import Figure
-
-    from ..contracts import AssessmentKind, RobustnessVisualisationContext
     from ..results import RobustnessResult
+else:
+    # Runtime alias: a real import would be circular (``results`` imports this
+    # module for ``BaseRobustnessVisualiser``). ``Any`` lets get_type_hints()
+    # resolve the string annotation without the cycle.
+    RobustnessResult = Any
 
 
 class BaseRobustnessVisualiser(ABC, AdapterMixin):

--- a/src/raitap/robustness/visualisers/base_visualiser.py
+++ b/src/raitap/robustness/visualisers/base_visualiser.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 class BaseRobustnessVisualiser(ABC, AdapterMixin):
     """All robustness visualisers extend this class.
 
-    Subclasses declare which method kinds they support via the
+    Subclasses declare which assessment kinds they support via the
     ``supported_assessment_kinds`` ClassVar; the factory enforces compatibility at
     YAML parse time so configuration errors fail fast.
 

--- a/src/raitap/robustness/visualisers/base_visualiser.py
+++ b/src/raitap/robustness/visualisers/base_visualiser.py
@@ -7,12 +7,12 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from raitap._adapters import AdapterMixin
 
-from ..exceptions import MethodKindVisualiserIncompatibilityError
+from ..exceptions import AssessmentKindVisualiserIncompatibilityError
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
 
-    from ..contracts import MethodKind, RobustnessVisualisationContext
+    from ..contracts import AssessmentKind, RobustnessVisualisationContext
     from ..results import RobustnessResult
 
 
@@ -20,7 +20,7 @@ class BaseRobustnessVisualiser(ABC, AdapterMixin):
     """All robustness visualisers extend this class.
 
     Subclasses declare which method kinds they support via the
-    ``supported_method_kinds`` ClassVar; the factory enforces compatibility at
+    ``supported_assessment_kinds`` ClassVar; the factory enforces compatibility at
     YAML parse time so configuration errors fail fast.
 
     Empirical visualisers may also declare class-level facet hints used by
@@ -32,20 +32,22 @@ class BaseRobustnessVisualiser(ABC, AdapterMixin):
     unaffected unless they explicitly opt into the contract.
     """
 
-    supported_method_kinds: ClassVar[frozenset[MethodKind]] = frozenset()
+    supported_assessment_kinds: ClassVar[frozenset[AssessmentKind]] = frozenset()
     # Class-level because embedding robustness facets is a visual layout property.
     embeds_clean_input: ClassVar[bool] = False
     embeds_perturbation_map: ClassVar[bool] = False
 
     def validate_result(self, result: RobustnessResult) -> None:
-        if not self.supported_method_kinds:
+        if not self.supported_assessment_kinds:
             return
-        if result.method_kind not in self.supported_method_kinds:
-            raise MethodKindVisualiserIncompatibilityError(
+        if result.assessment_kind not in self.supported_assessment_kinds:
+            raise AssessmentKindVisualiserIncompatibilityError(
                 assessor_target=result.assessor_target,
                 visualiser=type(self).__name__,
-                assessor_method_kind=result.method_kind.value,
-                supported_method_kinds=[k.value for k in sorted(self.supported_method_kinds)],
+                assessor_assessment_kind=result.assessment_kind.value,
+                supported_assessment_kinds=[
+                    k.value for k in sorted(self.supported_assessment_kinds)
+                ],
             )
 
     @abstractmethod

--- a/src/raitap/robustness/visualisers/empirical/image_pair_visualiser.py
+++ b/src/raitap/robustness/visualisers/empirical/image_pair_visualiser.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 else:
     torch = lazy_import("torch")
 
-from ...contracts import MethodKind
+from ...contracts import AssessmentKind
 from ..base_visualiser import BaseRobustnessVisualiser
 
 if TYPE_CHECKING:
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 @robustness_visualiser(
     registry_name="image_pair",
-    supported_method_kinds=frozenset({MethodKind.EMPIRICAL_ATTACK}),
+    supported_assessment_kinds=frozenset({AssessmentKind.EMPIRICAL_ATTACK}),
     embeds_clean_input=True,
     embeds_perturbation_map=True,
 )
@@ -175,7 +175,7 @@ def _shared_display_range(clean: torch.Tensor, perturbed: torch.Tensor) -> tuple
 def _require_image_modality(result: RobustnessResult, visualiser_name: str) -> None:
     """Refuse to render a non-image robustness result through an image visualiser.
 
-    ``BaseRobustnessVisualiser.validate_result`` only enforces ``method_kind``;
+    ``BaseRobustnessVisualiser.validate_result`` only enforces ``assessment_kind``;
     image visualisers additionally need the result's input modality to be IMAGE
     so the (B, C, H, W) layout assumption holds. Without this guard a tabular
     or time-series result would silently feed garbage into ``imshow``.

--- a/src/raitap/robustness/visualisers/empirical/perturbation_heatmap_visualiser.py
+++ b/src/raitap/robustness/visualisers/empirical/perturbation_heatmap_visualiser.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 else:
     torch = lazy_import("torch")
 
-from ...contracts import MethodKind
+from ...contracts import AssessmentKind
 from ..base_visualiser import BaseRobustnessVisualiser
 from .image_pair_visualiser import _require_image_modality, _signed_perturbation_heatmap
 
@@ -31,7 +31,7 @@ _SUPPORTED_MODES = frozenset({"signed_dominant", "mean_abs", "mean", "max_abs"})
 
 @robustness_visualiser(
     registry_name="perturbation_heatmap",
-    supported_method_kinds=frozenset({MethodKind.EMPIRICAL_ATTACK}),
+    supported_assessment_kinds=frozenset({AssessmentKind.EMPIRICAL_ATTACK}),
     embeds_perturbation_map=True,
 )
 class PerturbationHeatmapVisualiser(BaseRobustnessVisualiser):

--- a/src/raitap/robustness/visualisers/formal/output_bounds_cohort.py
+++ b/src/raitap/robustness/visualisers/formal/output_bounds_cohort.py
@@ -5,7 +5,7 @@ For each output class ``k`` over the verified batch, render a boxplot of
 with no finite samples are omitted from the boxplot but keep their x-axis
 tick so the class index remains unambiguous.
 
-Declared compatible with :class:`MethodKind.FORMAL_VERIFICATION` only.
+Declared compatible with :class:`AssessmentKind.FORMAL_VERIFICATION` only.
 """
 
 from __future__ import annotations
@@ -17,7 +17,7 @@ import numpy as np
 
 from raitap.robustness.visualisers.registration import robustness_visualiser
 
-from ...contracts import MethodKind
+from ...contracts import AssessmentKind
 from ..base_visualiser import BaseRobustnessVisualiser
 
 if TYPE_CHECKING:
@@ -41,7 +41,7 @@ def _placeholder_figure(message: str) -> Figure:
 
 @robustness_visualiser(
     registry_name="output_bounds_cohort",
-    supported_method_kinds=frozenset({MethodKind.FORMAL_VERIFICATION}),
+    supported_assessment_kinds=frozenset({AssessmentKind.FORMAL_VERIFICATION}),
 )
 class OutputBoundsCohortVisualiser(BaseRobustnessVisualiser):
     """Boxplot of certified per-class bound widths across the verified batch."""

--- a/src/raitap/robustness/visualisers/formal/output_bounds_margin_heatmap.py
+++ b/src/raitap/robustness/visualisers/formal/output_bounds_margin_heatmap.py
@@ -13,7 +13,7 @@ The diverging colormap is centred on zero via
 :class:`matplotlib.colors.TwoSlopeNorm`, so colours stay interpretable when
 the magnitudes of the positive and negative tails differ.
 
-Declared compatible with :class:`MethodKind.FORMAL_VERIFICATION` only.
+Declared compatible with :class:`AssessmentKind.FORMAL_VERIFICATION` only.
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ from matplotlib.colors import TwoSlopeNorm
 
 from raitap.robustness.visualisers.registration import robustness_visualiser
 
-from ...contracts import MethodKind
+from ...contracts import AssessmentKind
 from ..base_visualiser import BaseRobustnessVisualiser
 
 if TYPE_CHECKING:
@@ -55,7 +55,7 @@ def _auto_figsize(n: int, k: int) -> tuple[float, float]:
 
 @robustness_visualiser(
     registry_name="output_bounds_margin_heatmap",
-    supported_method_kinds=frozenset({MethodKind.FORMAL_VERIFICATION}),
+    supported_assessment_kinds=frozenset({AssessmentKind.FORMAL_VERIFICATION}),
 )
 class OutputBoundsMarginHeatmapVisualiser(BaseRobustnessVisualiser):
     """Heatmap of per-class lower-vs-upper margins relative to the target class."""

--- a/src/raitap/robustness/visualisers/formal/output_bounds_pinned.py
+++ b/src/raitap/robustness/visualisers/formal/output_bounds_pinned.py
@@ -16,7 +16,7 @@ Note: the issue spec mentions reading resolved pin indices off
 so the constructor-kwarg path is the only pinning surface this visualiser
 exposes.
 
-Declared compatible with :class:`MethodKind.FORMAL_VERIFICATION` only.
+Declared compatible with :class:`AssessmentKind.FORMAL_VERIFICATION` only.
 """
 
 from __future__ import annotations
@@ -28,7 +28,7 @@ import numpy as np
 
 from raitap.robustness.visualisers.registration import robustness_visualiser
 
-from ...contracts import MethodKind
+from ...contracts import AssessmentKind
 from ..base_visualiser import BaseRobustnessVisualiser
 
 if TYPE_CHECKING:
@@ -55,7 +55,7 @@ def _placeholder_figure(message: str) -> Figure:
 
 @robustness_visualiser(
     registry_name="output_bounds_pinned",
-    supported_method_kinds=frozenset({MethodKind.FORMAL_VERIFICATION}),
+    supported_assessment_kinds=frozenset({AssessmentKind.FORMAL_VERIFICATION}),
 )
 class OutputBoundsPinnedVisualiser(BaseRobustnessVisualiser):
     """Per-pinned-sample plot of ``[lower_k, upper_k]`` certified intervals."""

--- a/src/raitap/robustness/visualisers/formal/output_bounds_width_heatmap.py
+++ b/src/raitap/robustness/visualisers/formal/output_bounds_width_heatmap.py
@@ -5,7 +5,7 @@ For each sample row ``i`` and output class ``k``, render
 verifier did not certify any bound (NaN) are rendered as masked / grey cells
 so the visual is honest about coverage.
 
-Declared compatible with :class:`MethodKind.FORMAL_VERIFICATION` only.
+Declared compatible with :class:`AssessmentKind.FORMAL_VERIFICATION` only.
 """
 
 from __future__ import annotations
@@ -17,7 +17,7 @@ import numpy as np
 
 from raitap.robustness.visualisers.registration import robustness_visualiser
 
-from ...contracts import MethodKind
+from ...contracts import AssessmentKind
 from ..base_visualiser import BaseRobustnessVisualiser
 
 if TYPE_CHECKING:
@@ -45,7 +45,7 @@ def _auto_figsize(n: int, k: int) -> tuple[float, float]:
 
 @robustness_visualiser(
     registry_name="output_bounds_width_heatmap",
-    supported_method_kinds=frozenset({MethodKind.FORMAL_VERIFICATION}),
+    supported_assessment_kinds=frozenset({AssessmentKind.FORMAL_VERIFICATION}),
 )
 class OutputBoundsWidthHeatmapVisualiser(BaseRobustnessVisualiser):
     """Heatmap of certified per-class output-bound widths across the batch."""

--- a/src/raitap/robustness/visualisers/formal/verdict_summary.py
+++ b/src/raitap/robustness/visualisers/formal/verdict_summary.py
@@ -8,7 +8,7 @@ Two side-by-side panels:
 * Right: histogram of ``runtime_per_sample`` (seconds), to surface
   long-tail timeouts vs. fast SAT/UNSAT cases.
 
-Declared compatible with :class:`MethodKind.FORMAL_VERIFICATION` only.
+Declared compatible with :class:`AssessmentKind.FORMAL_VERIFICATION` only.
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ import numpy as np
 
 from raitap.robustness.visualisers.registration import robustness_visualiser
 
-from ...contracts import MethodKind, RobustnessVerdict
+from ...contracts import AssessmentKind, RobustnessVerdict
 from ..base_visualiser import BaseRobustnessVisualiser
 
 if TYPE_CHECKING:
@@ -46,7 +46,7 @@ _VERDICT_COLORS = {
 
 @robustness_visualiser(
     registry_name="verdict_summary",
-    supported_method_kinds=frozenset({MethodKind.FORMAL_VERIFICATION}),
+    supported_assessment_kinds=frozenset({AssessmentKind.FORMAL_VERIFICATION}),
 )
 class VerdictSummaryVisualiser(BaseRobustnessVisualiser):
     """Bar chart of verdict counts plus a runtime histogram."""

--- a/src/raitap/robustness/visualisers/registration.py
+++ b/src/raitap/robustness/visualisers/registration.py
@@ -10,7 +10,7 @@ from raitap._adapters import AdapterDecoratorOptions, _register_core
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from raitap.robustness.contracts import MethodKind
+    from raitap.robustness.contracts import AssessmentKind
     from raitap.robustness.visualisers.base_visualiser import BaseRobustnessVisualiser
 
 
@@ -25,7 +25,7 @@ T = TypeVar("T", bound="BaseRobustnessVisualiser")
 
 def robustness_visualiser(
     *,
-    supported_method_kinds: frozenset[MethodKind] | _Unset = _UNSET,
+    supported_assessment_kinds: frozenset[AssessmentKind] | _Unset = _UNSET,
     embeds_clean_input: bool | _Unset = _UNSET,
     embeds_perturbation_map: bool | _Unset = _UNSET,
     **common: Unpack[AdapterDecoratorOptions],
@@ -35,7 +35,7 @@ def robustness_visualiser(
 
     def wrap(cls: type[T]) -> type[T]:
         for attr, value in (
-            ("supported_method_kinds", supported_method_kinds),
+            ("supported_assessment_kinds", supported_assessment_kinds),
             ("embeds_clean_input", embeds_clean_input),
             ("embeds_perturbation_map", embeds_perturbation_map),
         ):

--- a/src/raitap/robustness/visualisers/registration.py
+++ b/src/raitap/robustness/visualisers/registration.py
@@ -3,14 +3,18 @@ fields use the UNSET sentinel so omitted kwargs keep the base default."""
 
 from __future__ import annotations
 
+from collections.abc import (
+    Callable,  # noqa: TC003 — return annotation; get_type_hints() resolves it
+)
 from typing import TYPE_CHECKING, Final, TypeVar, Unpack
 
 from raitap._adapters import AdapterDecoratorOptions, _register_core
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
+# Runtime import: AssessmentKind appears in this public decorator's signature, so
+# typing.get_type_hints() must be able to resolve it from module globals.
+from raitap.robustness.contracts import AssessmentKind  # noqa: TC001
 
-    from raitap.robustness.contracts import AssessmentKind
+if TYPE_CHECKING:
     from raitap.robustness.visualisers.base_visualiser import BaseRobustnessVisualiser
 
 

--- a/src/raitap/robustness/visualisers/tests/test_output_bounds_visualisers.py
+++ b/src/raitap/robustness/visualisers/tests/test_output_bounds_visualisers.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 
 from raitap.robustness.contracts import (
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationBudget,
     PerturbationNorm,
@@ -19,7 +19,7 @@ from raitap.robustness.contracts import (
     RobustnessVisualisationContext,
     ThreatModel,
 )
-from raitap.robustness.exceptions import MethodKindVisualiserIncompatibilityError
+from raitap.robustness.exceptions import AssessmentKindVisualiserIncompatibilityError
 from raitap.robustness.results import RobustnessMetrics, RobustnessResult, encode_verdicts
 from raitap.robustness.visualisers import (
     OutputBoundsCohortVisualiser,
@@ -62,7 +62,7 @@ def _formal_result(
         output_bounds=output_bounds,
         runtime_per_sample=torch.zeros(n),
         semantics=RobustnessSemantics(
-            method_kind=MethodKind.FORMAL_VERIFICATION,
+            assessment_kind=AssessmentKind.FORMAL_VERIFICATION,
             threat_model=ThreatModel.WHITE_BOX,
             objective=Objective.UNTARGETED,
             families=frozenset({"smt"}),
@@ -74,7 +74,7 @@ def _formal_result(
 def _empirical_result() -> RobustnessResult:
     inputs = torch.zeros(2, 3)
     targets = torch.tensor([0, 1])
-    verdicts = [RobustnessVerdict.ATTACKED, RobustnessVerdict.NOT_ATTACKED]
+    verdicts = [RobustnessVerdict.ATTACK_SUCCEEDED, RobustnessVerdict.ATTACK_FAILED]
     return RobustnessResult(
         clean_inputs=inputs,
         targets=targets,
@@ -86,7 +86,7 @@ def _empirical_result() -> RobustnessResult:
         assessor_target="raitap.robustness.assessors.TorchattacksAssessor",
         algorithm="PGD",
         semantics=RobustnessSemantics(
-            method_kind=MethodKind.EMPIRICAL_ATTACK,
+            assessment_kind=AssessmentKind.EMPIRICAL_ATTACK,
             threat_model=ThreatModel.WHITE_BOX,
             objective=Objective.UNTARGETED,
             families=frozenset({"gradient"}),
@@ -100,7 +100,7 @@ def _ctx(
 ) -> RobustnessVisualisationContext:
     return RobustnessVisualisationContext(
         algorithm="linf-box",
-        method_kind=MethodKind.FORMAL_VERIFICATION,
+        assessment_kind=AssessmentKind.FORMAL_VERIFICATION,
         sample_names=names,
         show_sample_names=show_sample_names,
     )
@@ -149,9 +149,9 @@ def test_cohort_visualiser_handles_all_nan_gracefully() -> None:
         plt.close(figure)
 
 
-def test_cohort_method_kind_rejection_for_empirical_results() -> None:
+def test_cohort_assessment_kind_rejection_for_empirical_results() -> None:
     visualiser = OutputBoundsCohortVisualiser()
-    with pytest.raises(MethodKindVisualiserIncompatibilityError):
+    with pytest.raises(AssessmentKindVisualiserIncompatibilityError):
         visualiser.validate_result(_empirical_result())
 
 
@@ -226,9 +226,9 @@ def test_pinned_visualiser_handles_none_bounds_gracefully() -> None:
         plt.close(figure)
 
 
-def test_pinned_method_kind_rejection_for_empirical_results() -> None:
+def test_pinned_assessment_kind_rejection_for_empirical_results() -> None:
     visualiser = OutputBoundsPinnedVisualiser()
-    with pytest.raises(MethodKindVisualiserIncompatibilityError):
+    with pytest.raises(AssessmentKindVisualiserIncompatibilityError):
         visualiser.validate_result(_empirical_result())
 
 
@@ -290,8 +290,8 @@ def test_width_heatmap_handles_none_bounds_gracefully() -> None:
         plt.close(figure)
 
 
-def test_width_heatmap_method_kind_rejection_for_empirical_results() -> None:
-    with pytest.raises(MethodKindVisualiserIncompatibilityError):
+def test_width_heatmap_assessment_kind_rejection_for_empirical_results() -> None:
+    with pytest.raises(AssessmentKindVisualiserIncompatibilityError):
         OutputBoundsWidthHeatmapVisualiser().validate_result(_empirical_result())
 
 
@@ -367,8 +367,8 @@ def test_margin_heatmap_falls_back_when_targets_missing() -> None:
         plt.close(figure)
 
 
-def test_margin_heatmap_method_kind_rejection_for_empirical_results() -> None:
-    with pytest.raises(MethodKindVisualiserIncompatibilityError):
+def test_margin_heatmap_assessment_kind_rejection_for_empirical_results() -> None:
+    with pytest.raises(AssessmentKindVisualiserIncompatibilityError):
         OutputBoundsMarginHeatmapVisualiser().validate_result(_empirical_result())
 
 

--- a/src/raitap/robustness/visualisers/tests/test_registration.py
+++ b/src/raitap/robustness/visualisers/tests/test_registration.py
@@ -47,13 +47,13 @@ def test_robustness_visualiser_lands_in_unscoped_pool() -> None:
 
 
 def test_robustness_capability_fields_via_decorator() -> None:
-    from raitap.robustness.contracts import MethodKind
+    from raitap.robustness.contracts import AssessmentKind
     from raitap.robustness.visualisers.base_visualiser import BaseRobustnessVisualiser
     from raitap.robustness.visualisers.registration import robustness_visualiser
 
     @robustness_visualiser(
         registry_name="_stub_rob_caps",
-        supported_method_kinds=frozenset({MethodKind.EMPIRICAL_ATTACK}),
+        supported_assessment_kinds=frozenset({AssessmentKind.EMPIRICAL_ATTACK}),
         embeds_clean_input=True,
     )
     class _StubRob(BaseRobustnessVisualiser):
@@ -62,6 +62,6 @@ def test_robustness_capability_fields_via_decorator() -> None:
 
             return _Figure()
 
-    assert _StubRob.supported_method_kinds == frozenset({MethodKind.EMPIRICAL_ATTACK})
+    assert _StubRob.supported_assessment_kinds == frozenset({AssessmentKind.EMPIRICAL_ATTACK})
     assert _StubRob.embeds_clean_input is True
     assert _StubRob.embeds_perturbation_map == BaseRobustnessVisualiser.embeds_perturbation_map

--- a/src/raitap/robustness/visualisers/tests/test_verdict_summary.py
+++ b/src/raitap/robustness/visualisers/tests/test_verdict_summary.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import torch
 
 from raitap.robustness.contracts import (
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationBudget,
     PerturbationNorm,
@@ -50,7 +50,7 @@ def _make_formal_result() -> RobustnessResult:
         assessor_name="marabou_linf",
         runtime_per_sample=torch.tensor([0.1, 0.4, 0.7, 0.8]),
         semantics=RobustnessSemantics(
-            method_kind=MethodKind.FORMAL_VERIFICATION,
+            assessment_kind=AssessmentKind.FORMAL_VERIFICATION,
             threat_model=ThreatModel.WHITE_BOX,
             objective=Objective.UNTARGETED,
             families=frozenset({"smt", "complete", "sound"}),
@@ -62,7 +62,7 @@ def _make_formal_result() -> RobustnessResult:
 def _formal_context() -> RobustnessVisualisationContext:
     return RobustnessVisualisationContext(
         algorithm="linf-box",
-        method_kind=MethodKind.FORMAL_VERIFICATION,
+        assessment_kind=AssessmentKind.FORMAL_VERIFICATION,
         sample_names=None,
         show_sample_names=False,
     )
@@ -84,5 +84,5 @@ def test_verdict_summary_renders_two_panels() -> None:
 
 def test_verdict_summary_only_supports_formal_verification() -> None:
     visualiser = VerdictSummaryVisualiser()
-    assert MethodKind.FORMAL_VERIFICATION in visualiser.supported_method_kinds
-    assert MethodKind.EMPIRICAL_ATTACK not in visualiser.supported_method_kinds
+    assert AssessmentKind.FORMAL_VERIFICATION in visualiser.supported_assessment_kinds
+    assert AssessmentKind.EMPIRICAL_ATTACK not in visualiser.supported_assessment_kinds

--- a/src/raitap/robustness/visualisers/tests/test_visualisers.py
+++ b/src/raitap/robustness/visualisers/tests/test_visualisers.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 from raitap.robustness.contracts import (
-    MethodKind,
+    AssessmentKind,
     Objective,
     PerturbationBudget,
     PerturbationNorm,
@@ -16,7 +16,7 @@ from raitap.robustness.contracts import (
     RobustnessVisualisationContext,
     ThreatModel,
 )
-from raitap.robustness.exceptions import MethodKindVisualiserIncompatibilityError
+from raitap.robustness.exceptions import AssessmentKindVisualiserIncompatibilityError
 from raitap.robustness.results import RobustnessMetrics, RobustnessResult, encode_verdicts
 from raitap.robustness.visualisers import (
     ImagePairVisualiser,
@@ -32,7 +32,9 @@ def _make_result() -> RobustnessResult:
         clean_inputs=inputs,
         targets=targets,
         clean_predictions=torch.tensor([0, 1]),
-        verdicts=encode_verdicts([RobustnessVerdict.ATTACKED, RobustnessVerdict.NOT_ATTACKED]),
+        verdicts=encode_verdicts(
+            [RobustnessVerdict.ATTACK_SUCCEEDED, RobustnessVerdict.ATTACK_FAILED]
+        ),
         metrics=RobustnessMetrics(clean_accuracy=1.0, adversarial_accuracy=0.5),
         run_dir=Path("."),
         experiment_name="t",
@@ -43,7 +45,7 @@ def _make_result() -> RobustnessResult:
         perturbed_predictions=torch.tensor([1, 1]),
         perturbation_distance=torch.tensor([0.05, 0.05]),
         semantics=RobustnessSemantics(
-            method_kind=MethodKind.EMPIRICAL_ATTACK,
+            assessment_kind=AssessmentKind.EMPIRICAL_ATTACK,
             threat_model=ThreatModel.WHITE_BOX,
             objective=Objective.UNTARGETED,
             families=frozenset({"gradient_sign"}),
@@ -55,7 +57,7 @@ def _make_result() -> RobustnessResult:
 def _empirical_context() -> RobustnessVisualisationContext:
     return RobustnessVisualisationContext(
         algorithm="PGD",
-        method_kind=MethodKind.EMPIRICAL_ATTACK,
+        assessment_kind=AssessmentKind.EMPIRICAL_ATTACK,
         sample_names=["a", "b"],
         show_sample_names=True,
     )
@@ -162,7 +164,7 @@ def test_image_pair_visualiser_uses_shared_display_range_for_clean_and_perturbed
         clean_inputs=inputs,
         targets=targets,
         clean_predictions=torch.tensor([0]),
-        verdicts=encode_verdicts([RobustnessVerdict.NOT_ATTACKED]),
+        verdicts=encode_verdicts([RobustnessVerdict.ATTACK_FAILED]),
         metrics=RobustnessMetrics(clean_accuracy=1.0, adversarial_accuracy=1.0),
         run_dir=Path("."),
         experiment_name="t",
@@ -173,7 +175,7 @@ def test_image_pair_visualiser_uses_shared_display_range_for_clean_and_perturbed
         perturbed_predictions=torch.tensor([0]),
         perturbation_distance=torch.tensor([0.05]),
         semantics=RobustnessSemantics(
-            method_kind=MethodKind.EMPIRICAL_ATTACK,
+            assessment_kind=AssessmentKind.EMPIRICAL_ATTACK,
             threat_model=ThreatModel.WHITE_BOX,
             objective=Objective.UNTARGETED,
             families=frozenset({"gradient_sign"}),
@@ -195,13 +197,13 @@ def test_image_pair_visualiser_uses_shared_display_range_for_clean_and_perturbed
         plt.close(figure)
 
 
-def test_validate_result_blocks_wrong_method_kind() -> None:
+def test_validate_result_blocks_wrong_assessment_kind() -> None:
     result = _make_result()
-    # Force a verifier-only visualiser by patching supported_method_kinds.
+    # Force a verifier-only visualiser by patching supported_assessment_kinds.
     visualiser = ImagePairVisualiser(max_samples=1)
-    type(visualiser).supported_method_kinds = frozenset({MethodKind.FORMAL_VERIFICATION})
+    type(visualiser).supported_assessment_kinds = frozenset({AssessmentKind.FORMAL_VERIFICATION})
     try:
-        with pytest.raises(MethodKindVisualiserIncompatibilityError):
+        with pytest.raises(AssessmentKindVisualiserIncompatibilityError):
             visualiser.validate_result(result)
     finally:
-        type(visualiser).supported_method_kinds = frozenset({MethodKind.EMPIRICAL_ATTACK})
+        type(visualiser).supported_assessment_kinds = frozenset({AssessmentKind.EMPIRICAL_ATTACK})

--- a/src/raitap/tests/_fake_plugin/raitap_fakeplugin/__init__.py
+++ b/src/raitap/tests/_fake_plugin/raitap_fakeplugin/__init__.py
@@ -1,6 +1,6 @@
 from raitap import adapters
 from raitap.robustness.assessors.base_assessor import EmpiricalAttackAssessor
-from raitap.robustness.contracts import MethodKind, Objective, PerturbationNorm, ThreatModel
+from raitap.robustness.contracts import AssessmentKind, Objective, PerturbationNorm, ThreatModel
 from raitap.robustness.semantics import AssessorSemanticsHints
 
 
@@ -8,7 +8,7 @@ from raitap.robustness.semantics import AssessorSemanticsHints
     registry_name="fakeattack",
     algorithm_registry={
         "PGD": AssessorSemanticsHints(
-            MethodKind.EMPIRICAL_ATTACK,
+            AssessmentKind.EMPIRICAL_ATTACK,
             ThreatModel.WHITE_BOX,
             Objective.UNTARGETED,
             PerturbationNorm.LINF,


### PR DESCRIPTION
## Summary

Closes #199. Two enum-naming fixes from an enum-clarity review.

### 1. `RobustnessVerdict` empirical members (Option A)

| before | after | value before | value after |
|---|---|---|---|
| `ATTACKED` | `ATTACK_SUCCEEDED` | `attacked` | `attack_succeeded` |
| `NOT_ATTACKED` | `ATTACK_FAILED` | `not_attacked` | `attack_failed` |

`NOT_ATTACKED` wrongly read as "no attack was run"; the sample *was* attacked, the attack just failed. `VERDICT_CODES` integer encoding is unchanged (codes 1–6 stay pinned — the public contract is the integers, not the strings).

### 2. `MethodKind` → `AssessmentKind` (full sweep)

Avoids confusion with transparency's `MethodFamily`. Propagated to:
- `method_kind` field/attr → `assessment_kind`
- `supported_method_kinds` → `supported_assessment_kinds`
- `MethodKindVisualiserIncompatibilityError` → `AssessmentKindVisualiserIncompatibilityError`

### Verification
- `ruff check` + `ruff format`: clean
- `uv run pytest src/raitap/robustness src/raitap/reporting`: 228 passed, 7 skipped
- Docs (contributor + user robustness pages) updated to match.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — If this PR breaks compatibility (API, configs, file formats, etc.), the title uses `!` after the type or scope (e.g. `feat!:` or `feat(transparency)!:`). I understand that this change will have a **direct, disruptive impact** on package users. I ensured that **this change is absolutely necessary and cannot be delayed**.
- [x] **Contributor guide** — I’ve read [**Pull requests and commit messages**](https://caiivs.github.io/raitap/contributor/pull-requests.html) before requesting review.

## Optional

- [x] **Issue** — A GitHub issues is linked to this PR ("Development" section in the right sidebar).
- [x] **Docs** — User or contributor docs updated where needed.
- [x] **Tests** — New or updated tests cover the change.
