### PR TITLE
fix(data)!: batch object-detection inputs as ragged list[Tensor]

### DIFF
--- a/docs/modules/data/preprocessing.md
+++ b/docs/modules/data/preprocessing.md
@@ -21,6 +21,10 @@ The 2 following config keys are available:
 - `preprocessing` runs in the loader so mixed-size image folders can stack at all, and so the work is outside autograd.
 - `model_input_transformation` inside autograd so Captum/SHAP attribution and PGD/FGSM attacks operate on the same input space you do.
 
+:::{warning}
+**Not supported for object detection.** Detection models take native per-image inputs and resize/normalise internally (e.g. torchvision `GeneralizedRCNNTransform`), so neither knob applies: a data-side resize/crop/pad would corrupt the ground-truth box coordinates (labels are not transformed with the pixels), and a model-side transform would double-process the input. Setting `data.preprocessing` or `data.model_input_transformation` for a detection model raises an error — leave both unset.
+:::
+
 The following values are allowed for both keys:
 
 - **`null`** (default): no preprocessing

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -59,6 +59,7 @@ class Data(Trackable):
             cfg,
             resolved_preprocessing=resolved_preprocessing,
         )
+        self._validate_loaded_tensor()
         labels_cfg = _get_optional_config_value(cfg.data, "labels")
         labels_kind = _get_optional_config_value(labels_cfg, "kind")
         self.labels: torch.Tensor | list[dict[str, torch.Tensor]] | None
@@ -178,6 +179,47 @@ class Data(Trackable):
             f"Supported image formats: {_IMAGE_EXTENSIONS}\n"
             f"Supported tabular formats: {_TABULAR_EXTENSIONS}"
         )
+
+    def _validate_loaded_tensor(self) -> None:
+        """Fail loud if ``self.tensor`` violates the contract for ``task_kind``.
+
+        Classification expects a dense ``(N, ...)`` tensor (``ndim >= 2``, at
+        least one sample). Detection expects a non-empty ``list`` of per-image
+        ``(C, H, W)`` tensors. Catching a shape/type mismatch here — naming the
+        contract — beats a silent mis-batch deep inside ``forward_pass`` (where
+        ``len()`` on a stray ``(C, H, W)`` tensor would count channels, not
+        samples).
+        """
+        if self.task_kind is TaskKind.detection:
+            if not isinstance(self.tensor, list):
+                raise TypeError(
+                    "Detection data must be a list of per-image (C, H, W) tensors, "
+                    f"got {type(self.tensor).__name__}."
+                )
+            if not self.tensor:
+                raise ValueError("Detection data is empty; loaded zero images.")
+            for index, image in enumerate(self.tensor):
+                if not isinstance(image, torch.Tensor) or image.ndim != 3:
+                    shape = tuple(image.shape) if isinstance(image, torch.Tensor) else None
+                    raise ValueError(
+                        "Detection data entries must be (C, H, W) tensors; entry "
+                        f"{index} is {type(image).__name__}"
+                        + (f" with shape {shape}." if shape is not None else ".")
+                    )
+            return
+
+        if not isinstance(self.tensor, torch.Tensor):
+            raise TypeError(
+                f"Classification data must be a dense (N, ...) tensor, "
+                f"got {type(self.tensor).__name__}."
+            )
+        if self.tensor.ndim < 2:
+            raise ValueError(
+                "Classification data must be a batched (N, ...) tensor with ndim >= 2, "
+                f"got shape {tuple(self.tensor.shape)}."
+            )
+        if self.tensor.shape[0] < 1:
+            raise ValueError("Classification data is empty; loaded zero samples.")
 
     def _load_labels(self, cfg: AppConfig) -> torch.Tensor | None:
         labels_cfg = _get_optional_config_value(cfg.data, "labels")

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -15,6 +15,7 @@ from raitap.data.preprocessing import module_as_per_image_callable, resolve_prep
 from raitap.data.types import IdStrategy, LabelEncoding, LabelKind
 from raitap.data.utils import download_file
 from raitap.tracking.base_tracker import BaseTracker, Trackable
+from raitap.types import DetectionInputs, TaskKind
 from raitap.utils.lazy import lazy_import
 
 from .samples import SAMPLE_SOURCES, _load_sample, resolve_sample_labels_path
@@ -48,9 +49,12 @@ class Data(Trackable):
         cfg: AppConfig,
         *,
         resolved_preprocessing: ResolvedPreprocessing | None = None,
+        task_kind: TaskKind = TaskKind.classification,
     ) -> None:
         self.name = cfg.data.name
         self.source = cfg.data.source
+        self.task_kind = task_kind
+        self.tensor: torch.Tensor | DetectionInputs
         self.tensor, self.sample_ids = self._load_data(
             cfg,
             resolved_preprocessing=resolved_preprocessing,
@@ -71,7 +75,7 @@ class Data(Trackable):
         cfg: AppConfig,
         *,
         resolved_preprocessing: ResolvedPreprocessing | None = None,
-    ) -> tuple[torch.Tensor, list[str] | None]:
+    ) -> tuple[torch.Tensor | DetectionInputs, list[str] | None]:
         """
         Load data from a specified source into a raw tensor.
 
@@ -80,15 +84,17 @@ class Data(Trackable):
         - Named demo sample (e.g. ``"imagenet_samples"``)
         - URL to a single downloadable file
         - Local directory of images → ``(N, 3, H, W)`` float32 in ``[0, 1]``
+          (or ``list[Tensor]`` of per-image ``(C, H, W)`` for detection)
         - Local directory of CSV / TSV / Parquet files → ``(N, F)`` float32 (rows concatenated)
         - Local image file → ``(1, 3, H, W)`` float32 in ``[0, 1]``
+          (or ``list[Tensor]`` of length 1 for detection)
         - Local CSV / TSV / Parquet file → ``(N, F)`` float32
 
         Args:
             cfg: Application configuration.
 
         Returns:
-            Raw data tensor.
+            Raw data tensor or ragged list of per-image tensors (detection).
         """
         source = cfg.data.source
         if not source or not source.strip():
@@ -110,6 +116,8 @@ class Data(Trackable):
                 data_module = resolved.data_module
         per_image_transform = module_as_per_image_callable(data_module)
 
+        is_detection = self.task_kind is TaskKind.detection
+
         # Demo samples need their own loader: source images have inconsistent
         # dimensions and ``_load_sample`` resizes them to a common shape so
         # they can be stacked. The generic dir-loader expects pre-aligned
@@ -119,6 +127,9 @@ class Data(Trackable):
             # at their native resolution instead of pre-squashing them to
             # ``_DEMO_SIZE`` before the bundled Resize/CenterCrop sees them.
             tensor, sample_ids = _load_sample(source, per_image_transform=per_image_transform)
+            if is_detection:
+                # Convert stacked tensor to per-image list for detection.
+                return list(tensor.unbind(0)), sample_ids
             return tensor, sample_ids
 
         path = get_source_path(source, kind=SourceKind.DATA)
@@ -132,6 +143,11 @@ class Data(Trackable):
                     "Separate them into different directories."
                 )
             if image_files:
+                if is_detection:
+                    ragged = _load_images_ragged(
+                        image_files, per_image_transform=per_image_transform
+                    )
+                    return ragged, _resolve_sample_ids(image_files, root=path)
                 tensor = torch.from_numpy(
                     _stack_images_numpy(image_files, per_image_transform=per_image_transform)
                 )
@@ -147,6 +163,9 @@ class Data(Trackable):
 
         suffix = path.suffix.lower()
         if suffix in _IMAGE_EXTENSIONS:
+            if is_detection:
+                ragged = _load_images_ragged([path], per_image_transform=per_image_transform)
+                return ragged, _resolve_sample_ids([path], root=path.parent)
             return (
                 _load_images(path, per_image_transform=per_image_transform),
                 _resolve_sample_ids([path], root=path.parent),
@@ -184,7 +203,7 @@ class Data(Trackable):
             labels_encoding=labels_encoding,
         )
 
-        expected = int(self.tensor.shape[0])
+        expected = len(self.tensor)
         if self.sample_ids and id_column:
             id_series = _column_as_series(labels_df, id_column)
             strategy = _resolve_id_strategy(labels_id_strategy, id_series)
@@ -253,7 +272,7 @@ class Data(Trackable):
         if not isinstance(records, list):
             raise ValueError(f"Detection labels file {labels_path} must be a JSON array.")
 
-        expected = int(self.tensor.shape[0])
+        expected = len(self.tensor)
 
         if self.sample_ids is not None:
             by_id: dict[str, dict[str, Any]] = {}
@@ -333,6 +352,17 @@ class Data(Trackable):
         Returns:
             Dictionary containing dataset metadata.
         """
+        if isinstance(self.tensor, list):
+            # Ragged detection batch: report count and dtype only; no fixed shape.
+            dtype_str = str(self.tensor[0].dtype) if self.tensor else "unknown"
+            return {
+                "name": self.name,
+                "source": self.source,
+                "num_samples": len(self.tensor),
+                "shape": "ragged",
+                "dtype": dtype_str,
+                "has_labels": self.labels is not None,
+            }
         shape = [int(dim) for dim in self.tensor.shape]
         dataset_info: dict[str, Any] = {
             "name": self.name,
@@ -605,6 +635,33 @@ def _load_images(
 ) -> torch.Tensor:
     """Load image files from a directory (or a single file) as raw (C, H, W) tensors."""
     return torch.from_numpy(_load_images_numpy(path, per_image_transform=per_image_transform))
+
+
+def _load_images_ragged(
+    files: list[Path],
+    *,
+    per_image_transform: Callable[[torch.Tensor], torch.Tensor] | None = None,
+) -> list[torch.Tensor]:
+    """Load pre-discovered image files as a ragged list of per-image ``(C, H, W)`` float32 tensors.
+
+    Unlike :func:`_stack_images_numpy`, this function does NOT stack the images,
+    so files with different spatial dimensions are handled without error. Each
+    returned tensor is a ``(C, H, W)`` float32 in ``[0, 1]``.  When
+    ``per_image_transform`` is supplied it is applied per image (as in
+    :func:`_stack_images_numpy`) before the tensor is appended, but no resize
+    is forced — the transform is passed through transparently.
+
+    Used for detection task inputs where batches are ragged by design.
+    """
+    result: list[torch.Tensor] = []
+    for f in files:
+        arr = np.array(Image.open(f).convert("RGB"))  # HWC uint8
+        chw = arr.transpose(2, 0, 1).astype(np.float32) / 255.0  # CHW float32
+        t: torch.Tensor = torch.from_numpy(chw)
+        if per_image_transform is not None:
+            t = per_image_transform(t)
+        result.append(t)
+    return result
 
 
 def _apply_data_module_to_batch(

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -655,7 +655,8 @@ def _load_images_ragged(
     """
     result: list[torch.Tensor] = []
     for f in files:
-        arr = np.array(Image.open(f).convert("RGB"))  # HWC uint8
+        with Image.open(f) as im:
+            arr = np.array(im.convert("RGB"))  # HWC uint8
         chw = arr.transpose(2, 0, 1).astype(np.float32) / 255.0  # CHW float32
         t: torch.Tensor = torch.from_numpy(chw)
         if per_image_transform is not None:

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -593,7 +593,8 @@ def _stack_images_numpy(
     """
     arrays = []
     for f in files:
-        arr = np.array(Image.open(f).convert("RGB"))  # HWC uint8
+        with Image.open(f) as im:
+            arr = np.array(im.convert("RGB"))  # HWC uint8
         chw = arr.transpose(2, 0, 1).astype(np.float32) / 255.0  # CHW float32
         if per_image_transform is not None:
             chw = per_image_transform(torch.from_numpy(chw)).numpy()

--- a/src/raitap/data/tests/test_data.py
+++ b/src/raitap/data/tests/test_data.py
@@ -217,6 +217,7 @@ class TestDataPreprocessing:
         _write_image(tmp_path / "c.jpg", 440, 780)
         cfg = self._make_cfg(str(tmp_path), preprocessing="model-bundled")
         data = Data(cfg)
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (3, 3, 224, 224)
         assert data.tensor.dtype == torch.float32
 
@@ -232,6 +233,7 @@ class TestDataPreprocessing:
             _write_image(tmp_path / f"img{i}.jpg", 64, 64)
         cfg = self._make_cfg(str(tmp_path), preprocessing=None)
         data = Data(cfg)
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (3, 3, 64, 64)
 
     def test_supplied_resolved_preprocessing_skips_resolution(self, tmp_path: Path) -> None:
@@ -270,6 +272,7 @@ class TestDataPreprocessing:
             resolve_preprocessing_mock.side_effect = AssertionError("should not resolve again")
             data = Data(cfg, resolved_preprocessing=resolved)
 
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (1, 3, 8, 8)
         resolve_preprocessing_mock.assert_not_called()
 
@@ -324,6 +327,7 @@ class TestDataPreprocessing:
 
         data = Data(cfg)
 
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (2, 3, 8, 8)
         assert data.tensor.dtype == torch.float32
 
@@ -417,6 +421,7 @@ class TestDataPreprocessing:
             SAMPLE_SOURCES.clear()
             SAMPLE_SOURCES.update(original)
 
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (3, 3, 224, 224)
         # The spy must see three per-image calls at NATIVE resolution
         # (the PIL pre-squash to 224x224 must NOT happen when a transform
@@ -493,6 +498,7 @@ class TestLoadData:
             )(),
         )
         data = Data(cfg)
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (1, 3, 32, 32)
 
     def test_local_image_directory(self, tmp_path: Path) -> None:
@@ -507,6 +513,7 @@ class TestLoadData:
             )(),
         )
         data = Data(cfg)
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape[0] == 2
 
     def test_local_csv_file(self, tmp_path: Path) -> None:
@@ -521,6 +528,7 @@ class TestLoadData:
             )(),
         )
         data = Data(cfg)
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (6, 3)
 
     def test_local_tabular_directory(self, tmp_path: Path) -> None:
@@ -535,6 +543,7 @@ class TestLoadData:
             )(),
         )
         data = Data(cfg)
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (6, 3)
 
     def test_mixed_directory_raises(self, tmp_path: Path) -> None:
@@ -613,6 +622,7 @@ class TestLoadData:
 
         data = Data(cfg, resolved_preprocessing=resolved)
 
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == baseline.shape
         torch.testing.assert_close(data.tensor, baseline * 10.0)
 
@@ -665,6 +675,7 @@ class TestLoadData:
         )
         with patch("raitap.data.data.get_source_path", return_value=p):
             data = Data(cfg)
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (2, 3)
 
     def test_url_source_loads_image_via_get_source_path(self, tmp_path: Path) -> None:
@@ -686,6 +697,7 @@ class TestLoadData:
         )
         with patch("raitap.data.data.get_source_path", return_value=p):
             data = Data(cfg)
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (1, 3, 32, 32)
 
     def test_sample_labels_align_with_sample_images(self, tmp_path: Path) -> None:

--- a/src/raitap/data/tests/test_data_class.py
+++ b/src/raitap/data/tests/test_data_class.py
@@ -60,6 +60,7 @@ class TestDataConstructor:
         data = Data(config)
 
         assert isinstance(data.tensor, torch.Tensor)
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (2, 2)
         assert data.source == str(csv_file)
 
@@ -201,6 +202,7 @@ class TestDataConstructor:
 
         data = Data(config)
 
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape[0] == 2
         assert data.labels is not None
         # Sample order is sorted by relative posix path: NORMAL/* < PNEUMONIA/*.

--- a/src/raitap/data/tests/test_detection_ragged.py
+++ b/src/raitap/data/tests/test_detection_ragged.py
@@ -261,3 +261,54 @@ class TestDescribeWithListTensor:
         assert info["shape"] == [2, 3]
         assert info["num_samples"] == 2
         assert "sample_shape" in info
+
+
+# ---------------------------------------------------------------------------
+# Loaded-tensor contract validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateLoadedTensor:
+    def _data_with(self, tensor: object, task_kind: TaskKind) -> Data:
+        data = Data.__new__(Data)
+        data.task_kind = task_kind
+        data.tensor = cast("torch.Tensor", tensor)
+        return data
+
+    def test_detection_accepts_list_of_chw_tensors(self) -> None:
+        data = self._data_with([torch.zeros(3, 24, 32)], TaskKind.detection)
+        data._validate_loaded_tensor()  # no raise
+
+    def test_detection_rejects_dense_tensor(self) -> None:
+        data = self._data_with(torch.zeros(2, 3, 8, 8), TaskKind.detection)
+        with pytest.raises(TypeError, match="must be a list"):
+            data._validate_loaded_tensor()
+
+    def test_detection_rejects_empty_list(self) -> None:
+        data = self._data_with([], TaskKind.detection)
+        with pytest.raises(ValueError, match="empty"):
+            data._validate_loaded_tensor()
+
+    def test_detection_rejects_non_chw_entry(self) -> None:
+        data = self._data_with([torch.zeros(24, 32)], TaskKind.detection)
+        with pytest.raises(ValueError, match=r"\(C, H, W\)"):
+            data._validate_loaded_tensor()
+
+    def test_classification_accepts_batched_tensor(self) -> None:
+        data = self._data_with(torch.zeros(4, 3, 8, 8), TaskKind.classification)
+        data._validate_loaded_tensor()  # no raise
+
+    def test_classification_rejects_list(self) -> None:
+        data = self._data_with([torch.zeros(3, 8, 8)], TaskKind.classification)
+        with pytest.raises(TypeError, match="dense"):
+            data._validate_loaded_tensor()
+
+    def test_classification_rejects_unbatched_tensor(self) -> None:
+        data = self._data_with(torch.zeros(5), TaskKind.classification)
+        with pytest.raises(ValueError, match="ndim >= 2"):
+            data._validate_loaded_tensor()
+
+    def test_classification_rejects_empty_batch(self) -> None:
+        data = self._data_with(torch.zeros(0, 3, 8, 8), TaskKind.classification)
+        with pytest.raises(ValueError, match="empty"):
+            data._validate_loaded_tensor()

--- a/src/raitap/data/tests/test_detection_ragged.py
+++ b/src/raitap/data/tests/test_detection_ragged.py
@@ -1,0 +1,261 @@
+"""TDD tests for the ragged-list detection data path (issue #197).
+
+Covers:
+- Detection task_kind + differently-sized images → list[Tensor] (no ValueError).
+- Classification task_kind on uniform images → stacked dense tensor (regression guard).
+- _load_detection_labels count validation works when self.tensor is a list.
+- describe() returns sane metadata for a list-valued tensor.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from raitap.data.data import Data
+from raitap.types import TaskKind
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from raitap.configs.schema import AppConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_image(path: Path, width: int, height: int) -> None:
+    """Write a minimal solid-colour RGB image with the given size."""
+    arr = np.zeros((height, width, 3), dtype=np.uint8)
+    Image.fromarray(arr, "RGB").save(path)
+
+
+def _make_config(source: str, name: str = "test_det") -> AppConfig:
+    return cast(
+        "AppConfig",
+        SimpleNamespace(
+            data=SimpleNamespace(
+                source=source,
+                name=name,
+                labels=SimpleNamespace(
+                    source=None,
+                    kind=None,
+                    id_column=None,
+                    column=None,
+                    encoding=None,
+                    id_strategy=None,
+                ),
+            )
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core bug regression: ragged image directory must not raise
+# ---------------------------------------------------------------------------
+
+
+class TestDetectionRaggedLoader:
+    def test_different_sized_images_detection_returns_list(self, tmp_path: Path) -> None:
+        """Detection task_kind: differently-sized images load as list[Tensor], not stacked."""
+        data_dir = tmp_path / "images"
+        data_dir.mkdir()
+        # Three images with different spatial sizes — np.stack would crash here.
+        _write_image(data_dir / "a.jpg", width=32, height=24)
+        _write_image(data_dir / "b.jpg", width=64, height=48)
+        _write_image(data_dir / "c.jpg", width=16, height=16)
+
+        cfg = _make_config(str(data_dir))
+        data = Data(cfg, task_kind=TaskKind.detection)
+
+        # Must be a list, not a stacked tensor.
+        assert isinstance(data.tensor, list)
+        assert len(data.tensor) == 3
+
+        # Each element is a (C, H, W) float32 tensor in [0, 1].
+        shapes = [tuple(t.shape) for t in data.tensor]
+        assert (3, 24, 32) in shapes
+        assert (3, 48, 64) in shapes
+        assert (3, 16, 16) in shapes
+        for t in data.tensor:
+            assert t.dtype == torch.float32
+            assert t.min() >= 0.0
+            assert t.max() <= 1.0
+
+    def test_different_sized_images_detection_preserves_native_size(self, tmp_path: Path) -> None:
+        """No resize is applied — each tensor keeps its native resolution."""
+        data_dir = tmp_path / "images"
+        data_dir.mkdir()
+        _write_image(data_dir / "wide.jpg", width=100, height=50)
+        _write_image(data_dir / "tall.jpg", width=20, height=80)
+
+        cfg = _make_config(str(data_dir))
+        data = Data(cfg, task_kind=TaskKind.detection)
+
+        assert isinstance(data.tensor, list)
+        shapes = sorted(tuple(t.shape) for t in data.tensor)
+        assert (3, 50, 100) in shapes
+        assert (3, 80, 20) in shapes
+
+    def test_single_image_file_detection_returns_list(self, tmp_path: Path) -> None:
+        """A single image file also produces a list of length 1 under detection."""
+        img = tmp_path / "img.jpg"
+        _write_image(img, width=32, height=32)
+        cfg = _make_config(str(img))
+        data = Data(cfg, task_kind=TaskKind.detection)
+
+        assert isinstance(data.tensor, list)
+        assert len(data.tensor) == 1
+        assert data.tensor[0].shape == (3, 32, 32)
+
+
+# ---------------------------------------------------------------------------
+# Classification regression guard: stacked tensor path unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestClassificationStackedGuard:
+    def test_classification_uniform_images_still_stacked(self, tmp_path: Path) -> None:
+        """Default (classification) task_kind still produces a stacked dense NCHW tensor."""
+        data_dir = tmp_path / "images"
+        data_dir.mkdir()
+        _write_image(data_dir / "a.jpg", width=32, height=32)
+        _write_image(data_dir / "b.jpg", width=32, height=32)
+
+        cfg = _make_config(str(data_dir))
+        data = Data(cfg)  # default task_kind = classification
+
+        assert isinstance(data.tensor, torch.Tensor)
+        assert data.tensor.shape == (2, 3, 32, 32)
+        assert data.tensor.dtype == torch.float32
+
+    def test_explicit_classification_task_kind_also_stacks(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "images"
+        data_dir.mkdir()
+        _write_image(data_dir / "x.jpg", width=8, height=8)
+
+        cfg = _make_config(str(data_dir))
+        data = Data(cfg, task_kind=TaskKind.classification)
+
+        assert isinstance(data.tensor, torch.Tensor)
+        assert data.tensor.shape == (1, 3, 8, 8)
+
+
+# ---------------------------------------------------------------------------
+# Detection label count validation with list tensor
+# ---------------------------------------------------------------------------
+
+
+class TestDetectionLabelsWithListTensor:
+    def _write_labels_json(self, path: Path, n: int) -> None:
+        payload = [{"sample_id": f"img_{i}", "boxes": [], "labels": []} for i in range(n)]
+        path.write_text(json.dumps(payload))
+
+    def test_detection_labels_count_matches_list_tensor(self, tmp_path: Path) -> None:
+        """_load_detection_labels: len(self.tensor) works when tensor is a list."""
+        labels_path = tmp_path / "boxes.json"
+        self._write_labels_json(labels_path, n=3)
+
+        data = Data.__new__(Data)
+        # Simulate a ragged list (different sizes so a stacked tensor couldn't exist).
+        data.tensor = [
+            torch.zeros(3, 24, 32),
+            torch.zeros(3, 48, 64),
+            torch.zeros(3, 16, 16),
+        ]
+        data.sample_ids = ["img_0", "img_1", "img_2"]
+
+        from raitap.data.types import LabelKind
+
+        cfg = cast(
+            "AppConfig",
+            SimpleNamespace(
+                data=SimpleNamespace(
+                    labels=SimpleNamespace(
+                        source=str(labels_path),
+                        kind=LabelKind.detection,
+                    )
+                )
+            ),
+        )
+        out = data._load_detection_labels(cfg)
+        assert out is not None
+        assert len(out) == 3
+
+    def test_detection_labels_count_mismatch_raises_with_list_tensor(self, tmp_path: Path) -> None:
+        """Wrong record count still raises even when tensor is a list."""
+        labels_path = tmp_path / "boxes.json"
+        self._write_labels_json(labels_path, n=2)  # only 2 records
+
+        data = Data.__new__(Data)
+        data.tensor = [torch.zeros(3, 24, 32), torch.zeros(3, 48, 64), torch.zeros(3, 16, 16)]
+        data.sample_ids = None  # force row-order path
+
+        from raitap.data.types import LabelKind
+
+        cfg = cast(
+            "AppConfig",
+            SimpleNamespace(
+                data=SimpleNamespace(
+                    labels=SimpleNamespace(
+                        source=str(labels_path),
+                        kind=LabelKind.detection,
+                    )
+                )
+            ),
+        )
+        with pytest.raises(ValueError, match="3 samples"):
+            data._load_detection_labels(cfg)
+
+
+# ---------------------------------------------------------------------------
+# describe() with a ragged list tensor
+# ---------------------------------------------------------------------------
+
+
+class TestDescribeWithListTensor:
+    def test_describe_ragged_list(self, tmp_path: Path) -> None:
+        """describe() must not crash and must be JSON-serialisable for a list tensor."""
+        data_dir = tmp_path / "images"
+        data_dir.mkdir()
+        _write_image(data_dir / "a.jpg", width=32, height=24)
+        _write_image(data_dir / "b.jpg", width=64, height=48)
+
+        cfg = _make_config(str(data_dir), name="det_data")
+        data = Data(cfg, task_kind=TaskKind.detection)
+
+        info = data.describe()
+
+        # Must be JSON-serialisable (no tensors, no torch.Size, no np.int64, ...).
+        import json as _json
+
+        serialised = _json.dumps(info)
+        reloaded = _json.loads(serialised)
+
+        assert reloaded["num_samples"] == 2
+        assert reloaded["has_labels"] is False
+        assert reloaded["name"] == "det_data"
+        # Shape must be flagged as ragged (string or absent).
+        assert reloaded.get("shape") == "ragged" or "shape" not in reloaded
+        # sample_shape must be absent for ragged data.
+        assert "sample_shape" not in reloaded
+
+    def test_describe_dense_tensor_unchanged(self, tmp_path: Path) -> None:
+        """Dense-tensor path in describe() keeps the existing list[int] shape contract."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("a,b,c\n1,2,3\n4,5,6")
+        cfg = _make_config(str(csv_file))
+        data = Data(cfg)
+
+        info = data.describe()
+        assert info["shape"] == [2, 3]
+        assert info["num_samples"] == 2
+        assert "sample_shape" in info

--- a/src/raitap/data/tests/test_detection_ragged.py
+++ b/src/raitap/data/tests/test_detection_ragged.py
@@ -134,6 +134,7 @@ class TestClassificationStackedGuard:
         data = Data(cfg)  # default task_kind = classification
 
         assert isinstance(data.tensor, torch.Tensor)
+        assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (2, 3, 32, 32)
         assert data.tensor.dtype == torch.float32
 
@@ -145,6 +146,7 @@ class TestClassificationStackedGuard:
         cfg = _make_config(str(data_dir))
         data = Data(cfg, task_kind=TaskKind.classification)
 
+        assert isinstance(data.tensor, torch.Tensor)
         assert isinstance(data.tensor, torch.Tensor)
         assert data.tensor.shape == (1, 3, 8, 8)
 

--- a/src/raitap/models/backend.py
+++ b/src/raitap/models/backend.py
@@ -196,10 +196,19 @@ class TorchBackend(ModelBackend):
         reshaped = _adapt_input_shape(inputs, self.expected_input_shape)
         return reshaped.to(self.device)
 
+    def prepare_detection_inputs(self, inputs: list[torch.Tensor]) -> list[torch.Tensor]:
+        """Prepare a ragged list of detection images for inference.
+
+        Each ``(C, H, W)`` tensor is moved to the backend device without
+        any shape adaptation — detection images keep their native resolution.
+        Torchvision detection models accept ``list[Tensor]`` natively.
+        """
+        return [img.to(self.device) for img in inputs]
+
     def _prepare_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
         return _move_tensors_to_device(kwargs, self.device)
 
-    def __call__(self, inputs: torch.Tensor) -> Any:
+    def __call__(self, inputs: torch.Tensor | list[torch.Tensor]) -> Any:
         return self.model(inputs)
 
     def as_model_for_explanation(self) -> nn.Module:

--- a/src/raitap/models/model.py
+++ b/src/raitap/models/model.py
@@ -124,16 +124,18 @@ def _apply_preprocessing(
         else resolve_preprocessing(config.model, config.data)
     )
 
+    # Detection models resize/normalise internally and take native per-image
+    # inputs, so a data-side transform would corrupt box coordinates (labels
+    # are not transformed) and a model-side transform would double-process.
+    detection_preprocessing = resolved.data_module is not None or resolved.model_module is not None
+    if backend.task_kind is TaskKind.detection and detection_preprocessing:
+        raise RaitapError(
+            "Preprocessing is not supported for object detection models. "
+            "Unset data.preprocessing and data.model_input_transformation: "
+            "detection takes native per-image inputs and normalises internally."
+        )
+
     if resolved.model_module is not None:
-        if backend.task_kind is TaskKind.detection:
-            raise RaitapError(
-                "data.model_input_transformation is not supported for object "
-                "detection models: detectors normalise inputs internally "
-                "(torchvision GeneralizedRCNNTransform), so an external "
-                "model-side transformation would double-process the input. It "
-                "is also incompatible with the per-image (variable-resolution) "
-                "detection input. Leave the model-side knob unset for detection."
-            )
         if isinstance(backend, OnnxBackend):
             if resolved.model_origin != "custom-file":
                 raise NotImplementedError(

--- a/src/raitap/models/model.py
+++ b/src/raitap/models/model.py
@@ -11,6 +11,8 @@ from raitap.configs import cfg_to_dict
 from raitap.data.metadata import shape_tuple
 from raitap.data.preprocessing import ResolvedPreprocessing, resolve_preprocessing
 from raitap.tracking.base_tracker import BaseTracker, Trackable
+from raitap.types import TaskKind
+from raitap.utils.errors import RaitapError
 from raitap.utils.lazy import lazy_import
 
 from .backend import ModelBackend, OnnxBackend, TorchBackend
@@ -123,6 +125,15 @@ def _apply_preprocessing(
     )
 
     if resolved.model_module is not None:
+        if backend.task_kind is TaskKind.detection:
+            raise RaitapError(
+                "data.model_input_transformation is not supported for object "
+                "detection models: detectors normalise inputs internally "
+                "(torchvision GeneralizedRCNNTransform), so an external "
+                "model-side transformation would double-process the input. It "
+                "is also incompatible with the per-image (variable-resolution) "
+                "detection input. Leave the model-side knob unset for detection."
+            )
         if isinstance(backend, OnnxBackend):
             if resolved.model_origin != "custom-file":
                 raise NotImplementedError(

--- a/src/raitap/models/tests/test_models.py
+++ b/src/raitap/models/tests/test_models.py
@@ -946,12 +946,12 @@ class TestModelPreprocessingWrap:
         """Detection models normalise inputs internally; an external model-side
         transformation would double-process and is incompatible with the ragged
         ``list[Tensor]`` detection input. ``_apply_preprocessing`` must reject it
-        rather than silently wrap the detector in ``nn.Sequential``."""
+        with a ``RaitapError`` rather than silently wrap the detector in
+        ``nn.Sequential``."""
         from raitap.data.preprocessing import ResolvedPreprocessing
         from raitap.models.model import _apply_preprocessing
         from raitap.types import TaskKind
-        from raitap.utils.diagnostics import Module
-        from raitap.utils.errors import RaitapError, resolve_diagnostic_from_traceback
+        from raitap.utils.errors import RaitapError
 
         cfg = _make_config("resnet18")
         backend = TorchBackend(
@@ -965,18 +965,11 @@ class TestModelPreprocessingWrap:
             description="supplied",
         )
 
-        with pytest.raises(RaitapError, match="detection") as excinfo:
+        with pytest.raises(RaitapError, match="detection"):
             _apply_preprocessing(backend, cfg, resolved_preprocessing=resolved)
 
         # The detector must be left untouched (not wrapped).
         assert isinstance(backend.model, nn.Identity)
-
-        # The failure must attribute to the Models module so the CLI failure
-        # panel shows the correct source chip. A bare RaitapError raised inside
-        # ``src/raitap/models/`` is frame/traceback-walked to ``Module.models``;
-        # no explicit Diagnostic is needed.
-        diagnostic = resolve_diagnostic_from_traceback(excinfo.value.__traceback__)
-        assert diagnostic.module is Module.models
 
     def test_model_bundled_wrap_consumes_raw_input(self) -> None:
         from raitap.configs.schema import AppConfig, DataConfig, ModelConfig

--- a/src/raitap/models/tests/test_models.py
+++ b/src/raitap/models/tests/test_models.py
@@ -942,6 +942,42 @@ class TestModelPreprocessingWrap:
         assert wrapped_preprocessing is not model_module
         assert not wrapped_preprocessing.training
 
+    def test_model_input_transformation_rejected_for_detection(self) -> None:
+        """Detection models normalise inputs internally; an external model-side
+        transformation would double-process and is incompatible with the ragged
+        ``list[Tensor]`` detection input. ``_apply_preprocessing`` must reject it
+        rather than silently wrap the detector in ``nn.Sequential``."""
+        from raitap.data.preprocessing import ResolvedPreprocessing
+        from raitap.models.model import _apply_preprocessing
+        from raitap.types import TaskKind
+        from raitap.utils.diagnostics import Module
+        from raitap.utils.errors import RaitapError, resolve_diagnostic_from_traceback
+
+        cfg = _make_config("resnet18")
+        backend = TorchBackend(
+            nn.Identity(), device=torch.device("cpu"), task_kind=TaskKind.detection
+        )
+        resolved = ResolvedPreprocessing(
+            data_module=None,
+            model_module=nn.Dropout(),
+            data_origin="off",
+            model_origin="custom-file",
+            description="supplied",
+        )
+
+        with pytest.raises(RaitapError, match="detection") as excinfo:
+            _apply_preprocessing(backend, cfg, resolved_preprocessing=resolved)
+
+        # The detector must be left untouched (not wrapped).
+        assert isinstance(backend.model, nn.Identity)
+
+        # The failure must attribute to the Models module so the CLI failure
+        # panel shows the correct source chip. A bare RaitapError raised inside
+        # ``src/raitap/models/`` is frame/traceback-walked to ``Module.models``;
+        # no explicit Diagnostic is needed.
+        diagnostic = resolve_diagnostic_from_traceback(excinfo.value.__traceback__)
+        assert diagnostic.module is Module.models
+
     def test_model_bundled_wrap_consumes_raw_input(self) -> None:
         from raitap.configs.schema import AppConfig, DataConfig, ModelConfig
 

--- a/src/raitap/models/tests/test_models.py
+++ b/src/raitap/models/tests/test_models.py
@@ -971,6 +971,34 @@ class TestModelPreprocessingWrap:
         # The detector must be left untouched (not wrapped).
         assert isinstance(backend.model, nn.Identity)
 
+    def test_data_preprocessing_rejected_for_detection(self) -> None:
+        """A data-side ``data.preprocessing`` module is also rejected for
+        detection: a resize/crop/pad would change pixels while the box labels
+        stay untransformed, corrupting mAP and attribution coordinates. Guards
+        the model-side and data-side knobs symmetrically."""
+        from raitap.data.preprocessing import ResolvedPreprocessing
+        from raitap.models.model import _apply_preprocessing
+        from raitap.types import TaskKind
+        from raitap.utils.errors import RaitapError
+
+        cfg = _make_config("resnet18")
+        backend = TorchBackend(
+            nn.Identity(), device=torch.device("cpu"), task_kind=TaskKind.detection
+        )
+        resolved = ResolvedPreprocessing(
+            data_module=nn.Dropout(),
+            model_module=None,
+            data_origin="custom-file",
+            model_origin="off",
+            description="supplied",
+        )
+
+        with pytest.raises(RaitapError, match="detection"):
+            _apply_preprocessing(backend, cfg, resolved_preprocessing=resolved)
+
+        # The detector must be left untouched (not wrapped).
+        assert isinstance(backend.model, nn.Identity)
+
     def test_model_bundled_wrap_consumes_raw_input(self) -> None:
         from raitap.configs.schema import AppConfig, DataConfig, ModelConfig
 

--- a/src/raitap/pipeline/orchestrator.py
+++ b/src/raitap/pipeline/orchestrator.py
@@ -22,7 +22,6 @@ from raitap.pipeline.ui import print_summary
 from raitap.reporting import build_report, create_report, reporting_enabled
 from raitap.reporting.sample_selection import resolve_report_sample_selection
 from raitap.tracking import BaseTracker
-from raitap.types import TaskKind
 from raitap.utils.lazy import lazy_import
 
 if TYPE_CHECKING:
@@ -76,7 +75,7 @@ def _run_pipeline(
         data = Data(
             config,
             resolved_preprocessing=resolved_preprocessing,
-            task_kind=getattr(model.backend, "task_kind", TaskKind.classification),
+            task_kind=model.backend.task_kind,
         )
     _validate_report_sample_selection(config, data)
     if verbose:

--- a/src/raitap/pipeline/orchestrator.py
+++ b/src/raitap/pipeline/orchestrator.py
@@ -5,7 +5,7 @@ The actual phase work lives under :mod:`raitap.pipeline.phases`."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from raitap import raitap_log
 from raitap.data import Data
@@ -139,11 +139,7 @@ def run_without_tracking(
     """
     raitap_log.info("Running model forward pass...")
     with torch.no_grad():
-        # ``forward_pass`` is typed to accept ``torch.Tensor``; detection will
-        # pass a ``list[Tensor]`` at runtime — the forward-pass phase handles it
-        # (see issue #197).  Cast here so pyright doesn't flag the union type
-        # while keeping the call site byte-for-byte unchanged in behaviour.
-        forward_output = forward_pass(config, model.backend, cast("torch.Tensor", data.tensor))
+        forward_output = forward_pass(config, model.backend, data.tensor)
 
     metrics_eval = evaluate_metrics(config, forward_output, data.labels)
 

--- a/src/raitap/pipeline/orchestrator.py
+++ b/src/raitap/pipeline/orchestrator.py
@@ -5,7 +5,7 @@ The actual phase work lives under :mod:`raitap.pipeline.phases`."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from raitap import raitap_log
 from raitap.data import Data
@@ -22,6 +22,7 @@ from raitap.pipeline.ui import print_summary
 from raitap.reporting import build_report, create_report, reporting_enabled
 from raitap.reporting.sample_selection import resolve_report_sample_selection
 from raitap.tracking import BaseTracker
+from raitap.types import TaskKind
 from raitap.utils.lazy import lazy_import
 
 if TYPE_CHECKING:
@@ -72,7 +73,11 @@ def _run_pipeline(
             resolved_preprocessing=resolved_preprocessing,
             allow_unsafe_pickle=allow_unsafe_pickle,
         )
-        data = Data(config, resolved_preprocessing=resolved_preprocessing)
+        data = Data(
+            config,
+            resolved_preprocessing=resolved_preprocessing,
+            task_kind=getattr(model.backend, "task_kind", TaskKind.classification),
+        )
     _validate_report_sample_selection(config, data)
     if verbose:
         print_summary(config, model)
@@ -135,7 +140,11 @@ def run_without_tracking(
     """
     raitap_log.info("Running model forward pass...")
     with torch.no_grad():
-        forward_output = forward_pass(config, model.backend, data.tensor)
+        # ``forward_pass`` is typed to accept ``torch.Tensor``; detection will
+        # pass a ``list[Tensor]`` at runtime — the forward-pass phase handles it
+        # (see issue #197).  Cast here so pyright doesn't flag the union type
+        # while keeping the call site byte-for-byte unchanged in behaviour.
+        forward_output = forward_pass(config, model.backend, cast("torch.Tensor", data.tensor))
 
     metrics_eval = evaluate_metrics(config, forward_output, data.labels)
 
@@ -186,5 +195,5 @@ def _validate_report_sample_selection(config: AppConfig, data: Data) -> None:
     resolve_report_sample_selection(
         selection,
         sample_ids=data.sample_ids,
-        batch_size=int(data.tensor.shape[0]) if data.tensor.ndim > 0 else 0,
+        batch_size=len(data.tensor),
     )

--- a/src/raitap/pipeline/phases/assess_robustness.py
+++ b/src/raitap/pipeline/phases/assess_robustness.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from raitap import raitap_log
 from raitap.metrics import metrics_prediction_pair
@@ -95,7 +95,9 @@ def assess_robustness(
             config,
             name,
             model,
-            data.tensor,
+            # Non-classification short-circuited above, so this is the dense
+            # NCHW classification path; narrow the ``Data.tensor`` union.
+            cast("torch.Tensor", data.tensor),
             targets,
             input_metadata=input_metadata,
             sample_ids=data.sample_ids,

--- a/src/raitap/pipeline/phases/assess_transparency.py
+++ b/src/raitap/pipeline/phases/assess_transparency.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from raitap import raitap_log
 from raitap.configs import cfg_to_dict
@@ -101,7 +101,9 @@ def assess_transparency(
             config,
             name,
             model,
-            data.tensor,
+            # Detection routed away at the task-kind check above, so this is the
+            # dense-NCHW classification path; narrow the ``Data.tensor`` union.
+            cast("torch.Tensor", data.tensor),
             input_metadata=input_metadata,
             sample_ids=data.sample_ids,
             sample_names=data.sample_ids,

--- a/src/raitap/pipeline/phases/explain_detection.py
+++ b/src/raitap/pipeline/phases/explain_detection.py
@@ -16,7 +16,7 @@ import torch
 from raitap import raitap_log
 from raitap.models.task_wrappers import DetectionTarget, ScalarDetectionWrapper
 from raitap.transparency.contracts import DetectionBox
-from raitap.types import TaskKind
+from raitap.types import DetectionInputs, TaskKind
 from raitap.utils.errors import RaitapError
 
 if TYPE_CHECKING:
@@ -33,9 +33,21 @@ _DEFAULT_MAX_BOXES = 5
 _DEFAULT_IOU_THRESHOLD = 0.5
 
 
+def _sample_as_batch(inputs: torch.Tensor | DetectionInputs, index: int) -> torch.Tensor:
+    """Return a (1, C, H, W) tensor for sample *index* from either input form.
+
+    - ``list[Tensor]`` (ragged, one ``(C,H,W)`` per image): unsqueeze at dim 0.
+    - Dense ``(N,C,H,W)`` tensor: standard one-element slice preserving the
+      batch dimension.
+    """
+    if isinstance(inputs, list):
+        return inputs[index].unsqueeze(0)
+    return inputs[index : index + 1]
+
+
 def explain_detection(
     *,
-    inputs: torch.Tensor,
+    inputs: torch.Tensor | DetectionInputs,
     forward_output: ForwardOutput,
     backend: ModelBackend,
     explainer: Any,
@@ -130,7 +142,7 @@ def explain_detection(
         order = scores[raw_candidates].argsort(descending=True)
         top_k_raw_indices = raw_candidates[order[:max_boxes]]
 
-        sample_inputs = inputs[sample_index : sample_index + 1]
+        sample_inputs = _sample_as_batch(inputs, sample_index)
 
         for display_index, raw_index_value in enumerate(top_k_raw_indices.tolist()):
             raw_index = int(raw_index_value)

--- a/src/raitap/pipeline/phases/forward_pass.py
+++ b/src/raitap/pipeline/phases/forward_pass.py
@@ -89,6 +89,33 @@ def resolve_forward_batch_size(config: AppConfig) -> int:
     return configured
 
 
+def _validate_inputs_for_task(inputs: torch.Tensor | DetectionInputs, task_kind: TaskKind) -> None:
+    """Guard the input contract before ``len()``/slicing assumes it.
+
+    ``Data`` already validates at load time; this catches direct callers that
+    bypass it. Detection wants a ``list`` of per-image tensors; classification
+    wants a dense ``(N, ...)`` tensor (``len()`` on a stray ``(C, H, W)`` would
+    silently count channels, not samples).
+    """
+    if task_kind is TaskKind.detection:
+        if not isinstance(inputs, list):
+            raise TypeError(
+                "forward_pass(detection) expected a list of per-image (C, H, W) "
+                f"tensors; got {type(inputs).__name__}."
+            )
+        return
+    if not isinstance(inputs, torch.Tensor):
+        raise TypeError(
+            f"forward_pass({task_kind.value}) expected a dense (N, ...) tensor; "
+            f"got {type(inputs).__name__}."
+        )
+    if inputs.ndim < 2:
+        raise ValueError(
+            f"forward_pass({task_kind.value}) expected a batched (N, ...) tensor "
+            f"with ndim >= 2; got shape {tuple(inputs.shape)}."
+        )
+
+
 def forward_pass(
     config: AppConfig, backend: Any, inputs: torch.Tensor | DetectionInputs
 ) -> ForwardOutput:
@@ -105,9 +132,9 @@ def forward_pass(
     ``(N, C, H, W)`` tensor.
     """
     batch_size = resolve_forward_batch_size(config)
-    total_batch = len(inputs)
-
     task_kind = backend.task_kind
+    _validate_inputs_for_task(inputs, task_kind)
+    total_batch = len(inputs)
 
     if task_kind is TaskKind.detection:
         detection_predictions: list[dict[str, torch.Tensor]] = []

--- a/src/raitap/pipeline/phases/forward_pass.py
+++ b/src/raitap/pipeline/phases/forward_pass.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from raitap.pipeline.outputs import ForwardOutput
-from raitap.types import TaskKind
+from raitap.types import DetectionInputs, TaskKind
 from raitap.utils.lazy import lazy_import
 
 # Conservative default for prediction/metrics forwards. Transparency methods
@@ -89,16 +89,23 @@ def resolve_forward_batch_size(config: AppConfig) -> int:
     return configured
 
 
-def forward_pass(config: AppConfig, backend: Any, inputs: torch.Tensor) -> ForwardOutput:
+def forward_pass(
+    config: AppConfig, backend: Any, inputs: torch.Tensor | DetectionInputs
+) -> ForwardOutput:
     """Run the model backend forward in chunks of ``forward_batch_size``.
 
     Returns a typed :class:`ForwardOutput` keyed by ``backend.task_kind``.
     Classification backends produce ``predictions_tensor`` (CPU-detached);
     detection backends produce ``detection_predictions`` (a length-N list of
     per-sample dicts with ``boxes`` / ``scores`` / ``labels`` tensors).
+
+    For detection, ``inputs`` is a ragged ``list[torch.Tensor]`` with one
+    native-resolution ``(C, H, W)`` tensor per image (sizes may differ, so
+    they cannot be stacked). For classification, ``inputs`` is a dense
+    ``(N, C, H, W)`` tensor.
     """
     batch_size = resolve_forward_batch_size(config)
-    total_batch = int(inputs.shape[0])
+    total_batch = len(inputs)
 
     task_kind = getattr(backend, "task_kind", TaskKind.classification)
 
@@ -106,7 +113,7 @@ def forward_pass(config: AppConfig, backend: Any, inputs: torch.Tensor) -> Forwa
         detection_predictions: list[dict[str, torch.Tensor]] = []
         for start in range(0, total_batch, batch_size):
             end = min(start + batch_size, total_batch)
-            prepared_inputs = backend._prepare_inputs(inputs[start:end])
+            prepared_inputs = backend.prepare_detection_inputs(inputs[start:end])
             raw_output: Any = backend(prepared_inputs)
             if not isinstance(raw_output, list):
                 raise TypeError(

--- a/src/raitap/pipeline/phases/forward_pass.py
+++ b/src/raitap/pipeline/phases/forward_pass.py
@@ -148,6 +148,11 @@ def forward_pass(
                     f"got {type(raw_output).__name__}."
                 )
             for sample_dict in raw_output:
+                if not isinstance(sample_dict, dict):
+                    raise TypeError(
+                        "forward_pass(detection) expected each backend output entry to be a "
+                        f"dict of tensors; got {type(sample_dict).__name__}."
+                    )
                 detection_predictions.append({k: v.detach().cpu() for k, v in sample_dict.items()})
             del prepared_inputs, raw_output
             if torch.cuda.is_available():

--- a/src/raitap/pipeline/phases/forward_pass.py
+++ b/src/raitap/pipeline/phases/forward_pass.py
@@ -107,7 +107,7 @@ def forward_pass(
     batch_size = resolve_forward_batch_size(config)
     total_batch = len(inputs)
 
-    task_kind = getattr(backend, "task_kind", TaskKind.classification)
+    task_kind = backend.task_kind
 
     if task_kind is TaskKind.detection:
         detection_predictions: list[dict[str, torch.Tensor]] = []

--- a/src/raitap/pipeline/phases/tests/test_assess_robustness_detection.py
+++ b/src/raitap/pipeline/phases/tests/test_assess_robustness_detection.py
@@ -1,0 +1,88 @@
+"""Regression test for issue #197: assess_robustness short-circuits before
+touching ``data.tensor`` when ``task_kind == detection``.
+
+For detection, ``data.tensor`` is a ragged ``list[torch.Tensor]`` (variable
+per-image sizes).  The classification path later indexes it as a dense
+``(N, C, H, W)`` tensor via ``RobustnessAssessment``.  The guard at line ~78
+of ``assess_robustness.py`` must fire *before* that code path is reached so
+that no ``AttributeError`` / ``TypeError`` is raised on the ragged list.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import torch
+
+from raitap.configs.schema import AppConfig, RobustnessConfig
+from raitap.pipeline.outputs import ForwardOutput
+from raitap.pipeline.phases.assess_robustness import assess_robustness
+from raitap.types import TaskKind
+
+
+def _make_detection_forward_output(num_samples: int = 2) -> ForwardOutput:
+    """Minimal detection ForwardOutput that satisfies __post_init__."""
+    return ForwardOutput(
+        task_kind=TaskKind.detection,
+        batch_size=num_samples,
+        detection_predictions=[
+            {
+                "boxes": torch.zeros((0, 4)),
+                "scores": torch.zeros(0),
+                "labels": torch.zeros(0, dtype=torch.int64),
+            }
+            for _ in range(num_samples)
+        ],
+    )
+
+
+class _FakeData:
+    """Data stub with a ragged list[Tensor] as used by detection pipelines."""
+
+    def __init__(self, num_samples: int = 2) -> None:
+        # Deliberately ragged — different spatial sizes per image.
+        self.tensor: list[torch.Tensor] = [
+            torch.zeros(3, 40, 50),
+            torch.zeros(3, 60, 30),
+        ]
+        self.sample_ids = [f"img_{i}.jpg" for i in range(num_samples)]
+
+
+def test_assess_robustness_detection_returns_empty_and_skips_robustness_assessment() -> None:
+    """assess_robustness returns ([], []) for detection without touching data.tensor.
+
+    Regression for #197: when data.tensor is a ragged list[Tensor] the
+    detection guard must fire *before* RobustnessAssessment is constructed
+    (which would index data.tensor as a dense (N,C,H,W) tensor).
+    """
+    config = AppConfig(experiment_name="regression-197")
+    # Populate robustness so the first ``if not assessors`` guard does NOT
+    # short-circuit — we need to reach the task-kind check.
+    config.robustness = {
+        "fgsm": RobustnessConfig(
+            _target_="EmpiricalAttackAssessor",
+            algorithm="FGSM",
+        )
+    }
+
+    data = _FakeData(num_samples=2)
+    forward = _make_detection_forward_output(num_samples=2)
+
+    # Belt + suspenders: if the task-kind guard is ever removed or reordered,
+    # RobustnessAssessment would be called — catch that loudly.
+    with patch(
+        "raitap.pipeline.phases.assess_robustness.RobustnessAssessment",
+        side_effect=AssertionError("RobustnessAssessment must not be reached for detection"),
+    ):
+        results, visualisations = assess_robustness(
+            config,
+            model=None,  # type: ignore[arg-type]
+            data=data,  # type: ignore[arg-type]
+            forward_output=forward,
+            labels=None,
+            input_metadata=None,
+            resolved_preprocessing=None,
+        )
+
+    assert results == [], "expected empty results for detection task"
+    assert visualisations == [], "expected empty visualisations for detection task"

--- a/src/raitap/pipeline/phases/tests/test_explain_detection.py
+++ b/src/raitap/pipeline/phases/tests/test_explain_detection.py
@@ -340,7 +340,7 @@ def test_explain_detection_with_list_inputs(
 
     results = list(
         explain_detection(
-            inputs=list_inputs,  # type: ignore[arg-type]
+            inputs=list_inputs,
             forward_output=detection_forward_output,
             backend=backend,
             explainer=explainer,

--- a/src/raitap/pipeline/phases/tests/test_explain_detection.py
+++ b/src/raitap/pipeline/phases/tests/test_explain_detection.py
@@ -319,3 +319,64 @@ def test_explain_detection_rejects_invalid_max_boxes(
                 call_kwargs={},
             )
         )
+
+
+def test_explain_detection_with_list_inputs(
+    detection_forward_output: ForwardOutput, tmp_path: Path
+) -> None:
+    """When inputs is a list[Tensor] (ragged, one tensor per image),
+    each explain() call must receive a (1, C, H, W) tensor, not a list slice.
+    Tests both the correct shape and that different native resolutions are preserved."""
+    backend = TorchBackend(_FakeDetector(), task_kind=TaskKind.detection)
+    explainer = _RecordingExplainer()
+
+    # Two differently-sized images (C=3, but H*W differ) to confirm per-sample sizing.
+    # detection_forward_output has sample 0 with 2 boxes passing threshold=0.5 (scores 0.9, 0.7),
+    # sample 1 has zero detections.
+    list_inputs: list[torch.Tensor] = [
+        torch.zeros(3, 8, 8),  # sample 0 — native (3,8,8)
+        torch.zeros(3, 12, 10),  # sample 1 — native (3,12,10), but no detections → unused
+    ]
+
+    results = list(
+        explain_detection(
+            inputs=list_inputs,  # type: ignore[arg-type]
+            forward_output=detection_forward_output,
+            backend=backend,
+            explainer=explainer,
+            explainer_target="t",
+            explainer_name="x",
+            visualisers=[],
+            base_run_dir=tmp_path,
+            raitap_kwargs={"detection": {"score_threshold": 0.5, "max_boxes": 5}},
+            call_kwargs={},
+        )
+    )
+
+    # Same 2 boxes as the dense-tensor test (scores 0.9 and 0.7 for sample 0).
+    assert len(results) == 2
+    # The explainer must receive a (1, C, H, W) tensor for sample 0's native size.
+    for call in explainer.calls:
+        assert call["inputs_shape"] == (1, 3, 8, 8), (
+            f"Expected (1, 3, 8, 8) but got {call['inputs_shape']} — "
+            "list slice was probably passed instead of unsqueezed tensor"
+        )
+
+
+def test_sample_as_batch_helper_list_and_tensor() -> None:
+    """Unit-test _sample_as_batch directly for both list and dense tensor inputs."""
+    from raitap.pipeline.phases.explain_detection import _sample_as_batch
+
+    # List case — differently-sized tensors.
+    t0 = torch.zeros(3, 8, 8)
+    t1 = torch.zeros(3, 12, 10)
+    lst: list[torch.Tensor] = [t0, t1]
+    out0 = _sample_as_batch(lst, 0)
+    assert out0.shape == (1, 3, 8, 8)
+    out1 = _sample_as_batch(lst, 1)
+    assert out1.shape == (1, 3, 12, 10)
+
+    # Dense tensor case.
+    batch = torch.zeros(4, 3, 8, 8)
+    out = _sample_as_batch(batch, 2)
+    assert out.shape == (1, 3, 8, 8)

--- a/src/raitap/pipeline/phases/tests/test_forward_pass.py
+++ b/src/raitap/pipeline/phases/tests/test_forward_pass.py
@@ -1,0 +1,216 @@
+"""Tests for :func:`raitap.pipeline.phases.forward_pass.forward_pass`.
+
+Covers:
+- Detection forward pass with a ragged list of differently-sized tensors.
+- Classification forward pass regression (dense tensor, unchanged path).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+from torch import nn
+
+from raitap.models.backend import ModelBackend
+from raitap.pipeline.phases.forward_pass import forward_pass
+from raitap.types import TaskKind
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(batch_size: int = 32) -> Any:
+    """Return a minimal config stub accepted by resolve_forward_batch_size."""
+    return SimpleNamespace(
+        run=SimpleNamespace(forward_batch_size=batch_size),
+        data=SimpleNamespace(forward_batch_size=batch_size),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fake backends
+# ---------------------------------------------------------------------------
+
+
+class _FakeDetectionBackend(ModelBackend):
+    """Minimal detection backend stub that records the inputs it receives."""
+
+    supports_torch_autograd = True
+
+    def __init__(self, device: torch.device | None = None) -> None:
+        self.device = device or torch.device("cpu")
+        self._task_kind = TaskKind.detection
+        self.received_inputs: list[Any] = []
+
+    @property
+    def task_kind(self) -> TaskKind:
+        return self._task_kind
+
+    @property
+    def hardware_label(self) -> str:
+        return "fake-cpu"
+
+    def prepare_detection_inputs(self, inputs: list[torch.Tensor]) -> list[torch.Tensor]:
+        """Move each image tensor to the backend device (no reshape)."""
+        return [img.to(self.device) for img in inputs]
+
+    def __call__(self, inputs: list[torch.Tensor]) -> list[dict[str, torch.Tensor]]:  # type: ignore[override]
+        self.received_inputs.append(inputs)
+        return [
+            {
+                "boxes": torch.tensor([[0.0, 0.0, 5.0, 5.0]]),
+                "scores": torch.tensor([0.8]),
+                "labels": torch.tensor([1], dtype=torch.int64),
+            }
+            for _ in inputs
+        ]
+
+    def as_model_for_explanation(self) -> nn.Module:
+        raise NotImplementedError
+
+
+class _FakeClassificationBackend(ModelBackend):
+    """Minimal classification backend that echoes a fixed prediction tensor."""
+
+    supports_torch_autograd = True
+
+    def __init__(self, num_classes: int = 5) -> None:
+        self.num_classes = num_classes
+        self._task_kind = TaskKind.classification
+
+    @property
+    def task_kind(self) -> TaskKind:
+        return self._task_kind
+
+    @property
+    def hardware_label(self) -> str:
+        return "fake-cpu"
+
+    def _prepare_inputs(self, inputs: torch.Tensor) -> torch.Tensor:
+        return inputs
+
+    def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
+        n = inputs.shape[0]
+        return torch.zeros(n, self.num_classes)
+
+    def as_model_for_explanation(self) -> nn.Module:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Detection forward pass tests
+# ---------------------------------------------------------------------------
+
+
+def test_detection_forward_ragged_list_returns_correct_length() -> None:
+    """forward_pass with a ragged list[Tensor] produces detection_predictions of
+    correct length and does not crash on shape[0] or torch.stack."""
+    backend = _FakeDetectionBackend()
+    config = _make_config(batch_size=32)
+
+    # Two images at different native resolutions — cannot be stacked
+    inputs: list[torch.Tensor] = [
+        torch.zeros(3, 40, 50),
+        torch.zeros(3, 60, 30),
+    ]
+
+    result = forward_pass(config, backend, inputs)
+
+    assert result.task_kind is TaskKind.detection
+    assert result.batch_size == 2
+    assert result.detection_predictions is not None
+    assert len(result.detection_predictions) == 2
+
+
+def test_detection_forward_backend_receives_list_of_tensors() -> None:
+    """The backend __call__ must receive a list[Tensor], not a stacked tensor."""
+    backend = _FakeDetectionBackend()
+    config = _make_config(batch_size=32)
+
+    inputs: list[torch.Tensor] = [
+        torch.zeros(3, 40, 50),
+        torch.zeros(3, 60, 30),
+    ]
+
+    forward_pass(config, backend, inputs)
+
+    assert len(backend.received_inputs) == 1  # one chunk (batch_size=32 > 2)
+    chunk = backend.received_inputs[0]
+    assert isinstance(chunk, list)
+    assert all(isinstance(t, torch.Tensor) for t in chunk)
+
+
+def test_detection_forward_chunked_across_batch_size() -> None:
+    """With batch_size=1, the loop runs once per image; total predictions == num images."""
+    backend = _FakeDetectionBackend()
+    config = _make_config(batch_size=1)
+
+    inputs: list[torch.Tensor] = [
+        torch.zeros(3, 40, 50),
+        torch.zeros(3, 60, 30),
+        torch.zeros(3, 20, 80),
+    ]
+
+    result = forward_pass(config, backend, inputs)
+
+    assert result.batch_size == 3
+    assert result.detection_predictions is not None
+    assert len(result.detection_predictions) == 3
+    # Three separate chunks were passed to the model
+    assert len(backend.received_inputs) == 3
+
+
+def test_detection_forward_predictions_are_cpu_detached() -> None:
+    """Each per-sample dict in detection_predictions must have CPU tensors."""
+    backend = _FakeDetectionBackend()
+    config = _make_config(batch_size=32)
+
+    inputs: list[torch.Tensor] = [
+        torch.zeros(3, 40, 50),
+        torch.zeros(3, 60, 30),
+    ]
+
+    result = forward_pass(config, backend, inputs)
+
+    assert result.detection_predictions is not None
+    for sample_dict in result.detection_predictions:
+        for tensor in sample_dict.values():
+            assert tensor.device.type == "cpu"
+
+
+# ---------------------------------------------------------------------------
+# Classification regression test
+# ---------------------------------------------------------------------------
+
+
+def test_classification_forward_dense_tensor_unchanged() -> None:
+    """Classification branch: dense (N, C, H, W) tensor still works end-to-end."""
+    backend = _FakeClassificationBackend(num_classes=10)
+    config = _make_config(batch_size=32)
+
+    inputs = torch.zeros(4, 3, 8, 8)
+
+    result = forward_pass(config, backend, inputs)
+
+    assert result.task_kind is TaskKind.classification
+    assert result.batch_size == 4
+    assert result.predictions_tensor is not None
+    assert result.predictions_tensor.shape == (4, 10)
+
+
+def test_classification_forward_chunked_regression() -> None:
+    """Classification branch: chunked path (total > batch_size) still works."""
+    backend = _FakeClassificationBackend(num_classes=5)
+    config = _make_config(batch_size=2)
+
+    inputs = torch.zeros(6, 3, 8, 8)
+
+    result = forward_pass(config, backend, inputs)
+
+    assert result.task_kind is TaskKind.classification
+    assert result.batch_size == 6
+    assert result.predictions_tensor is not None
+    assert result.predictions_tensor.shape == (6, 5)

--- a/src/raitap/pipeline/phases/tests/test_forward_pass.py
+++ b/src/raitap/pipeline/phases/tests/test_forward_pass.py
@@ -231,6 +231,20 @@ def test_detection_forward_rejects_non_list_inputs() -> None:
         forward_pass(config, backend, torch.zeros(2, 3, 8, 8))
 
 
+def test_detection_forward_rejects_non_dict_backend_entries() -> None:
+    """A detection backend returning list[non-dict] must fail loud at the entry, not .items()."""
+
+    class _BadEntryBackend(_FakeDetectionBackend):
+        def __call__(self, inputs: list[torch.Tensor]) -> Any:  # type: ignore[override]
+            return [(0.9, "box") for _ in inputs]  # list, but tuples not dicts
+
+    backend = _BadEntryBackend()
+    config = _make_config()
+
+    with pytest.raises(TypeError, match="dict of tensors"):
+        forward_pass(config, backend, [torch.zeros(3, 8, 8)])
+
+
 def test_classification_forward_rejects_list_inputs() -> None:
     """A classification backend handed a list must fail loud."""
     backend = _FakeClassificationBackend()

--- a/src/raitap/pipeline/phases/tests/test_forward_pass.py
+++ b/src/raitap/pipeline/phases/tests/test_forward_pass.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 import torch
 from torch import nn
 
@@ -214,3 +215,35 @@ def test_classification_forward_chunked_regression() -> None:
     assert result.batch_size == 6
     assert result.predictions_tensor is not None
     assert result.predictions_tensor.shape == (6, 5)
+
+
+# ---------------------------------------------------------------------------
+# Input-contract guard tests
+# ---------------------------------------------------------------------------
+
+
+def test_detection_forward_rejects_non_list_inputs() -> None:
+    """A detection backend handed a dense tensor must fail loud, not slice it."""
+    backend = _FakeDetectionBackend()
+    config = _make_config()
+
+    with pytest.raises(TypeError, match="expected a list"):
+        forward_pass(config, backend, torch.zeros(2, 3, 8, 8))
+
+
+def test_classification_forward_rejects_list_inputs() -> None:
+    """A classification backend handed a list must fail loud."""
+    backend = _FakeClassificationBackend()
+    config = _make_config()
+
+    with pytest.raises(TypeError, match="expected a dense"):
+        forward_pass(config, backend, [torch.zeros(3, 8, 8)])  # type: ignore[arg-type]
+
+
+def test_classification_forward_rejects_unbatched_tensor() -> None:
+    """A 1-D tensor lacks a sample axis; reject before len()/slicing."""
+    backend = _FakeClassificationBackend()
+    config = _make_config()
+
+    with pytest.raises(ValueError, match="ndim >= 2"):
+        forward_pass(config, backend, torch.zeros(5))

--- a/src/raitap/tests/test_e2e_detection.py
+++ b/src/raitap/tests/test_e2e_detection.py
@@ -75,7 +75,10 @@ def test_detection_pipeline_e2e_via_fasterrcnn_mobilenet(tmp_path: Path) -> None
     from raitap.data.data import Data
 
     data = Data.__new__(Data)
-    data.tensor = images_tensor
+    # Detection batches are ragged ``list[Tensor]`` (one native-resolution
+    # ``(C, H, W)`` per image), not a dense ``NCHW`` tensor — exercise the
+    # canonical detection input path (issue #197).
+    data.tensor = [images_tensor[0]]
     data.sample_ids = sample_ids
     data.name = "udacity-e2e"
     data.source = "UdacitySelfDriving"

--- a/src/raitap/tests/test_memory_leaks.py
+++ b/src/raitap/tests/test_memory_leaks.py
@@ -142,11 +142,16 @@ def test_run_without_tracking_forward_output_is_cpu_and_detached() -> None:
     import torch.nn as nn
 
     from raitap.pipeline.orchestrator import run_without_tracking as _run_without_tracking
+    from raitap.types import TaskKind
 
     net = nn.Linear(4, 2, bias=False)
 
     class _Backend:
         hardware_label = "cpu"
+
+        @property
+        def task_kind(self) -> TaskKind:
+            return TaskKind.classification
 
         def _prepare_inputs(self, x: torch.Tensor) -> torch.Tensor:
             return x

--- a/src/raitap/tests/test_run_labels.py
+++ b/src/raitap/tests/test_run_labels.py
@@ -8,6 +8,7 @@ import torch
 
 import raitap.pipeline.orchestrator as run_pipeline
 from raitap.metrics import resolve_metric_targets
+from raitap.types import TaskKind
 
 if TYPE_CHECKING:
     from raitap.configs.schema import AppConfig
@@ -18,6 +19,10 @@ if TYPE_CHECKING:
 class _BackendStub:
     def __init__(self, output: torch.Tensor) -> None:
         self._output = output
+
+    @property
+    def task_kind(self) -> TaskKind:
+        return TaskKind.classification
 
     def _prepare_inputs(self, inputs: torch.Tensor) -> torch.Tensor:
         return inputs

--- a/src/raitap/tests/test_run_main.py
+++ b/src/raitap/tests/test_run_main.py
@@ -120,6 +120,10 @@ def test_forward_primary_tensor_batches_backend_calls() -> None:
         def __init__(self) -> None:
             self.prepared_batch_sizes: list[int] = []
 
+        @property
+        def task_kind(self) -> _TaskKind:
+            return _TaskKind.classification
+
         def _prepare_inputs(self, inputs: torch.Tensor) -> torch.Tensor:
             self.prepared_batch_sizes.append(int(inputs.shape[0]))
             return inputs

--- a/src/raitap/tests/test_run_main.py
+++ b/src/raitap/tests/test_run_main.py
@@ -377,7 +377,11 @@ def test_run_resolves_preprocessing_once_for_model_and_data(monkeypatch: MonkeyP
         resolved_preprocessing=resolved_preprocessing,
         allow_unsafe_pickle=False,
     )
-    data_factory.assert_called_once_with(config, resolved_preprocessing=resolved_preprocessing)
+    data_factory.assert_called_once_with(
+        config,
+        resolved_preprocessing=resolved_preprocessing,
+        task_kind=_TaskKind.classification,
+    )
     run_without_tracking.assert_called_once_with(
         config,
         model,

--- a/src/raitap/tests/test_run_main.py
+++ b/src/raitap/tests/test_run_main.py
@@ -45,6 +45,10 @@ class _BackendStub:
     def hardware_label(self) -> str:
         return "CPU"
 
+    @property
+    def task_kind(self) -> _TaskKind:
+        return _TaskKind.classification
+
     def _prepare_inputs(self, inputs: torch.Tensor) -> torch.Tensor:
         return inputs
 

--- a/src/raitap/types.py
+++ b/src/raitap/types.py
@@ -19,6 +19,16 @@ one source of truth.
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch
+
+#: A ragged batch of detection inputs: one native-resolution ``(C, H, W)``
+#: float32 tensor per image. Used as ``Data.tensor`` when
+#: ``task_kind == TaskKind.detection``.  Defined with ``TYPE_CHECKING`` so
+#: importing this module never triggers a real ``torch`` import.
+DetectionInputs = list["torch.Tensor"]
 
 
 class Hardware(StrEnum):


### PR DESCRIPTION
## Summary

Object-detection images are variable-size and cannot be stacked into a single dense `NCHW` tensor. The generic image loader raised `ValueError: Images have inconsistent shapes after preprocessing` and `examples/udacity-fasterrcnn` never ran end-to-end (the native-resolution detection path was never exercised through the CLI).

This represents a detection batch as a ragged `list[torch.Tensor]` — one native-resolution `(C, H, W)` tensor per image — gated by the model task-kind so **classification keeps its dense **``** path unchanged**. Resize and zero-pad are both rejected: they corrupt the attribution map and the mAP coordinate space and diverge from the direct-library fidelity reference. This matches torchvision's `List[Tensor]` input contract and Captum's per-sample semantics (see `docs/superpowers/specs/2026-05-24-object-detection-attribution-batching-research.md`).

Commits:

- `fix(data)` — `Data.task_kind` + ragged image loader; `len()`-based sample counts and `describe()` handle the list; consumers (`forward_pass`, `explain_detection`, orchestrator) branch per task-kind. `TorchBackend.prepare_detection_inputs` feeds the detector a per-image device list.
- `fix(models)` — reject `data.model_input_transformation` for detection (detectors normalise internally via `GeneralizedRCNNTransform`; an external model-side transform would double-process and is incompatible with the ragged input). The bundled detection preset was already a no-op, so this only guards an explicit, undocumented custom-file transform.
- `refactor(pipeline)` — access `model.backend.task_kind` directly instead of a `getattr` fallback (the base `ModelBackend` guarantees the property; fails loudly rather than silently mis-routing).

**Note (out of scope):** `test_detection_pipeline_e2e_via_fasterrcnn_mobilenet` fails because the model returns 0 boxes ≥0.5 on the 320×180 downsampled frame — confirmed identical on the base branch (verified via `git stash`), i.e. a pre-existing model-quality/threshold issue, not a regression here. Suggest a follow-up issue.

Closes [#197](https://github.com/CAIIVS/raitap/issues/197)

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — If this PR breaks compatibility (API, configs, file formats, etc.), the title uses `!` after the type or scope (e.g. `feat!:` or `feat(transparency)!:`). I understand that this change will have a **direct, disruptive impact** on package users. I ensured that **this change is absolutely necessary and cannot be delayed**.
- [x] **Contributor guide** — I’ve read [**Pull requests and commit messages**](https://caiivs.github.io/raitap/contributor/pull-requests.html) before requesting review.

## Optional

- [x] **Issue** — A GitHub issues is linked to this PR ("Development" section in the right sidebar).
- [x] **Docs** — User or contributor docs updated where needed.
- [x] **Tests** — New or updated tests cover the change.
