### PR TITLE
fix(transparency): render all-zero attribution maps instead of crashing

### DIFF
--- a/src/raitap/transparency/visualisers/captum_visualisers.py
+++ b/src/raitap/transparency/visualisers/captum_visualisers.py
@@ -102,6 +102,59 @@ def _last_mappable(ax: Any) -> Any:
     return None
 
 
+def _captum_normalisation_degenerate(
+    attr: np.ndarray, sign: str, outlier_perc: float = 2.0
+) -> bool:
+    """Whether Captum's ``_normalize_attr`` would hit ``scale_factor == 0``.
+
+    An all-zero (or sign-empty, e.g. a non-positive map under ``sign="positive"``)
+    slice is a *valid* explainer output — it means the method found no attribution
+    of that sign — but Captum's normaliser asserts ``Cannot normalize by scale
+    factor = 0`` on it rather than rendering it. We mirror Captum's threshold maths
+    here (channel-summed reduction, sign filter, cumulative-sum percentile) so the
+    slice can be rendered flat instead of crashing the figure.
+    """
+    combined = np.sum(attr, axis=2) if attr.ndim == 3 else attr
+    if sign == "positive":
+        values = (combined > 0) * combined
+    elif sign == "negative":
+        values = np.abs((combined < 0) * combined)
+    else:  # "all" / "absolute_value"
+        values = np.abs(combined)
+    sorted_vals = np.sort(values.flatten())
+    if sorted_vals.size == 0:
+        return True
+    cum_sums = np.cumsum(sorted_vals)
+    total = float(cum_sums[-1])
+    if total == 0:
+        return True
+    threshold_id = int(np.where(cum_sums >= total * 0.01 * (100.0 - outlier_perc))[0][0])
+    return bool(sorted_vals[threshold_id] == 0)
+
+
+def _degenerate_note(sign: str) -> str:
+    """Sign-aware annotation for a valid all-zero attribution map."""
+    if sign == "positive":
+        return "no positive attribution"
+    if sign == "negative":
+        return "no negative attribution"
+    return "no attribution"
+
+
+def _render_flat_attribution(ax: Any, sign: str, base_title: str | None) -> None:
+    """Render a valid all-zero attribution as a flat map with an explanatory note.
+
+    The map is zero everywhere, so we show a uniform field (faithful to the data)
+    and annotate it so a reader reads it as a finding — the method assigned no
+    attribution of this sign — rather than a rendering glitch.
+    """
+    ax.imshow(np.zeros((1, 1)), cmap="gray", vmin=-1.0, vmax=1.0)
+    ax.set_xticks([])
+    ax.set_yticks([])
+    note = _degenerate_note(sign)
+    ax.set_title(f"{base_title}\n({note})" if base_title else f"({note})")
+
+
 def _input_kind(explanation: object) -> str:
     semantics = getattr(explanation, "semantics", None)
     input_spec = getattr(semantics, "input_spec", None)
@@ -366,29 +419,43 @@ class CaptumImageVisualiser(BaseVisualiser):
                     sample_name=sample_name,
                 )
 
-                _, _ = viz.visualize_image_attr(
-                    attr_i,
-                    orig_i,
-                    method="original_image",
-                    sign="all",
-                    show_colorbar=False,
-                    plt_fig_axis=(fig, original_ax),
-                    use_pyplot=False,
-                    title=original_title,
-                )
+                if _captum_normalisation_degenerate(attr_i, "all"):
+                    # ``original_image`` only displays the input, but Captum
+                    # normalises attr first and would assert on this slice.
+                    original_ax.imshow(orig_i)
+                    original_ax.set_xticks([])
+                    original_ax.set_yticks([])
+                    if original_title is not None:
+                        original_ax.set_title(original_title)
+                else:
+                    _, _ = viz.visualize_image_attr(
+                        attr_i,
+                        orig_i,
+                        method="original_image",
+                        sign="all",
+                        show_colorbar=False,
+                        plt_fig_axis=(fig, original_ax),
+                        use_pyplot=False,
+                        title=original_title,
+                    )
 
                 attr_viz_kwargs = dict(kwargs)
                 attr_viz_kwargs["title"] = attr_title
-                _, _ = viz.visualize_image_attr(
-                    attr_i,
-                    orig_i,
-                    method=self.method,
-                    sign=self.sign,
-                    show_colorbar=False,
-                    plt_fig_axis=(fig, attr_ax),
-                    use_pyplot=False,
-                    **attr_viz_kwargs,
-                )
+                if _captum_normalisation_degenerate(
+                    attr_i, self.sign, float(kwargs.get("outlier_perc", 2))
+                ):
+                    _render_flat_attribution(attr_ax, self.sign, attr_title)
+                else:
+                    _, _ = viz.visualize_image_attr(
+                        attr_i,
+                        orig_i,
+                        method=self.method,
+                        sign=self.sign,
+                        show_colorbar=False,
+                        plt_fig_axis=(fig, attr_ax),
+                        use_pyplot=False,
+                        **attr_viz_kwargs,
+                    )
                 if self.show_colorbar and colorbar_ax is not None:
                     mappable = _last_mappable(attr_ax)
                     if mappable is None:
@@ -402,17 +469,22 @@ class CaptumImageVisualiser(BaseVisualiser):
             if self.title is not None and "title" not in viz_kwargs:
                 viz_kwargs["title"] = self.title
 
-            # Let Captum render into our existing axes
-            _, _ = viz.visualize_image_attr(
-                attr_i,
-                orig_i,
-                method=self.method,
-                sign=self.sign,
-                show_colorbar=self.show_colorbar,
-                plt_fig_axis=(fig, ax),
-                use_pyplot=False,
-                **viz_kwargs,
-            )
+            if _captum_normalisation_degenerate(
+                attr_i, self.sign, float(kwargs.get("outlier_perc", 2))
+            ):
+                _render_flat_attribution(ax, self.sign, viz_kwargs.get("title"))
+            else:
+                # Let Captum render into our existing axes
+                _, _ = viz.visualize_image_attr(
+                    attr_i,
+                    orig_i,
+                    method=self.method,
+                    sign=self.sign,
+                    show_colorbar=self.show_colorbar,
+                    plt_fig_axis=(fig, ax),
+                    use_pyplot=False,
+                    **viz_kwargs,
+                )
             if show_sample_names and i < len(names):
                 base_title = ax.get_title().strip()
                 label = f"{base_title}: {names[i]}" if base_title else names[i]

--- a/src/raitap/transparency/visualisers/captum_visualisers.py
+++ b/src/raitap/transparency/visualisers/captum_visualisers.py
@@ -128,6 +128,15 @@ def _captum_normalisation_degenerate(
     total = float(cum_sums[-1])
     if total == 0:
         return True
+    # NB: this is *not* equivalent to the ``total == 0`` check above and must not be
+    # simplified to it. For the default ``outlier_perc=2`` the percentile lands deep
+    # in the non-zero tail, so the two agree — but Captum scales by the
+    # ``(100 - outlier_perc)``-percentile value, which is itself 0 when enough mass
+    # sits at zero (e.g. ``outlier_perc=100`` → 0th percentile → the min, which is 0
+    # whenever any pixel is zero). In those cases ``total > 0`` yet Captum still hits
+    # ``scale_factor == 0``; replicating its threshold here is what catches them.
+    # ``np.where`` is non-empty for any valid ``outlier_perc`` in [0, 100] because the
+    # final cum-sum (== total) always satisfies ``total >= total * 0.01 * percentile``.
     threshold_id = int(np.where(cum_sums >= total * 0.01 * (100.0 - outlier_perc))[0][0])
     return bool(sorted_vals[threshold_id] == 0)
 

--- a/src/raitap/transparency/visualisers/tests/test_visualisers.py
+++ b/src/raitap/transparency/visualisers/tests/test_visualisers.py
@@ -224,6 +224,35 @@ class TestCaptumImageVisualiser:
         assert len(fig.axes) >= 4  # at least one axes per sample
 
     @pytest.mark.usefixtures("needs_captum")
+    def test_all_zero_attribution_renders_flat_panel_with_note(self) -> None:
+        # An all-zero map is a valid explainer output ("no positive evidence for
+        # the predicted class"), not malformed input. Captum's normaliser asserts
+        # ``scale factor = 0`` on it; the visualiser must instead render the map
+        # honestly as a flat panel annotated with a sign-aware note.
+        visualiser = CaptumImageVisualiser(method="heat_map", sign="positive")
+        attributions = torch.zeros(1, 3, 32, 32)
+
+        fig = visualiser.visualise(attributions)
+
+        assert fig is not None
+        titles = " ".join(ax.get_title() for ax in fig.axes)
+        assert "no positive attribution" in titles
+
+    @pytest.mark.usefixtures("needs_captum")
+    def test_zero_attribution_sample_renders_alongside_valid_one(
+        self, sample_images: torch.Tensor
+    ) -> None:
+        # One degenerate sample must not abort the valid samples in the batch.
+        visualiser = CaptumImageVisualiser(method="heat_map", sign="positive")
+        attributions = torch.randn(2, 3, 32, 32).abs()
+        attributions[0] = 0.0  # first sample is the degenerate all-zero map
+
+        fig = visualiser.visualise(attributions, inputs=sample_images[:2], max_samples=2)
+
+        assert fig is not None
+        assert len(fig.axes) >= 2
+
+    @pytest.mark.usefixtures("needs_captum")
     def test_max_samples_limit(self) -> None:
         visualiser = CaptumImageVisualiser(method="heat_map")
         large_batch = torch.randn(64, 3, 32, 32)


### PR DESCRIPTION
## Summary

A single all-zero (or sign-empty) attribution slice aborted the **entire** transparency phase — and with it robustness + the report — via Captum's `AssertionError: Cannot normalize by scale factor = 0`.

An all-zero map is a **valid** explainer output (e.g. a GradCam map with no positive evidence for the predicted class under `sign="positive"`), not malformed input. Captum's normaliser is simply too strict: it asserts on "nothing to scale" rather than rendering a flat map.

This PR makes `CaptumImageVisualiser` **render the valid all-zero map** instead of forwarding it to a normaliser that refuses it:

- `_captum_normalisation_degenerate(attr, sign)` — pre-detects the degenerate slice by mirroring Captum's zero-scale condition (no reliance on Captum raising).
- `_render_flat_attribution(...)` — renders a uniform field with a sign-aware note (`no positive attribution` / `no negative attribution` / `no attribution`), drawn onto the axis so it reads as a finding, not a glitch.
- Guards the three per-sample call sites; the original-image panel falls back to a plain `imshow` of the input.

**Scope note:** the issue also lists per-method *fault isolation* in the orchestrator. That is intentionally **not** included here — the whole-phase abort was a downstream consequence of this one crash, so removing the crash removes the abort. Fault isolation is separate, broader hardening (touches the phase signature, `RunOutputs`, and the report) and is better as its own change. This PR is internal to the visualiser: **no public API, signature, or pipeline changes.**

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — Not a breaking change; no `!` needed (internal to the visualiser, no API/config/format change).
- [x] **Contributor guide** — I've read **Pull requests and commit messages** before requesting review.

## Optional

- [x] **Issue** _(optional)_ — Closes #206.
- [x] **Docs** _(optional)_ — No doc change needed.
- [x] **Tests** _(optional)_ — New tests cover the all-zero render (single + mixed batch).