### PR TITLE
refactor(transparency)!: rename ExplanationScope.COHORT to AGGREGATED

### DIFF
--- a/docs/contributor/transparency.md
+++ b/docs/contributor/transparency.md
@@ -45,7 +45,7 @@ All visualisers extend `BaseVisualiser` (`src/raitap/transparency/visualisers/ba
 | `supported_output_spaces` | `frozenset[ExplanationOutputSpace]` | Attribution coordinate spaces the visualiser handles. |
 | `supported_method_families` | `frozenset[MethodFamily]` | Method families the visualiser understands. |
 | `compatible_algorithms` | `frozenset[str]` | Optional algorithm allowlist; empty = all algorithms. |
-| `produces_scope` | `ExplanationScope \| None` | Set only when the visualiser *changes* the result scope (e.g. summarising local → cohort). Leave `None` to preserve the input scope. |
+| `produces_scope` | `ExplanationScope \| None` | Set only when the visualiser *changes* the result scope (e.g. summarising local → aggregated). Leave `None` to preserve the input scope. |
 | `scope_definition_step` | `ScopeDefinitionStep \| None` | Where the produced scope was defined; set when `produces_scope` is set. |
 | `visual_summary` | `VisualSummarySpec \| None` | Metadata for summary visualisations. |
 | `embeds_original_input` | `bool` | Whether the normal layout includes an original-input panel alongside the rendered explanation. |
@@ -58,7 +58,7 @@ Plus two instance-level hooks:
 **Rules of thumb**
 
 - Per-sample renderers (heatmap, overlay): preserve scope — leave `produces_scope = None`.
-- Summary renderers (SHAP bar/beeswarm, tabular bar): consume local attributions and produce `COHORT` — set `produces_scope = ExplanationScope.COHORT` + `scope_definition_step = ScopeDefinitionStep.VISUALISER_SUMMARY`.
+- Summary renderers (SHAP bar/beeswarm, tabular bar): consume local attributions and produce `AGGREGATED` — set `produces_scope = ExplanationScope.AGGREGATED` + `scope_definition_step = ScopeDefinitionStep.VISUALISER_SUMMARY`.
 - Don't promote arbitrary debug batches or representative montages to `GLOBAL`.
 - Image visualisers with `embeds_original_input = True` **must** accept the runtime kwarg `include_original_input`. Reporting uses this to render one shared sample thumbnail and suppress repeated originals in sample-major compact local report sections. Keep YAML constructor names backward-compatible (the built-in image visualisers still accept `include_original_image`).
 
@@ -75,10 +75,10 @@ Describes the semantic breadth of an explanation or rendered visualisation:
 | Scope | Meaning |
 | --- | --- |
 | `LOCAL` | Explains individual input samples. Current Captum and SHAP attribution explainers produce local explanation artefacts. |
-| `COHORT` | Summarises the selected input batch or cohort. Current SHAP bar, SHAP beeswarm, and tabular bar visualisers produce cohort visual summaries when they aggregate local attributions. |
+| `AGGREGATED` | Summarises the selected input batch. Current SHAP bar, SHAP beeswarm, and tabular bar visualisers produce aggregated visual summaries when they aggregate local attributions. |
 | `GLOBAL` | Represents a dataset, population, or model-wide result. The enum keeps this concept available, but built-in visualisers do not promote arbitrary batches to global outputs. |
 
-The `COHORT` distinction is intentional. A SHAP plotting API may call a bar or beeswarm figure "global", but RAITAP only treats it as global when a first-class dataset, population, or model-level contract proves that scope.
+The `AGGREGATED` scope distinction is intentional. A SHAP plotting API may call a bar or beeswarm figure "global", but RAITAP only treats it as global when a first-class dataset, population, or model-level contract proves that scope.
 
 ### `ScopeDefinitionStep`
 
@@ -89,7 +89,7 @@ Records where the scope was defined:
 | `EXPLAINER_OUTPUT` | The explainer produced an artefact with this scope. |
 | `VISUALISER_SUMMARY` | The visualiser changed the result scope by summarising another explanation artefact. |
 
-For example, an attribution explainer produces local attributions with `EXPLAINER_OUTPUT`. A summary visualiser consumes those local attributions and produces a cohort figure with `VISUALISER_SUMMARY`.
+For example, an attribution explainer produces local attributions with `EXPLAINER_OUTPUT`. A summary visualiser consumes those local attributions and produces an aggregated figure with `VISUALISER_SUMMARY`.
 
 `VisualisationResult.scope` describes what the rendered figure represents. Reporting placement comes from this rendered visualisation scope, not from legacy report-placement strings.
 

--- a/docs/modules/reporting/output.md
+++ b/docs/modules/reporting/output.md
@@ -23,7 +23,7 @@ reports/
 ├── report.zip
 ├── report_manifest.json
 └── _assets/
-    ├── ... native global or cohort summary figures
+    ├── ... native global or aggregated summary figures
     └── ... selected local sample figures
 ```
 
@@ -46,7 +46,7 @@ Generated reports use this structure:
 3. **Robustness Details**
 4. **Appendix**
 
-Missing metrics, global, cohort, and robustness sections are omitted. If no
+Missing metrics, global explanations, aggregated explanations, and robustness sections are omitted. If no
 local explanations are present, the transparency details render a short
 placeholder rather than an empty card.
 
@@ -69,9 +69,9 @@ the configured visualiser or underlying library with `GLOBAL` scope.
 Current built-in transparency visualisers do not produce global outputs, so this
 section is usually omitted.
 
-### Cohort Explanations
+### Aggregated Explanations
 
-Cohort explanations summarize the selected input batch or cohort. Current SHAP
+Aggregated explanations summarize the selected input batch. Current SHAP
 bar, SHAP beeswarm, and tabular bar summaries belong here because they aggregate
 local attribution values from the selected samples. RAITAP intentionally does
 not call those figures global unless a future first-class dataset, population,

--- a/docs/modules/transparency/frameworks-and-libraries.md
+++ b/docs/modules/transparency/frameworks-and-libraries.md
@@ -73,11 +73,11 @@ visualisers against the explanation artifact they receive. In short:
 | `CaptumTextVisualiser` | Local token-sequence attributions | Local visualisation | Requires explicit token metadata. |
 | `CaptumTimeSeriesVisualiser` | Local time-series attributions | Local visualisation | Requires explicit time-series metadata. |
 | `ShapImageVisualiser` | Local image-shaped SHAP values from `GradientExplainer` or `DeepExplainer` | Local visualisation | Intended for pixel-level SHAP values, not tabular SHAP outputs. |
-| `ShapBarVisualiser` | Local tabular or interpretable SHAP attributions | Cohort visual summary | Summarizes the selected batch or cohort, so it is reported under Cohort Explanations. |
-| `ShapBeeswarmVisualiser` | Local tabular or interpretable SHAP attributions | Cohort visual summary | Summarizes attribution distributions for the selected batch or cohort. |
+| `ShapBarVisualiser` | Local tabular or interpretable SHAP attributions | Aggregated visual summary | Summarizes the selected batch, so it is reported under Aggregated Explanations. |
+| `ShapBeeswarmVisualiser` | Local tabular or interpretable SHAP attributions | Aggregated visual summary | Summarizes attribution distributions for the selected batch. |
 | `ShapForceVisualiser` | Local tabular or interpretable SHAP attributions for one selected sample | Local visualisation | Preserves local scope. |
 | `ShapWaterfallVisualiser` | Local tabular or interpretable SHAP attributions for one selected sample | Local visualisation | Preserves local scope. |
-| `TabularBarChartVisualiser` | Local tabular or interpretable attributions | Cohort visual summary | Uses mean absolute attribution-style aggregation for the selected batch or cohort. |
+| `TabularBarChartVisualiser` | Local tabular or interpretable attributions | Aggregated visual summary | Uses mean absolute attribution-style aggregation for the selected batch. |
 
 See {doc}`visualisers` for per-visualiser previews, constructor kwargs, and
 modality constraints. Contributor-facing details about semantic contracts are
@@ -194,7 +194,7 @@ Only `KernelExplainer` is compatible.
 #### Visualiser compatibility
 
 The following SHAP visualisers render tabular or interpretable SHAP values and
-produce cohort summaries:
+produce aggregated summaries:
 
 - `ShapBarVisualiser`
 - `ShapBeeswarmVisualiser`
@@ -333,7 +333,7 @@ transparency = {
 }
 ```
 
-**Note:** `ShapImageVisualiser` requires pixel-level SHAP values from `GradientExplainer` or `DeepExplainer`. Other SHAP visualisers are intended for tabular or interpretable feature outputs and are treated as cohort summaries when they aggregate the selected batch.
+**Note:** `ShapImageVisualiser` requires pixel-level SHAP values from `GradientExplainer` or `DeepExplainer`. Other SHAP visualisers are intended for tabular or interpretable feature outputs and are treated as aggregated summaries when they aggregate the selected batch.
 
 ## Third-party adapters
 

--- a/docs/modules/transparency/visualisers.md
+++ b/docs/modules/transparency/visualisers.md
@@ -117,7 +117,7 @@ layout.
 
 ### ShapBarVisualiser
 
-Mean-absolute-attribution bar chart across the cohort, one bar per input
+Mean-absolute-attribution bar chart across the selected batch, one bar per input
 feature. Use it as the headline "what matters on average?" figure for any
 tabular or interpretable-features explanation.
 
@@ -128,8 +128,8 @@ Wraps `shap.summary_plot(plot_type="bar")`.
 | `feature_names` | `None` | Optional list of feature labels. Falls back to SHAP's `f0 … fN` defaults. |
 | `max_display` | `20` | Maximum number of features to render. |
 
-Scope: `LOCAL` (consumes local attributions). Produces a cohort visual
-summary so reporting places the figure under cohort explanations. Output
+Scope: `LOCAL` (consumes local attributions). Produces an aggregated visual
+summary so reporting places the figure under aggregated explanations. Output
 spaces: `INPUT_FEATURES`, `INTERPRETABLE_FEATURES`. Method family: `SHAPLEY`.
 Requires `(B, F)` tabular or interpretable attributions.
 
@@ -149,7 +149,7 @@ Wraps `shap.summary_plot()` (default `plot_type="dot"`).
 | `feature_names` | `None` | Optional list of feature labels. |
 | `max_display` | `20` | Maximum number of features to render. |
 
-Scope: `LOCAL` consumed, cohort visual summary produced. Output spaces:
+Scope: `LOCAL` consumed, aggregated visual summary produced. Output spaces:
 `INPUT_FEATURES`, `INTERPRETABLE_FEATURES`. Method family: `SHAPLEY`.
 Requires `(B, F)` tabular or interpretable attributions; passing `inputs`
 unlocks the colour-by-feature-value channel.
@@ -230,7 +230,7 @@ or `TreeExplainer`.
 
 Framework-agnostic mean-absolute-attribution bar chart for tabular features.
 Use it when the explainer is Captum (or anything else) rather than SHAP and
-you still want the same "what matters on average?" cohort summary.
+you still want the same "what matters on average?" aggregated summary.
 
 Wraps a small Matplotlib renderer (no third-party plotting dependency).
 
@@ -238,7 +238,7 @@ Wraps a small Matplotlib renderer (no third-party plotting dependency).
 |---|---|---|
 | `feature_names` | `None` | List of feature names for x-axis labels. |
 
-Scope: `LOCAL` consumed, cohort visual summary produced. Output spaces:
+Scope: `LOCAL` consumed, aggregated visual summary produced. Output spaces:
 `INPUT_FEATURES`, `INTERPRETABLE_FEATURES`. All method families are
 accepted. Requires `(B, F)` tabular attributions; rejects image, text, and
 time-series modalities.

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -105,9 +105,9 @@ def build_report(config: AppConfig, outputs: RunOutputs) -> BuiltReport:
     if global_section is not None:
         sections.append(global_section)
 
-    cohort_section = _build_cohort_section(outputs, assets_dir=assets_dir)
-    if cohort_section is not None:
-        sections.append(cohort_section)
+    aggregated_section = _build_aggregated_section(outputs, assets_dir=assets_dir)
+    if aggregated_section is not None:
+        sections.append(aggregated_section)
 
     local_section = _build_local_section(
         outputs,
@@ -171,7 +171,7 @@ def build_merged_report(
     sections_by_title: dict[str, list[ReportGroup]] = {
         "Metrics": [],
         "Global Explanations": [],
-        "Cohort Explanations": [],
+        "Aggregated Explanations": [],
         "Local Explanations": [],
         "Robustness": [],
     }
@@ -611,19 +611,19 @@ def _build_global_section(outputs: RunOutputs, *, assets_dir: Path) -> ReportSec
     )
 
 
-def _build_cohort_section(outputs: RunOutputs, *, assets_dir: Path) -> ReportSection | None:
+def _build_aggregated_section(outputs: RunOutputs, *, assets_dir: Path) -> ReportSection | None:
     groups = _native_scope_groups(
         outputs.visualisations,
         scope=ExplanationScope.AGGREGATED,
-        role="cohort",
+        role="aggregated",
         assets_dir=assets_dir,
     )
     if not groups:
         return None
     return ReportSection.from_groups(
-        "Cohort Explanations",
+        "Aggregated Explanations",
         groups,
-        metadata={"section_role": "cohort"},
+        metadata={"section_role": "aggregated"},
     )
 
 

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -614,7 +614,7 @@ def _build_global_section(outputs: RunOutputs, *, assets_dir: Path) -> ReportSec
 def _build_cohort_section(outputs: RunOutputs, *, assets_dir: Path) -> ReportSection | None:
     groups = _native_scope_groups(
         outputs.visualisations,
-        scope=ExplanationScope.COHORT,
+        scope=ExplanationScope.AGGREGATED,
         role="cohort",
         assets_dir=assets_dir,
     )

--- a/src/raitap/reporting/templates/_local.html.j2
+++ b/src/raitap/reporting/templates/_local.html.j2
@@ -16,10 +16,10 @@
     </section>
   {% endif %}
 
-  {% if view.cohort_groups %}
+  {% if view.aggregated_groups %}
     <section class="subsection">
-      <h3>Cohort</h3>
-      {% for group in view.cohort_groups %}
+      <h3>Aggregated</h3>
+      {% for group in view.aggregated_groups %}
         <article class="card compact-card">
           <h4>{{ group.heading }}</h4>
           {% for image in group.image_srcs %}<img class="figure" src="{{ image }}" alt="{{ group.heading }}">{% endfor %}

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -421,10 +421,10 @@ def test_build_report_skips_global_section_for_local_only_outputs(tmp_path: Path
     assert [section.title for section in report.sections] == ["Local Explanations"]
 
 
-def test_build_report_places_cohort_visualisations_between_global_and_local(
+def test_build_report_places_aggregated_visualisations_between_global_and_local(
     tmp_path: Path,
 ) -> None:
-    config = AppConfig(experiment_name="cohort")
+    config = AppConfig(experiment_name="aggregated")
     set_output_root(config, tmp_path)
     config.reporting = ReportingConfig(_target_="PDFReporter", filename="report.pdf")
 
@@ -433,25 +433,25 @@ def test_build_report_places_cohort_visualisations_between_global_and_local(
         attributions=torch.rand(2, 1, 4, 4),
         inputs=torch.rand(2, 1, 4, 4),
         run_dir=tmp_path / "transparency" / "exp",
-        experiment_name="cohort",
+        experiment_name="aggregated",
         explainer_target="t",
         algorithm="IntegratedGradients",
         semantics=_local_image_semantics((2, 1, 4, 4)),
         explainer_name="captum_ig",
         visualisers=[ConfiguredVisualiser(visualiser=_LocalImageVisualiser())],
     )
-    native_cohort_path = _write_test_image(tmp_path / "native_cohort.png")
-    native_cohort = VisualisationResult(
+    native_aggregated_path = _write_test_image(tmp_path / "native_aggregated.png")
+    native_aggregated = VisualisationResult(
         explanation=explanation,
         figure=plt.figure(),
-        visualiser_name="Cohort_0",
-        visualiser_target="test.Cohort_0",
-        output_path=native_cohort_path,
+        visualiser_name="Aggregated_0",
+        visualiser_target="test.Aggregated_0",
+        output_path=native_aggregated_path,
         scope=ExplanationScope.AGGREGATED,
     )
     outputs = RunOutputs(
         explanations=[explanation],
-        visualisations=[native_cohort],
+        visualisations=[native_aggregated],
         metrics=_MetricsStub(metrics_image),  # type: ignore[arg-type]
         forward_output=_fo(torch.tensor([[0.1, 0.9], [0.8, 0.2]])),
         prediction_summaries=(
@@ -464,10 +464,10 @@ def test_build_report_places_cohort_visualisations_between_global_and_local(
 
     assert [section.title for section in report.sections] == [
         "Metrics",
-        "Cohort Explanations",
+        "Aggregated Explanations",
         "Local Explanations",
     ]
-    assert report.sections[1].groups[0].metadata["role"] == "cohort"
+    assert report.sections[1].groups[0].metadata["role"] == "aggregated"
 
 
 def test_build_report_local_assets_are_staged_and_closed(tmp_path: Path) -> None:
@@ -1837,7 +1837,7 @@ def test_build_merged_report_deduplicates_identical_metrics_only(tmp_path: Path)
     assert len(sections["Local Explanations"].groups) == 3
 
 
-def test_build_merged_report_preserves_present_section_order_with_cohort(
+def test_build_merged_report_preserves_present_section_order_with_aggregated(
     tmp_path: Path,
 ) -> None:
     sweep_dir = tmp_path / "multirun"
@@ -1845,7 +1845,7 @@ def test_build_merged_report_preserves_present_section_order_with_cohort(
     _write_child_manifest(
         sweep_dir / "0",
         heading="Metrics A",
-        include_cohort=True,
+        include_aggregated=True,
         include_local=True,
     )
     child_manifests: list[tuple[str, str | None, ReportManifest]] = [
@@ -1865,7 +1865,7 @@ def test_build_merged_report_preserves_present_section_order_with_cohort(
 
     assert [section.title for section in report.sections] == [
         "Metrics",
-        "Cohort Explanations",
+        "Aggregated Explanations",
         "Local Explanations",
     ]
 
@@ -2043,7 +2043,7 @@ def _write_child_manifest(
     *,
     heading: str,
     table_rows: tuple[tuple[str, str], ...] = (("accuracy", "0.9000"),),
-    include_cohort: bool = False,
+    include_aggregated: bool = False,
     include_local: bool = False,
 ) -> None:
     report_dir = child_dir / "reports"
@@ -2063,16 +2063,16 @@ def _write_child_manifest(
         )
     ]
     if include_local:
-        if include_cohort:
-            cohort_asset = _write_test_image(report_dir / "_assets" / "cohort.png")
+        if include_aggregated:
+            aggregated_asset = _write_test_image(report_dir / "_assets" / "aggregated.png")
             sections.append(
                 ReportSection.from_groups(
-                    "Cohort Explanations",
+                    "Aggregated Explanations",
                     [
                         ReportGroup(
-                            heading=f"Cohort {heading}",
-                            images=(cohort_asset,),
-                            metadata={"role": "cohort"},
+                            heading=f"Aggregated {heading}",
+                            images=(aggregated_asset,),
+                            metadata={"role": "aggregated"},
                         )
                     ],
                 )

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -447,7 +447,7 @@ def test_build_report_places_cohort_visualisations_between_global_and_local(
         visualiser_name="Cohort_0",
         visualiser_target="test.Cohort_0",
         output_path=native_cohort_path,
-        scope=ExplanationScope.COHORT,
+        scope=ExplanationScope.AGGREGATED,
     )
     outputs = RunOutputs(
         explanations=[explanation],

--- a/src/raitap/reporting/view_model.py
+++ b/src/raitap/reporting/view_model.py
@@ -126,7 +126,7 @@ class ReportView:
     summary: SummaryView
     metrics: MetricsView | None
     global_groups: tuple[GenericGroupView, ...]
-    cohort_groups: tuple[GenericGroupView, ...]
+    aggregated_groups: tuple[GenericGroupView, ...]
     local_samples: tuple[LocalSampleView, ...]
     robustness_assessors: tuple[RobustnessAssessorView, ...]
     appendix: AppendixView
@@ -143,7 +143,7 @@ def build_view(
     metadata = {} if metadata is None else metadata
     metrics: MetricsView | None = None
     global_groups: tuple[GenericGroupView, ...] = ()
-    cohort_groups: tuple[GenericGroupView, ...] = ()
+    aggregated_groups: tuple[GenericGroupView, ...] = ()
     local_samples: tuple[LocalSampleView, ...] = ()
     robustness_assessors: tuple[RobustnessAssessorView, ...] = ()
 
@@ -153,8 +153,8 @@ def build_view(
             metrics = _build_metrics_view(section)
         elif role == "global":
             global_groups = _build_generic_groups(section)
-        elif role == "cohort":
-            cohort_groups = _build_generic_groups(section)
+        elif role == "aggregated":
+            aggregated_groups = _build_generic_groups(section)
         elif role == "local":
             local_samples = _build_local_samples(section)
         elif role == "robustness":
@@ -195,7 +195,7 @@ def build_view(
         summary=summary,
         metrics=metrics,
         global_groups=global_groups,
-        cohort_groups=cohort_groups,
+        aggregated_groups=aggregated_groups,
         local_samples=local_samples,
         robustness_assessors=robustness_assessors,
         appendix=AppendixView(sections=tuple(sections)),
@@ -206,7 +206,7 @@ def _section_role(section: ReportSection) -> str:
     raw = str(section.metadata.get("section_role", ""))
     aliases = {
         "global_explanations": "global",
-        "cohort_explanations": "cohort",
+        "aggregated_explanations": "aggregated",
         "local_explanations": "local",
     }
     return aliases.get(raw, raw)

--- a/src/raitap/transparency/contracts.py
+++ b/src/raitap/transparency/contracts.py
@@ -35,7 +35,7 @@ class ExplanationScope(StrEnum):
     """Semantic breadth represented by an explanation artifact."""
 
     LOCAL = "local"
-    COHORT = "cohort"
+    AGGREGATED = "aggregated"
     GLOBAL = "global"
 
 

--- a/src/raitap/transparency/tests/test_contracts.py
+++ b/src/raitap/transparency/tests/test_contracts.py
@@ -52,7 +52,7 @@ explainer_output_scope = contracts.explainer_output_scope
 
 
 def test_semantic_enum_members_are_exact_and_not_placeholders() -> None:
-    assert {member.name for member in ExplanationScope} == {"LOCAL", "COHORT", "GLOBAL"}
+    assert {member.name for member in ExplanationScope} == {"LOCAL", "AGGREGATED", "GLOBAL"}
     assert {member.name for member in ScopeDefinitionStep} == {
         "EXPLAINER_OUTPUT",
         "VISUALISER_SUMMARY",

--- a/src/raitap/transparency/tests/test_results.py
+++ b/src/raitap/transparency/tests/test_results.py
@@ -605,7 +605,7 @@ def test_render_visualisation_for_scope_targets_one_visualiser_and_forwards_kwar
 
 def test_render_visualisation_for_scope_returns_none_for_scope_mismatch(tmp_path: Path) -> None:
     class _CohortVisualiser(BaseVisualiser):
-        produces_scope = ExplanationScope.COHORT
+        produces_scope = ExplanationScope.AGGREGATED
 
         def visualise(
             self,

--- a/src/raitap/transparency/tests/test_results.py
+++ b/src/raitap/transparency/tests/test_results.py
@@ -604,7 +604,7 @@ def test_render_visualisation_for_scope_targets_one_visualiser_and_forwards_kwar
 
 
 def test_render_visualisation_for_scope_returns_none_for_scope_mismatch(tmp_path: Path) -> None:
-    class _CohortVisualiser(BaseVisualiser):
+    class _AggregatedVisualiser(BaseVisualiser):
         produces_scope = ExplanationScope.AGGREGATED
 
         def visualise(
@@ -627,7 +627,7 @@ def test_render_visualisation_for_scope_returns_none_for_scope_mismatch(tmp_path
         explainer_target="t",
         algorithm="a",
         semantics=_semantics(),
-        visualisers=[ConfiguredVisualiser(visualiser=_CohortVisualiser())],
+        visualisers=[ConfiguredVisualiser(visualiser=_AggregatedVisualiser())],
     )
 
     assert explanation.render_visualisation_for_scope(0, scope="local") is None

--- a/src/raitap/transparency/visualisers/shap_visualisers.py
+++ b/src/raitap/transparency/visualisers/shap_visualisers.py
@@ -182,7 +182,7 @@ class _TabularSummaryContractMixin(BaseVisualiser):
         }
     )
     supported_method_families: ClassVar[frozenset[MethodFamily]] = frozenset({MethodFamily.SHAPLEY})
-    produces_scope: ClassVar[ExplanationScope | None] = ExplanationScope.COHORT
+    produces_scope: ClassVar[ExplanationScope | None] = ExplanationScope.AGGREGATED
     scope_definition_step: ClassVar[ScopeDefinitionStep | None] = (
         ScopeDefinitionStep.VISUALISER_SUMMARY
     )

--- a/src/raitap/transparency/visualisers/tabular_visualiser.py
+++ b/src/raitap/transparency/visualisers/tabular_visualiser.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
         }
     ),
     supported_method_families=frozenset(MethodFamily),
-    produces_scope=ExplanationScope.COHORT,
+    produces_scope=ExplanationScope.AGGREGATED,
     scope_definition_step=ScopeDefinitionStep.VISUALISER_SUMMARY,
     visual_summary=VisualSummarySpec(
         summary_type="tabular_bar",

--- a/src/raitap/transparency/visualisers/tests/test_visualisers.py
+++ b/src/raitap/transparency/visualisers/tests/test_visualisers.py
@@ -509,7 +509,7 @@ class TestTabularBarChartVisualiser:
         visualiser = TabularBarChartVisualiser()
         assert visualiser is not None
 
-    def test_contract_produces_cohort_visualiser_summary(self) -> None:
+    def test_contract_produces_aggregated_visualiser_summary(self) -> None:
         assert TabularBarChartVisualiser.produces_scope is ExplanationScope.AGGREGATED
         assert (
             TabularBarChartVisualiser.scope_definition_step
@@ -832,7 +832,7 @@ class TestShapBarVisualiser:
         visualiser = ShapBarVisualiser()
         assert visualiser is not None
 
-    def test_contract_produces_cohort_visualiser_summary(self) -> None:
+    def test_contract_produces_aggregated_visualiser_summary(self) -> None:
         assert ShapBarVisualiser.produces_scope is ExplanationScope.AGGREGATED
         assert ShapBarVisualiser.scope_definition_step is ScopeDefinitionStep.VISUALISER_SUMMARY
         assert ShapBarVisualiser.visual_summary is not None
@@ -900,7 +900,7 @@ class TestShapBeeswarmVisualiser:
         visualiser = ShapBeeswarmVisualiser()
         assert visualiser is not None
 
-    def test_contract_produces_cohort_distribution_summary(self) -> None:
+    def test_contract_produces_aggregated_distribution_summary(self) -> None:
         assert ShapBeeswarmVisualiser.produces_scope is ExplanationScope.AGGREGATED
         assert (
             ShapBeeswarmVisualiser.scope_definition_step is ScopeDefinitionStep.VISUALISER_SUMMARY

--- a/src/raitap/transparency/visualisers/tests/test_visualisers.py
+++ b/src/raitap/transparency/visualisers/tests/test_visualisers.py
@@ -118,7 +118,7 @@ class TestBaseVisualiserContract:
                 "payload kind",
             ),
             (
-                _explanation(scope=ExplanationScope.COHORT),
+                _explanation(scope=ExplanationScope.AGGREGATED),
                 "scope",
             ),
             (
@@ -510,7 +510,7 @@ class TestTabularBarChartVisualiser:
         assert visualiser is not None
 
     def test_contract_produces_cohort_visualiser_summary(self) -> None:
-        assert TabularBarChartVisualiser.produces_scope is ExplanationScope.COHORT
+        assert TabularBarChartVisualiser.produces_scope is ExplanationScope.AGGREGATED
         assert (
             TabularBarChartVisualiser.scope_definition_step
             is ScopeDefinitionStep.VISUALISER_SUMMARY
@@ -833,7 +833,7 @@ class TestShapBarVisualiser:
         assert visualiser is not None
 
     def test_contract_produces_cohort_visualiser_summary(self) -> None:
-        assert ShapBarVisualiser.produces_scope is ExplanationScope.COHORT
+        assert ShapBarVisualiser.produces_scope is ExplanationScope.AGGREGATED
         assert ShapBarVisualiser.scope_definition_step is ScopeDefinitionStep.VISUALISER_SUMMARY
         assert ShapBarVisualiser.visual_summary is not None
         assert ShapBarVisualiser.visual_summary.aggregation == "mean_absolute_attribution"
@@ -901,7 +901,7 @@ class TestShapBeeswarmVisualiser:
         assert visualiser is not None
 
     def test_contract_produces_cohort_distribution_summary(self) -> None:
-        assert ShapBeeswarmVisualiser.produces_scope is ExplanationScope.COHORT
+        assert ShapBeeswarmVisualiser.produces_scope is ExplanationScope.AGGREGATED
         assert (
             ShapBeeswarmVisualiser.scope_definition_step is ScopeDefinitionStep.VISUALISER_SUMMARY
         )


### PR DESCRIPTION
## Summary

Renames the transparency scope `ExplanationScope.COHORT` → `AGGREGATED` (enum member + `StrEnum` value `"cohort"` → `"aggregated"`) and every downstream `cohort` identifier/label it spawned in the **transparency** and **reporting** packages. Pure terminology cleanup — "aggregated" reads clearer than the "cohort" jargon for the per-class/per-group artifacts it labels. No semantic change to what the scope represents.

Closes #211.

What changed:
- **Contract** — enum member name + value in `transparency/contracts.py`.
- **Scope producers** — `produces_scope` on `TabularBarChartVisualiser`, `ShapBarVisualiser`, `ShapBeeswarmVisualiser`.
- **Reporting** — `_build_cohort_section` → `_build_aggregated_section`, role `"aggregated"`, section title `"Aggregated Explanations"`, `view_model.aggregated_groups` + role branch + alias, and the `_local.html.j2` template heading/field.
- **Tests** — `test_contracts` member-set assertion, plus a clean sweep of `test_builder.py` (incl. the incidental `experiment_name` fixture label).
- **Docs (4)** — contributor + transparency-module + reporting-module docs.

**Breaking change** (`refactor!`, hard break — no back-compat alias, no tolerant deserializer; matches precedent #200): the serialized manifest scope value `"cohort"` → `"aggregated"`. Existing run manifests carrying `"scope": "cohort"` will no longer deserialize.

**Scope note — issue §3 deliberately excluded:** the issue also proposed renaming the robustness `output_bounds_cohort` visualiser (`OutputBoundsCohortVisualiser`, registry key `output_bounds_cohort`). It was left untouched because it has **zero coupling to `ExplanationScope`** — it imports only `raitap.robustness.contracts`; its "cohort" is an independent word (the per-class verifier batch), not the scope dim. Folding it in would be a separate, unrelated breaking change to a public registry key. Can be a follow-up issue if repo-wide "cohort" vocabulary consistency is desired.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — Title uses `!` after the scope (`refactor(transparency)!:`). The serialized scope value changes; this is a deliberate hard break, no compatibility shim.
- [x] **Contributor guide** — Read.

## Optional

- [x] **Issue** _(optional)_ — Closes #211.
- [x] **Docs** _(optional)_ — 4 transparency/reporting docs updated.
- [x] **Tests** _(optional)_ — Existing tests updated to assert the `AGGREGATED` scope; full transparency + reporting suites pass (432 passed, 10 skipped).
