### PR TITLE
fix(transparency): upsample low-res CAM maps in detection visualiser

### DIFF
--- a/src/raitap/transparency/tests/test_detection_image_visualiser.py
+++ b/src/raitap/transparency/tests/test_detection_image_visualiser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import matplotlib.pyplot as plt
 import pytest
 import torch
 
@@ -122,3 +123,29 @@ def test_detection_image_visualiser_is_importable_from_visualisers_package() -> 
     assert pkg.DetectionImageVisualiser is DetectionImageVisualiser or (
         pkg.DetectionImageVisualiser.__name__ == "DetectionImageVisualiser"
     )
+
+
+def test_visualiser_upsamples_low_res_cam_to_full_image_extent() -> None:
+    """LayerGradCam yields a low-res spatial map; the overlay must span the
+    whole image, not sit in a top-left corner patch. Regression guard for the
+    detection visualiser missing the bilinear-upsample the classification path
+    already has (issue #203)."""
+    vis = DetectionImageVisualiser()
+    cam = torch.rand(1, 1, 8, 8)  # low-res CAM map, e.g. from LayerGradCam
+    inputs = torch.rand(1, 3, 64, 64)
+    ctx = VisualisationContext(
+        algorithm="LayerGradCam",
+        sample_names=["img_0"],
+        show_sample_names=False,
+        detection_box=_box(label_name="car"),
+    )
+
+    fig = vis.visualise(cam, inputs, context=ctx)
+    try:
+        main_ax = fig.get_axes()[0]
+        overlay = main_ax.images[1]  # images[0] = original; images[1] = attribution overlay
+        left, right, bottom, top = overlay.get_extent()
+        assert abs(right - left) == pytest.approx(64.0, abs=2.0)
+        assert abs(top - bottom) == pytest.approx(64.0, abs=2.0)
+    finally:
+        plt.close(fig)

--- a/src/raitap/transparency/visualisers/detection_image_visualiser.py
+++ b/src/raitap/transparency/visualisers/detection_image_visualiser.py
@@ -24,6 +24,7 @@ from raitap.transparency.visualisers.registration import transparency_visualiser
 from raitap.types import TaskKind
 
 from .base_visualiser import BaseVisualiser
+from .captum_visualisers import _resize_attr_to_hw
 
 if TYPE_CHECKING:
     import torch
@@ -103,6 +104,13 @@ class DetectionImageVisualiser(BaseVisualiser):
                 f"DetectionImageVisualiser expected (C, H, W) or (H, W) attribution; "
                 f"got shape {attr_arr.shape!r}."
             )
+        # Layer methods (e.g. LayerGradCam) yield low-res spatial maps; bilinear-
+        # upsample to the image so the heat overlay spans the full frame instead
+        # of a top-left corner patch. Mirrors the classification path
+        # (captum_visualisers._resize_attr_to_hw). Issue #203.
+        target_hw = img_hwc.shape[:2]
+        if attr_2d.shape != target_hw:
+            attr_2d = _resize_attr_to_hw(attr_2d, target_hw)
         attr_max = float(np.max(np.abs(attr_2d))) if attr_2d.size else 0.0
         if attr_max > 0:
             attr_2d = attr_2d / attr_max


### PR DESCRIPTION
## Summary

`DetectionImageVisualiser` drew a low-resolution CAM map (e.g. from `LayerGradCam`) at its native size in the **top-left corner** instead of over the full image — the attribution `imshow` had no `extent` and the map was never upsampled. Per-pixel families (IntegratedGradients, Saliency) were unaffected because their attributions are already image-resolution.

Fix: bilinear-upsample `attr_2d` to the image `H×W` before overlay, reusing the helper the classification visualiser already applies (`captum_visualisers._resize_attr_to_hw`). Matches Captum's documented pattern (upsample CAM via `LayerAttribution.interpolate` before overlay).

Closes #203.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — If this PR breaks compatibility (API, configs, file formats, etc.), the title uses `!` after the type or scope (e.g. `feat!:` or `feat(transparency)!:`). I understand that this change will have a **direct, disruptive impact** on package users. I ensured that **this change is absolutely necessary and cannot be delayed**. _(Non-breaking: render-only fix; title is `fix:`.)_
- [x] **Contributor guide** — I’ve read [**Pull requests and commit messages**](https://caiivs.github.io/raitap/contributor/pull-requests.html) before requesting review.

## Optional

- [x] **Issue** — A GitHub issues is linked to this PR ("Development" section in the right sidebar). _(#203, via "Closes".)_
- [x] **Docs** — User or contributor docs updated where needed.
- [x] **Tests** — New or updated tests cover the change. _(test_visualiser_upsamples_low_res_cam_to_full_image_extent; full visualiser + detection-transparency suites: 123 passed.)_
