### PR TITLE
feat(transparency): document attribution baselines (IG / SHAP) in artefact and report

### DIFF
--- a/docs/contributor/adding-a-module.md
+++ b/docs/contributor/adding-a-module.md
@@ -38,7 +38,7 @@ The walkthrough below uses a fictional `fairness` module.
 Mirror the shape of `src/raitap/transparency/contracts.py` or `src/raitap/robustness/contracts.py`. Declare:
 
 - Enums for the kinds your module distinguishes (e.g. `FairnessMetricKind`, `ProtectedAttributeKind`).
-- The `Mapping[str, T]` value type that goes into `algorithm_registry` (transparency uses `frozenset[MethodFamily]`; robustness uses `AssessorSemanticsHints`).
+- The `Mapping[str, T]` value type that goes into `algorithm_registry` (transparency uses `ExplainerSemanticsHints`; robustness uses `AssessorSemanticsHints` — both are frozen per-algorithm hints dataclasses).
 - A `Protocol` for the adapter (optional but useful for cross-module callers).
 
 ## 2. Base class (`assessors/base_assessor.py`)

--- a/docs/contributor/adding-an-adapter.md
+++ b/docs/contributor/adding-an-adapter.md
@@ -27,7 +27,7 @@ import re
 from typing import TYPE_CHECKING
 
 from raitap import adapters
-from raitap.transparency.contracts import MethodFamily
+from raitap.transparency.contracts import ExplainerSemanticsHints, MethodFamily
 
 from .base_explainer import AttributionOnlyExplainer
 
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
         (r"some noisy.*pattern", UserWarning, r"superxai.*"),
     ],
     algorithm_registry={           # required kwarg, pyright errors at decoration if missing
-        "supertreeshap": frozenset({MethodFamily.SHAPLEY}),
+        "supertreeshap": ExplainerSemanticsHints(frozenset({MethodFamily.SHAPLEY})),
     },
     # onnx_compatible_algorithms — optional, defaults to none (ONNX support is rare).
     # Pass an explicit frozenset to enable a subset, or `ALL` for everything in
@@ -82,7 +82,7 @@ class SuperXAIExplainer(AttributionOnlyExplainer):
 - **Base class.** `AttributionOnlyExplainer` provides batching, artefact persistence, and `explain()` orchestration. Other families use other bases (`EmpiricalAttackAssessor` for robustness, `BaseMetricComputer` for metrics, etc.) — find them in files starting with `base_`. The concrete adapter is just a normal class; nothing flags it as abstract (the old `abstract=True` workaround was removed).
 - **Decorator.** `@adapters.transparency(...)` is the sole entry point for registration. `registry_name` is required and pyright-checked at the decoration site via `Required[str]`. Each family has its own facade attribute (`adapters.robustness`, `adapters.metrics`, `adapters.reporter`, `adapters.tracker`, `visualisers.transparency`, `visualisers.robustness`) — pick the one matching your base class.
 - **Registration kwargs.** `library` is the pip name powering `self._lazy_import()` — pass it when you wrap a third-party package (the usual case). `extra` is the uv extra surfaced in install hints and scanned by `raitap.deps.inference`; it **defaults to `registry_name`** so you only need to set it explicitly when they differ (e.g. `classification_metrics` + `detection_metrics` both share `extra="metrics"`). `error_patterns` and `suppress_warnings` are optional polish.
-- **`algorithm_registry` (decorator kwarg).** Transparency and robustness only. Maps algorithm name → method families (or `AssessorSemanticsHints` for robustness) RAITAP tracks and reports on. **Required** — pyright errors at the decoration site if you omit it. Missing or misnamed entries make algorithms unselectable. The decorator assigns it onto the class so `type(self).algorithm_registry` still works at runtime.
+- **`algorithm_registry` (decorator kwarg).** Transparency and robustness only. Maps algorithm name → a per-algorithm semantics-hints value RAITAP tracks and reports on (`ExplainerSemanticsHints` for transparency, `AssessorSemanticsHints` for robustness). **Required** — pyright errors at the decoration site if you omit it. Missing or misnamed entries make algorithms unselectable. The decorator assigns it onto the class so `type(self).algorithm_registry` still works at runtime.
 - **`output_payload_kind` (decorator kwarg).** Transparency only. Tells the report renderer what artefact shape the explainer emits (`ATTRIBUTIONS`, `SALIENCY_MAP`, ...). Defaults to `ExplanationPayloadKind.ATTRIBUTIONS` — only pass it if your explainer emits something else.
 - **`onnx_compatible_algorithms` (decorator kwarg).** Transparency only. Optional — defaults to "none compatible" (ONNX support is rare). Pass an explicit `frozenset({"name1", "name2"})` to enable a subset, or `from raitap.transparency import ALL; onnx_compatible_algorithms=ALL` to mark every algorithm in `algorithm_registry` ONNX-compatible without re-listing them. The decorator resolves the sentinel and assigns the final frozenset onto the class as `type(self).ONNX_COMPATIBLE_ALGORITHMS` for use inside `check_backend_compat`.
 - **`super().__init__()`.** Cooperative parent init — the base class allocates buffers the framework reads later (e.g. `self.attributions = None`). Forgetting raises `AttributeError` deep inside `explain()`. Always call first when overriding `__init__`.

--- a/docs/contributor/adding-an-algorithm.md
+++ b/docs/contributor/adding-an-algorithm.md
@@ -81,7 +81,24 @@ Pass `from raitap.transparency import ALL` (or `raitap.robustness.ALL`) instead 
 
 The default `check_backend_compat` enforces this allowlist — algorithms not in the set raise `ExplainerBackendIncompatibilityError` (or `AssessorBackendIncompatibilityError`) when the user picks an ONNX backend.
 
-## 4. Tests
+## 4. Baseline default (transparency only, optional)
+
+Attribution methods that take a *reference input* — Integrated Gradients (`baselines=`) and SHAP (`background_data=`) — have that baseline recorded in `metadata.json` and the report (issue #210). Two class-body attributes on the adapter drive this:
+
+- `baseline_kwarg` — the call kwarg that holds the reference (`"baselines"` for Captum, `"background_data"` for SHAP). `None` (the base-class default) means the family takes no baseline.
+- `baseline_defaults` — a `Mapping[str, BaselineMode]` of *algorithm name → implicit default mode*, used when the user omits the kwarg. Declared **per algorithm** because one adapter wraps many algorithms, most of which take no baseline.
+
+If your new algorithm takes a baseline **and** has a meaningful default when the user omits it, add one entry (use a `BaselineMode` member from `transparency/contracts.py`):
+
+```python
+class CaptumExplainer(AttributionOnlyExplainer):
+    baseline_kwarg = "baselines"
+    baseline_defaults = {"IntegratedGradients": BaselineMode.ZERO, "NewMethod": BaselineMode.ZERO}
+```
+
+Nothing to do if your algorithm only uses a baseline when the user supplies one (no implicit default) — the kwarg-present path records it as `configured`/`user_tensor` automatically — or if it takes no reference at all (Saliency, GradCam).
+
+## 5. Tests
 
 Add a unit test next to the adapter (`src/raitap/<module>/<subdir>/tests/test_<adapter>.py`) that:
 
@@ -100,7 +117,7 @@ The family E2E matrix parametrises over algorithm names — add an entry to keep
 - **Transparency**: `src/raitap/transparency/tests/e2e_case_matrix.py::MATRIX_CASES`. Add a `MatrixCase(id="...", framework=..., algorithm="NewMethod", ...)`.
 - **Robustness**: `src/raitap/robustness/tests/e2e_assessor_matrix.py::MATRIX_CASES`. Add an `AssessorMatrixCase(id="...", family=..., algorithm="NewAlgo", needs_extra=..., constructor_kwargs={...})`. Keep `constructor_kwargs` minimal (low `steps`, low `n_queries`) — the matrix is a wire-up smoke test, not a behaviour-sensitivity test. Each case must finish in under ~5s on CI.
 
-## 5. Docs
+## 6. Docs
 
 Add a row to `docs/modules/<module>/frameworks-and-libraries.md` for the new algorithm so it surfaces in the user-facing "does raitap support X?" lookup. Mention the families it belongs to and whether it is ONNX-compatible.
 

--- a/docs/contributor/adding-an-algorithm.md
+++ b/docs/contributor/adding-an-algorithm.md
@@ -37,7 +37,7 @@ from raitap import adapters
             frozenset({MethodFamily.GRADIENT, MethodFamily.PERTURBATION})
         ),
     },
-    baseline_kwarg="baselines",
+    baseline_kwarg_name="baselines",
     onnx_compatible_algorithms=frozenset({...}),
 )
 class CaptumExplainer(AttributionOnlyExplainer): ...
@@ -88,23 +88,28 @@ The default `check_backend_compat` enforces this allowlist — algorithms not in
 
 ## 4. Baseline default (transparency only, optional)
 
-Attribution methods that take a *reference input* — Integrated Gradients (`baselines=`) and SHAP (`background_data=`) — have that baseline recorded in `metadata.json` and the report (issue #210). Two declarations drive this:
+Attribution methods that take a *reference input* — Integrated Gradients (`baselines=`) and SHAP (`background_data=`) — have that baseline recorded in `metadata.json` and the report (issue #210), and users set it library-agnostically via `raitap.baseline`. Three declarations drive this:
 
-- `baseline_kwarg` — a `@adapters.transparency` decorator kwarg naming the call kwarg that holds the reference (`"baselines"` for Captum, `"background_data"` for SHAP). Omitted (the default) means the family takes no baseline. It's per-**adapter** (one library, one kwarg name).
+- `baseline_kwarg_name` — a `@adapters.transparency` decorator kwarg naming the call kwarg that holds the reference (`"baselines"` for Captum, `"background_data"` for SHAP). Omitted (the default) means the family takes no baseline. It's per-**adapter** (one library, one kwarg name), and is where `raitap.baseline` gets routed.
 - `ExplainerSemanticsHints.baseline_default` — the per-**algorithm** implicit default mode, used when the user omits the kwarg. Lives on the algorithm's registry entry because one adapter wraps many algorithms, most of which take no baseline (so they leave it `None`).
+- `ExplainerSemanticsHints.baseline_cardinality` — `BaselineCardinality.SINGLE` (one broadcast reference, e.g. IG) or `SET` (a sample distribution, e.g. SHAP). Used only to *warn* on a mismatched `raitap.baseline` (never to reshape it); leave `None` to skip the check.
 
-If your new algorithm takes a baseline **and** has a meaningful default when the user omits it, set `baseline_default` on its registry entry (use a `BaselineMode` member from `transparency/contracts.py`):
+If your new algorithm takes a baseline **and** has a meaningful default when the user omits it, set `baseline_default` (and, ideally, `baseline_cardinality`) on its registry entry:
 
 ```python
 @adapters.transparency(
     registry_name="captum",
-    baseline_kwarg="baselines",
+    baseline_kwarg_name="baselines",
     algorithm_registry={
         "IntegratedGradients": ExplainerSemanticsHints(
-            frozenset({MethodFamily.GRADIENT}), baseline_default=BaselineMode.ZERO
+            frozenset({MethodFamily.GRADIENT}),
+            baseline_default=BaselineMode.ZERO,
+            baseline_cardinality=BaselineCardinality.SINGLE,
         ),
         "NewMethod": ExplainerSemanticsHints(
-            frozenset({MethodFamily.GRADIENT}), baseline_default=BaselineMode.ZERO
+            frozenset({MethodFamily.GRADIENT}),
+            baseline_default=BaselineMode.ZERO,
+            baseline_cardinality=BaselineCardinality.SINGLE,
         ),
     },
 )

--- a/docs/contributor/adding-an-algorithm.md
+++ b/docs/contributor/adding-an-algorithm.md
@@ -29,10 +29,15 @@ from raitap import adapters
     registry_name="captum",
     library="captum",
     algorithm_registry={
-        "IntegratedGradients": frozenset({MethodFamily.GRADIENT}),
+        "IntegratedGradients": ExplainerSemanticsHints(
+            frozenset({MethodFamily.GRADIENT}), baseline_default=BaselineMode.ZERO
+        ),
         # ... existing entries ...
-        "NewMethod": frozenset({MethodFamily.GRADIENT, MethodFamily.PERTURBATION}),
+        "NewMethod": ExplainerSemanticsHints(
+            frozenset({MethodFamily.GRADIENT, MethodFamily.PERTURBATION})
+        ),
     },
+    baseline_kwarg="baselines",
     onnx_compatible_algorithms=frozenset({...}),
 )
 class CaptumExplainer(AttributionOnlyExplainer): ...
@@ -61,7 +66,7 @@ class TorchattacksAssessor(EmpiricalAttackAssessor): ...
 ```
 
 The map value carries the semantics RAITAP tracks and reports on:
-- **Transparency** → `frozenset[MethodFamily]`. New `MethodFamily` values go in `src/raitap/transparency/contracts.py`.
+- **Transparency** → `ExplainerSemanticsHints` (`families: frozenset[MethodFamily]` + optional `baseline_default`). New `MethodFamily` values go in `src/raitap/transparency/contracts.py`.
 - **Robustness** → `AssessorSemanticsHints` (assessment kind, threat model, objective, norm, family tags). Defined in `src/raitap/robustness/semantics.py`.
 
 A missing entry means the algorithm cannot be selected via config — the family's runtime check fails fast.
@@ -83,20 +88,30 @@ The default `check_backend_compat` enforces this allowlist — algorithms not in
 
 ## 4. Baseline default (transparency only, optional)
 
-Attribution methods that take a *reference input* — Integrated Gradients (`baselines=`) and SHAP (`background_data=`) — have that baseline recorded in `metadata.json` and the report (issue #210). Two class-body attributes on the adapter drive this:
+Attribution methods that take a *reference input* — Integrated Gradients (`baselines=`) and SHAP (`background_data=`) — have that baseline recorded in `metadata.json` and the report (issue #210). Two declarations drive this:
 
-- `baseline_kwarg` — the call kwarg that holds the reference (`"baselines"` for Captum, `"background_data"` for SHAP). `None` (the base-class default) means the family takes no baseline.
-- `baseline_defaults` — a `Mapping[str, BaselineMode]` of *algorithm name → implicit default mode*, used when the user omits the kwarg. Declared **per algorithm** because one adapter wraps many algorithms, most of which take no baseline.
+- `baseline_kwarg` — a `@adapters.transparency` decorator kwarg naming the call kwarg that holds the reference (`"baselines"` for Captum, `"background_data"` for SHAP). Omitted (the default) means the family takes no baseline. It's per-**adapter** (one library, one kwarg name).
+- `ExplainerSemanticsHints.baseline_default` — the per-**algorithm** implicit default mode, used when the user omits the kwarg. Lives on the algorithm's registry entry because one adapter wraps many algorithms, most of which take no baseline (so they leave it `None`).
 
-If your new algorithm takes a baseline **and** has a meaningful default when the user omits it, add one entry (use a `BaselineMode` member from `transparency/contracts.py`):
+If your new algorithm takes a baseline **and** has a meaningful default when the user omits it, set `baseline_default` on its registry entry (use a `BaselineMode` member from `transparency/contracts.py`):
 
 ```python
-class CaptumExplainer(AttributionOnlyExplainer):
-    baseline_kwarg = "baselines"
-    baseline_defaults = {"IntegratedGradients": BaselineMode.ZERO, "NewMethod": BaselineMode.ZERO}
+@adapters.transparency(
+    registry_name="captum",
+    baseline_kwarg="baselines",
+    algorithm_registry={
+        "IntegratedGradients": ExplainerSemanticsHints(
+            frozenset({MethodFamily.GRADIENT}), baseline_default=BaselineMode.ZERO
+        ),
+        "NewMethod": ExplainerSemanticsHints(
+            frozenset({MethodFamily.GRADIENT}), baseline_default=BaselineMode.ZERO
+        ),
+    },
+)
+class CaptumExplainer(AttributionOnlyExplainer): ...
 ```
 
-Nothing to do if your algorithm only uses a baseline when the user supplies one (no implicit default) — the kwarg-present path records it as `configured`/`user_tensor` automatically — or if it takes no reference at all (Saliency, GradCam).
+Nothing to do if your algorithm only uses a baseline when the user supplies one (no implicit default) — the kwarg-present path records it as `configured`/`user_tensor` automatically — or if it takes no reference at all (Saliency, GradCam): leave `baseline_default` unset (`None`).
 
 ## 5. Tests
 

--- a/docs/contributor/transparency.md
+++ b/docs/contributor/transparency.md
@@ -36,12 +36,13 @@ BaseExplainer                       # root — owns output_payload_kind + check_
 
 ### Baseline contract (reference-input methods)
 
-Methods that take a *reference input* (IG `baselines=`, SHAP `background_data=`) document that baseline in `metadata.json` + the report (issue #210). Two declarations on the adapter drive it:
+Methods that take a *reference input* (IG `baselines=`, SHAP `background_data=`) document that baseline in `metadata.json` + the report (issue #210). The user sets it library-agnostically via `raitap.baseline`, routed to the adapter's own kwarg. Three declarations on the adapter drive this:
 
 | Declaration | Where | Purpose |
 | --- | --- | --- |
-| `baseline_kwarg` | `@adapters.transparency` decorator kwarg | The call kwarg holding the reference (`"baselines"`, `"background_data"`); omitted (default `None`) = no baseline. Per-**adapter**. |
+| `baseline_kwarg_name` | `@adapters.transparency` decorator kwarg | The call kwarg holding the reference (`"baselines"`, `"background_data"`); omitted (default `None`) = no baseline. Per-**adapter**. Also names where `raitap.baseline` is routed. |
 | `ExplainerSemanticsHints.baseline_default` | per-algorithm `algorithm_registry` entry | Per-**algorithm** implicit default mode (`BaselineMode.ZERO` / `INPUT_BATCH`) used when the kwarg is omitted; `None` when the algorithm takes no baseline. |
+| `ExplainerSemanticsHints.baseline_cardinality` | per-algorithm `algorithm_registry` entry | `BaselineCardinality.SINGLE` (one broadcast reference, e.g. IG) or `SET` (a sample distribution, e.g. SHAP). Used to *warn* on a mismatched `raitap.baseline` (never to reshape it); `None` skips the check. |
 
 Capture happens once at the `AttributionOnlyExplainer.explain` chokepoint via `build_baseline_record` (`transparency/baselines.py`), which resolves the `BaselineMode` (`configured` / `user_tensor` / `zero` / `input_batch`), hashes the tensor, and renders an image preview. It is wrapped so a render/hash failure degrades to no baseline rather than discarding attributions. See [Adding an algorithm](adding-an-algorithm.md).
 

--- a/docs/contributor/transparency.md
+++ b/docs/contributor/transparency.md
@@ -34,6 +34,17 @@ BaseExplainer                       # root — owns output_payload_kind + check_
 
 `output_payload_kind: ClassVar[ExplanationPayloadKind]` (default `ATTRIBUTIONS`) records what artefact shape the explainer emits. It's set via the `@adapters.transparency` decorator kwarg.
 
+### Baseline contract (reference-input methods)
+
+Methods that take a *reference input* (IG `baselines=`, SHAP `background_data=`) document that baseline in `metadata.json` + the report (issue #210). Two class-body ClassVars on the adapter declare it:
+
+| ClassVar | Type | Purpose |
+| --- | --- | --- |
+| `baseline_kwarg` | `ClassVar[str \| None]` | The call kwarg holding the reference (`"baselines"`, `"background_data"`); `None` (default) = no baseline. |
+| `baseline_defaults` | `ClassVar[Mapping[str, BaselineMode]]` | Per-**algorithm** implicit default mode (`BaselineMode.ZERO` / `INPUT_BATCH`) used when the kwarg is omitted. |
+
+Capture happens once at the `AttributionOnlyExplainer.explain` chokepoint via `build_baseline_record` (`transparency/baselines.py`), which resolves the `BaselineMode` (`configured` / `user_tensor` / `zero` / `input_batch`), hashes the tensor, and renders an image preview. It is wrapped so a render/hash failure degrades to no baseline rather than discarding attributions. See [Adding an algorithm](adding-an-algorithm.md).
+
 ## Visualiser semantic contract
 
 All visualisers extend `BaseVisualiser` (`src/raitap/transparency/visualisers/base_visualiser.py`). On top of `visualise(...) -> Figure` and the optional `save(...)`, each visualiser must declare its semantic compatibility via ClassVars — the runtime validates these against `ExplanationResult.semantics` before calling `visualise`.

--- a/docs/contributor/transparency.md
+++ b/docs/contributor/transparency.md
@@ -36,12 +36,12 @@ BaseExplainer                       # root — owns output_payload_kind + check_
 
 ### Baseline contract (reference-input methods)
 
-Methods that take a *reference input* (IG `baselines=`, SHAP `background_data=`) document that baseline in `metadata.json` + the report (issue #210). Two class-body ClassVars on the adapter declare it:
+Methods that take a *reference input* (IG `baselines=`, SHAP `background_data=`) document that baseline in `metadata.json` + the report (issue #210). Two declarations on the adapter drive it:
 
-| ClassVar | Type | Purpose |
+| Declaration | Where | Purpose |
 | --- | --- | --- |
-| `baseline_kwarg` | `ClassVar[str \| None]` | The call kwarg holding the reference (`"baselines"`, `"background_data"`); `None` (default) = no baseline. |
-| `baseline_defaults` | `ClassVar[Mapping[str, BaselineMode]]` | Per-**algorithm** implicit default mode (`BaselineMode.ZERO` / `INPUT_BATCH`) used when the kwarg is omitted. |
+| `baseline_kwarg` | `@adapters.transparency` decorator kwarg | The call kwarg holding the reference (`"baselines"`, `"background_data"`); omitted (default `None`) = no baseline. Per-**adapter**. |
+| `ExplainerSemanticsHints.baseline_default` | per-algorithm `algorithm_registry` entry | Per-**algorithm** implicit default mode (`BaselineMode.ZERO` / `INPUT_BATCH`) used when the kwarg is omitted; `None` when the algorithm takes no baseline. |
 
 Capture happens once at the `AttributionOnlyExplainer.explain` chokepoint via `build_baseline_record` (`transparency/baselines.py`), which resolves the `BaselineMode` (`configured` / `user_tensor` / `zero` / `input_batch`), hashes the tensor, and renders an image preview. It is wrapped so a render/hash failure degrades to no baseline rather than discarding attributions. See [Adding an algorithm](adding-an-algorithm.md).
 

--- a/docs/contributor/writing-a-plugin.md
+++ b/docs/contributor/writing-a-plugin.md
@@ -54,7 +54,7 @@ import re
 from typing import TYPE_CHECKING
 
 from raitap import adapters
-from raitap.transparency.contracts import MethodFamily
+from raitap.transparency.contracts import ExplainerSemanticsHints, MethodFamily
 from raitap.transparency.explainers.base_explainer import AttributionOnlyExplainer
 
 if TYPE_CHECKING:
@@ -69,7 +69,9 @@ if TYPE_CHECKING:
         re.compile(r"some library footgun"): "Do X instead.", # nicer error messages to avoid deep stack traces in RAITAP
     },
     algorithm_registry={
-        "supertreeshap": frozenset({MethodFamily.SHAPLEY}), # the algos your library offers
+        # the algos your library offers; ExplainerSemanticsHints carries the
+        # method families (+ optional baseline_default for reference-input methods)
+        "supertreeshap": ExplainerSemanticsHints(frozenset({MethodFamily.SHAPLEY})),
     },
     onnx_compatible_algorithms=frozenset({"supertreeshap"}), # algos compatible with ONNX models
 )

--- a/docs/modules/transparency/configuration.md
+++ b/docs/modules/transparency/configuration.md
@@ -46,7 +46,8 @@ myst:
 :default: null
 :description: Keyword arguments passed verbatim to the underlying library when
   computing attributions. Any nested dict with a `source` key is treated as a
-  runtime data source.
+  runtime data source. For a baseline / reference input prefer `raitap.baseline`
+  (library-agnostic name) over the raw library kwarg here.
 
 :option: raitap
 :allowed: dict
@@ -109,6 +110,22 @@ myst:
   controlled by `data.input_metadata.shape` instead — see
   {doc}`../data/configuration`.
 
+:option: raitap.baseline
+:allowed: dict | tensor
+:default: null
+:description: Library-agnostic baseline / reference input for attribution methods
+  that take one (Captum `baselines`, SHAP `background_data`). Preferred over the raw
+  library kwarg under `call:` — the name stays the same when you switch libraries.
+  Same value shape as a `call:` data source: `{source, n_samples}` (or a tensor via
+  the Python API). If the baseline is also set via the library's own kwarg (under
+  `call:` or passed at runtime), `raitap.baseline` wins and a warning is logged —
+  it is never overridden silently. Setting it on an explainer that
+  takes no baseline (e.g. Saliency) raises `raitap.utils.errors.RaitapError`. A
+  single-reference method (e.g. Integrated Gradients) warns if given a multi-sample
+  baseline (`n_samples > 1`) — that shape only works for a sample-set method like
+  SHAP; use `n_samples: 1` for a broadcast reference. Omit it to fall back to the
+  method's implicit default (zeros for IG, the input batch for SHAP).
+
 :option: visualisers
 :allowed: list[dict]
 :default: []
@@ -126,6 +143,8 @@ transparency:
     call:
       target: 0
     raitap:
+      baseline:                 # library-agnostic; routed to Captum's `baselines`
+        source: "./data/baseline"
       input_metadata:
         kind: image
         layout: NCHW
@@ -138,10 +157,10 @@ transparency:
     algorithm: "KernelExplainer"
     call:
       target: 0
-      background_data:
+    raitap:
+      baseline:
         source: "./data/background"
         n_samples: 32
-    raitap:
       batch_size: 1
       input_metadata:
         kind: tabular
@@ -159,19 +178,17 @@ transparency = {
     "my_first_explainer": captum(
         algorithm="IntegratedGradients",
         call={"target": 0},
-        raitap={"input_metadata": {"kind": "image", "layout": "NCHW"}},
+        raitap={
+            "baseline": {"source": "./data/baseline"},  # routed to Captum's `baselines`
+            "input_metadata": {"kind": "image", "layout": "NCHW"},
+        },
         visualisers=[captum_image(call={"max_samples": 1})],
     ),
     "my_second_explainer": shap(
         algorithm="KernelExplainer",
-        call={
-            "target": 0,
-            "background_data": {
-                "source": "./data/background",
-                "n_samples": 32,
-            },
-        },
+        call={"target": 0},
         raitap={
+            "baseline": {"source": "./data/background", "n_samples": 32},
             "batch_size": 1,
             "input_metadata": {
                 "kind": "tabular",

--- a/docs/modules/transparency/frameworks-and-libraries.md
+++ b/docs/modules/transparency/frameworks-and-libraries.md
@@ -30,9 +30,9 @@ transparency:
       local_smoothing: 0.0
     call:
       target: 0
-      background_data:
-        source: imagenet_samples
     raitap:
+      baseline:
+        source: imagenet_samples
       batch_size: 1
     visualisers:
       - _target_: "ShapImageVisualiser"
@@ -46,11 +46,11 @@ transparency = {
     "my_first_explainer": shap(
         algorithm="GradientExplainer",
         constructor={"local_smoothing": 0.0},
-        call={
-            "target": 0,
-            "background_data": {"source": "imagenet_samples"},
+        call={"target": 0},
+        raitap={
+            "baseline": {"source": "imagenet_samples"},
+            "batch_size": 1,
         },
-        raitap={"batch_size": 1},
         visualisers=[shap_image(call={"max_samples": 1})],
     ),
 }
@@ -162,9 +162,9 @@ transparency:
     constructor: {}
     call:
       target: 0
-      background_data:
-        source: imagenet_samples
     raitap:
+      baseline:
+        source: imagenet_samples
       batch_size: 1
 
 :python:
@@ -173,17 +173,18 @@ from raitap.transparency import shap
 transparency = {
     "my_shap_explainer": shap(
         algorithm="GradientExplainer",
-        call={
-            "target": 0,
-            "background_data": {"source": "imagenet_samples"},
+        call={"target": 0},
+        raitap={
+            "baseline": {"source": "imagenet_samples"},
+            "batch_size": 1,
         },
-        raitap={"batch_size": 1},
     ),
 }
 ```
 
-`GradientExplainer`, `DeepExplainer`, and `KernelExplainer` usually require
-`background_data`. If it is not provided, RAITAP falls back to the input batch.
+`GradientExplainer`, `DeepExplainer`, and `KernelExplainer` usually require a
+background reference. Set it with the library-agnostic `raitap.baseline` (see
+{doc}`configuration`); if omitted, RAITAP falls back to the input batch.
 
 `DeepExplainer` can fail on PyTorch models that use `SiLU` activations (for example EfficientNet variants) due to autograd/in-place limitations. In those cases, use `GradientExplainer`.
 
@@ -276,10 +277,10 @@ transparency:
       local_smoothing: 0.0
     call:
       target: 0
-      background_data:
+    raitap:
+      baseline:
         source: imagenet_samples
         n_samples: 50
-    raitap:
       batch_size: 1
     visualisers:
       # Minimal configuration
@@ -306,14 +307,11 @@ transparency = {
     "my_shap_explainer": shap(
         algorithm="GradientExplainer",
         constructor={"local_smoothing": 0.0},
-        call={
-            "target": 0,
-            "background_data": {
-                "source": "imagenet_samples",
-                "n_samples": 50,
-            },
+        call={"target": 0},
+        raitap={
+            "baseline": {"source": "imagenet_samples", "n_samples": 50},
+            "batch_size": 1,
         },
-        raitap={"batch_size": 1},
         visualisers=[
             # Minimal configuration.
             shap_image(max_samples=1),

--- a/docs/modules/transparency/output.md
+++ b/docs/modules/transparency/output.md
@@ -36,7 +36,7 @@ metadata. It also keeps two separate runtime buckets:
 values are stored directly, while tensor-like values are summarized rather than
 embedded verbatim so `metadata.json` stays lightweight and readable.
 
-### `baseline` block
+## `baseline` block
 
 For attribution methods that use a reference input — Integrated Gradients
 (`baselines`) and SHAP (`background_data`) — `metadata.json` carries a `baseline`

--- a/docs/modules/transparency/output.md
+++ b/docs/modules/transparency/output.md
@@ -38,11 +38,8 @@ embedded verbatim so `metadata.json` stays lightweight and readable.
 
 ## `baseline` block
 
-For attribution methods that use a reference input — Integrated Gradients
-(`baselines`) and SHAP (`background_data`) — `metadata.json` carries a `baseline`
-block documenting the exact reference the explanation was computed against
-(issue #210). The recognised baseline kwarg is moved out of `call_kwargs` into
-this block; runs without a baseline omit it entirely.
+For attribution methods that use a reference input (baseline data), `metadata.json` carries a `baseline`
+block documenting the exact reference the explanation was computed against.
 
 ```json
 "baseline": {
@@ -57,15 +54,15 @@ this block; runs without a baseline omit it entirely.
 }
 ```
 
-- `mode` — how the baseline was obtained: `configured` (resolved from a YAML
+- `mode`: how the baseline was obtained: `configured` (resolved from a YAML
   data source), `user_tensor` (passed directly via the Python API), `zero`
   (Captum's implicit all-zeros default), or `input_batch` (SHAP's implicit
   default of using the input batch).
-- `source` / `n_samples` — set only for `configured` baselines (the YAML
+- `source` / `n_samples`: set only for `configured` baselines (the YAML
   provenance).
-- `sha256` — content hash of the tensor actually used as the baseline; recorded
+- `sha256`: content hash of the tensor actually used as the baseline; recorded
   here only, never shown in the report.
-- `image_path` — a rendered preview (image modality only), relative to the run
+- `image_path`: a rendered preview (image modality only), relative to the run
   directory; a single tile for one image, or a capped grid for a multi-image
   baseline. The report shows this image and the descriptor fields, but not the
   hash.

--- a/docs/modules/transparency/output.md
+++ b/docs/modules/transparency/output.md
@@ -35,3 +35,37 @@ metadata. It also keeps two separate runtime buckets:
 `call_kwargs` is a best-effort JSON summary of the library invocation. Scalar
 values are stored directly, while tensor-like values are summarized rather than
 embedded verbatim so `metadata.json` stays lightweight and readable.
+
+### `baseline` block
+
+For attribution methods that use a reference input — Integrated Gradients
+(`baselines`) and SHAP (`background_data`) — `metadata.json` carries a `baseline`
+block documenting the exact reference the explanation was computed against
+(issue #210). The recognised baseline kwarg is moved out of `call_kwargs` into
+this block; runs without a baseline omit it entirely.
+
+```json
+"baseline": {
+  "kwarg_name": "background_data",
+  "mode": "configured",
+  "source": "imagenet_samples",
+  "n_samples": 50,
+  "shape": [50, 3, 224, 224],
+  "dtype": "torch.float32",
+  "sha256": "…",
+  "image_path": "baseline.png"
+}
+```
+
+- `mode` — how the baseline was obtained: `configured` (resolved from a YAML
+  data source), `user_tensor` (passed directly via the Python API), `zero`
+  (Captum's implicit all-zeros default), or `input_batch` (SHAP's implicit
+  default of using the input batch).
+- `source` / `n_samples` — set only for `configured` baselines (the YAML
+  provenance).
+- `sha256` — content hash of the tensor actually used as the baseline; recorded
+  here only, never shown in the report.
+- `image_path` — a rendered preview (image modality only), relative to the run
+  directory; a single tile for one image, or a capped grid for a multi-image
+  baseline. The report shows this image and the descriptor fields, but not the
+  hash.

--- a/docs/using-raitap/examples/imagenet-captum-ig-pgd.md
+++ b/docs/using-raitap/examples/imagenet-captum-ig-pgd.md
@@ -45,6 +45,9 @@ transparency:
     algorithm: IntegratedGradients
     call:
       target: 0
+    raitap:
+      baseline:
+        source: ./data/baseline
     visualisers:
       - _target_: CaptumImageVisualiser
 
@@ -87,6 +90,8 @@ cfg = AppConfig(
         "default": captum(
             algorithm="IntegratedGradients",
             call={"target": 0},
+            # Library-agnostic baseline; routed to Captum's `baselines`.
+            raitap={"baseline": {"source": "./data/baseline"}},
             visualisers=[captum_image()],
         ),
     },
@@ -104,7 +109,7 @@ outputs = run(cfg, auto_install_deps=True)
 :output:
 outputs/<date>/<time>/
 ├── metrics/{metrics.json, artifacts.json, metadata.json, metrics_overview.png}
-├── transparency/default/{attributions.pt, CaptumImageVisualiser_0.png, metadata.json}
+├── transparency/default/{attributions.pt, baseline.png, CaptumImageVisualiser_0.png, metadata.json}
 ├── robustness/pgd/{robustness_data.pt, ImagePairVisualiser_0.png, metadata.json}
 └── reports/{report.html, report.zip, _assets/…}
 ```

--- a/docs/using-raitap/examples/kitchen-sink.md
+++ b/docs/using-raitap/examples/kitchen-sink.md
@@ -38,7 +38,8 @@ transparency:
     constructor: {}
     call:
       target: 0
-      baselines:
+    raitap:
+      baseline:
         source: "./data/baselines"
         n_samples: 8
     visualisers:
@@ -60,10 +61,10 @@ transparency:
     call:
       target: 0
       nsamples: 10
-      background_data:
+    raitap:
+      baseline:
         source: "./data/background"
         n_samples: 32
-    raitap:
       batch_size: 1
       progress_desc: "SHAP batches"
     visualisers:
@@ -142,10 +143,9 @@ config = AppConfig(
     transparency={
         "captum_ig": captum(
             algorithm="IntegratedGradients",
-            call={
-                "target": 0,
-                "baselines": {"source": "./data/baselines", "n_samples": 8},
-            },
+            call={"target": 0},
+            # Preferred library-agnostic baseline; routed to Captum's `baselines`.
+            raitap={"baseline": {"source": "./data/baselines", "n_samples": 8}},
             visualisers=[
                 captum_image(
                     method="blended_heat_map",
@@ -160,15 +160,12 @@ config = AppConfig(
         "shap_gradient": shap(
             algorithm="GradientExplainer",
             constructor={"local_smoothing": 0.0},
-            call={
-                "target": 0,
-                "nsamples": 10,
-                "background_data": {
-                    "source": "./data/background",
-                    "n_samples": 32,
-                },
+            call={"target": 0, "nsamples": 10},
+            raitap={
+                "baseline": {"source": "./data/background", "n_samples": 32},
+                "batch_size": 1,
+                "progress_desc": "SHAP batches",
             },
-            raitap={"batch_size": 1, "progress_desc": "SHAP batches"},
             visualisers=[shap_image(max_samples=2)],
         ),
     },

--- a/src/raitap/configs/adapter_factory.py
+++ b/src/raitap/configs/adapter_factory.py
@@ -455,6 +455,10 @@ def resolve_call_data_sources(
     preprocessing transform), it is applied per-image so that auxiliary
     tensors (SHAP background, baselines, …) share the same shape as the
     primary ``Data.tensor``.
+
+    When ``provenance_out`` is supplied, each resolved data-source kwarg also
+    records ``{key: {"source", "n_samples"}}`` into it (a side-channel for
+    baseline documentation; callers that omit it are unaffected).
     """
     resolved: dict[str, Any] = {}
     for key, value in call_kwargs.items():

--- a/src/raitap/configs/adapter_factory.py
+++ b/src/raitap/configs/adapter_factory.py
@@ -436,6 +436,7 @@ def resolve_call_data_sources(
     *,
     log_label: str = "call",
     per_image_transform: Callable[[torch.Tensor], torch.Tensor] | None = None,
+    provenance_out: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Replace ``call:`` values matching ``{source, n_samples}`` with loaded tensors.
 
@@ -471,6 +472,8 @@ def resolve_call_data_sources(
                 source,
                 n_samples,
             )
+            if provenance_out is not None:
+                provenance_out[key] = {"source": str(source), "n_samples": n_samples}
             resolved[key] = load_tensor_from_source(
                 str(source),
                 n_samples=n_samples,

--- a/src/raitap/pipeline/phases/assess_transparency.py
+++ b/src/raitap/pipeline/phases/assess_transparency.py
@@ -179,6 +179,7 @@ def _assess_transparency_detection(
             if input_metadata is not None:
                 raitap_cfg["input_metadata"] = input_metadata
 
+            call_provenance: dict[str, dict[str, Any]] = {}
             merged_kwargs = resolve_call_data_sources(
                 call_from_config,
                 log_label="call",
@@ -186,6 +187,7 @@ def _assess_transparency_detection(
                     config,
                     resolved_preprocessing=resolved_preprocessing,
                 ),
+                provenance_out=call_provenance,
             )
             merged_kwargs = backend._prepare_kwargs(merged_kwargs)
 
@@ -202,6 +204,7 @@ def _assess_transparency_detection(
                 base_run_dir=base_run_dir,
                 raitap_kwargs=raitap_cfg,
                 call_kwargs=merged_kwargs,
+                call_provenance=call_provenance,
             ):
                 explanations.append(result)
                 visualisations.extend(result.visualise())

--- a/src/raitap/pipeline/phases/assess_transparency.py
+++ b/src/raitap/pipeline/phases/assess_transparency.py
@@ -136,6 +136,7 @@ def _assess_transparency_detection(
     from raitap.configs import resolve_run_dir
     from raitap.configs.adapter_factory import resolve_per_image_transform
     from raitap.pipeline.phases.explain_detection import explain_detection
+    from raitap.transparency.baselines import apply_config_baseline
     from raitap.transparency.factory import (
         _PARSED_EXPLAINER_CONFIG_CACHE,
         _parse_explainer_config,
@@ -178,6 +179,12 @@ def _assess_transparency_detection(
                 raitap_cfg["sample_names"] = data.sample_ids
             if input_metadata is not None:
                 raitap_cfg["input_metadata"] = input_metadata
+
+            call_from_config = apply_config_baseline(
+                explainer=explainer,
+                call_kwargs=call_from_config,
+                raitap_kwargs=raitap_cfg,
+            )
 
             call_provenance: dict[str, dict[str, Any]] = {}
             merged_kwargs = resolve_call_data_sources(

--- a/src/raitap/pipeline/phases/explain_detection.py
+++ b/src/raitap/pipeline/phases/explain_detection.py
@@ -57,7 +57,7 @@ def explain_detection(
     base_run_dir: Path,
     raitap_kwargs: dict[str, Any] | None,
     call_kwargs: dict[str, Any],
-    call_provenance: Mapping[str, Any] | None = None,
+    call_provenance: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> Iterator[ExplanationResult]:
     """Yield one ExplanationResult per detected box.
 

--- a/src/raitap/pipeline/phases/explain_detection.py
+++ b/src/raitap/pipeline/phases/explain_detection.py
@@ -20,7 +20,7 @@ from raitap.types import DetectionInputs, TaskKind
 from raitap.utils.errors import RaitapError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Sequence
+    from collections.abc import Iterator, Mapping, Sequence
     from pathlib import Path
 
     from raitap.models.backend import ModelBackend
@@ -57,6 +57,7 @@ def explain_detection(
     base_run_dir: Path,
     raitap_kwargs: dict[str, Any] | None,
     call_kwargs: dict[str, Any],
+    call_provenance: Mapping[str, Any] | None = None,
 ) -> Iterator[ExplanationResult]:
     """Yield one ExplanationResult per detected box.
 
@@ -183,6 +184,7 @@ def explain_detection(
                 explainer_name=explainer_name,
                 visualisers=list(visualisers),
                 raitap_kwargs=per_box_raitap,
+                call_provenance=call_provenance,
                 **normalised_call_kwargs,
             )
             result.detection_box = DetectionBox(

--- a/src/raitap/pipeline/phases/explain_detection.py
+++ b/src/raitap/pipeline/phases/explain_detection.py
@@ -115,6 +115,10 @@ def explain_detection(
 
     base_model = backend.as_model_for_explanation()
 
+    # One baseline preview is shared by every box of a sample (same inputs +
+    # call kwargs). Render it once and copy for the rest, keyed by content hash.
+    baseline_render_cache: dict[str, Path] = {}
+
     for sample_index, predictions_i in enumerate(detection_predictions):
         scores = predictions_i.get("scores", torch.zeros(0))
         boxes = predictions_i.get("boxes", torch.zeros((0, 4)))
@@ -185,6 +189,7 @@ def explain_detection(
                 visualisers=list(visualisers),
                 raitap_kwargs=per_box_raitap,
                 call_provenance=call_provenance,
+                baseline_render_cache=baseline_render_cache,
                 **normalised_call_kwargs,
             )
             result.detection_box = DetectionBox(

--- a/src/raitap/pipeline/phases/tests/test_explain_detection.py
+++ b/src/raitap/pipeline/phases/tests/test_explain_detection.py
@@ -80,6 +80,7 @@ class _RecordingExplainer:
                 "inputs_shape": tuple(inputs.shape),
                 "run_dir": run_dir,
                 "call_target": kwargs.get("target"),
+                "call_provenance": kwargs.get("call_provenance"),
             }
         )
         semantics = ExplanationSemantics(
@@ -361,6 +362,34 @@ def test_explain_detection_with_list_inputs(
             f"Expected (1, 3, 8, 8) but got {call['inputs_shape']} — "
             "list slice was probably passed instead of unsqueezed tensor"
         )
+
+
+def test_explain_detection_forwards_call_provenance(
+    detection_forward_output: ForwardOutput, tmp_path: Path
+) -> None:
+    backend = TorchBackend(_FakeDetector(), task_kind=TaskKind.detection)
+    explainer = _RecordingExplainer()
+    provenance = {"baselines": {"source": "cfg", "n_samples": 1}}
+
+    list(
+        explain_detection(
+            inputs=torch.zeros(2, 3, 8, 8),
+            forward_output=detection_forward_output,
+            backend=backend,
+            explainer=explainer,
+            explainer_target="t",
+            explainer_name="x",
+            visualisers=[],
+            base_run_dir=tmp_path,
+            raitap_kwargs={"detection": {"score_threshold": 0.5, "max_boxes": 5}},
+            call_kwargs={},
+            call_provenance=provenance,
+        )
+    )
+
+    assert explainer.calls, "expected at least one explain() call"
+    for call in explainer.calls:
+        assert call["call_provenance"] == provenance
 
 
 def test_sample_as_batch_helper_list_and_tensor() -> None:

--- a/src/raitap/pipeline/phases/tests/test_explain_detection.py
+++ b/src/raitap/pipeline/phases/tests/test_explain_detection.py
@@ -14,6 +14,7 @@ from raitap.pipeline.outputs import ForwardOutput
 from raitap.pipeline.phases.explain_detection import explain_detection
 from raitap.transparency.contracts import (
     DetectionBox,
+    ExplainerSemanticsHints,
     ExplanationOutputSpace,
     ExplanationPayloadKind,
     ExplanationScope,
@@ -50,7 +51,9 @@ class _RecordingExplainer:
     """Test double — captures every explain() invocation."""
 
     algorithm = "IntegratedGradients"
-    algorithm_registry: ClassVar[dict[str, Any]] = {"IntegratedGradients": frozenset()}
+    algorithm_registry: ClassVar[dict[str, Any]] = {
+        "IntegratedGradients": ExplainerSemanticsHints(frozenset())
+    }
     output_payload_kind = ExplanationPayloadKind.ATTRIBUTIONS
     output_scope = ExplanationScope.LOCAL
 

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -704,6 +704,20 @@ def _build_local_section(
             if not explanation.has_visualisations_for_scope(ExplanationScope.LOCAL):
                 continue
             explainer_name = explanation.explainer_name or explanation.run_dir.name
+            box_suffix_for_baseline = (
+                f"_box_{explanation.detection_box.display_index}_{explanation.detection_box.raw_index}"
+                if explanation.detection_box is not None
+                else ""
+            )
+            baseline_image = _stage_baseline_image(
+                explanation,
+                assets_dir=assets_dir,
+                stem=(
+                    f"sample_{selected.summary.sample_index}_"
+                    f"{_safe_name(explainer_name)}{box_suffix_for_baseline}"
+                ),
+            )
+            baseline_emitted = False
 
             for visualiser_index, configured in enumerate(explanation.visualisers):
                 if (
@@ -781,6 +795,10 @@ def _build_local_section(
                     metadata["visualiser_title"] = str(visualiser_title)
                 if thumbnail_source_names:
                     metadata["thumbnail_source_explainer_names"] = thumbnail_source_names
+                group_images = images
+                if baseline_image is not None and not baseline_emitted:
+                    group_images = (*images, baseline_image)
+                    baseline_emitted = True
                 sample_groups.append(
                     ReportGroup(
                         heading=(
@@ -788,7 +806,7 @@ def _build_local_section(
                             f" - Visualiser: {visualiser_name}"
                             f"{heading_box_part}"
                         ),
-                        images=images,
+                        images=group_images,
                         table_rows=_transparency_table_rows(
                             explanation,
                             selected_samples=[selected],
@@ -1468,3 +1486,26 @@ def _requested_sample_metadata(sample: SelectedSample) -> dict[str, object]:
 
 def _safe_name(value: str) -> str:
     return "".join(ch if ch.isalnum() else "_" for ch in value).strip("_") or "asset"
+
+
+def _stage_baseline_image(
+    explanation: Any,
+    *,
+    assets_dir: Path,
+    stem: str,
+) -> Path | None:
+    """Copy an explanation's baseline PNG into ``assets_dir``; return staged path.
+
+    Returns ``None`` when the explanation has no baseline image or the source
+    file is missing (backward-compatible artefacts).
+    """
+    baseline = getattr(explanation, "baseline", None)
+    if baseline is None or baseline.image_path is None:
+        return None
+    source = explanation.run_dir / baseline.image_path
+    if not source.exists():
+        return None
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    target = assets_dir / f"baseline_{stem}{source.suffix}"
+    shutil.copy2(source, target)
+    return target

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -1087,6 +1087,21 @@ def _overlay_detection_boxes(figure: Any, *, outputs: RunOutputs, sample_index: 
         )
 
 
+# Human-facing labels for the baseline ``mode`` token. The raw token is kept in
+# ``metadata.json``; the report shows the readable phrasing (issue #210).
+_BASELINE_MODE_LABELS = {
+    "configured": "configured dataset",
+    "user_tensor": "user-provided tensor",
+    "zero": "all-zeros (method default)",
+    "input_batch": "input batch (method default)",
+}
+
+
+def _baseline_mode_label(mode: object) -> str:
+    token = str(mode)
+    return _BASELINE_MODE_LABELS.get(token, token)
+
+
 def _transparency_table_rows(
     explanation: Any,
     *,
@@ -1133,7 +1148,7 @@ def _transparency_table_rows(
 
     baseline = getattr(explanation, "baseline", None)
     if baseline is not None:
-        rows.append(("baseline.mode", str(baseline.mode)))
+        rows.append(("baseline.mode", _baseline_mode_label(baseline.mode)))
         if baseline.source is not None:
             rows.append(("baseline.source", str(baseline.source)))
         if baseline.n_samples is not None:

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -795,9 +795,17 @@ def _build_local_section(
                     metadata["visualiser_title"] = str(visualiser_title)
                 if thumbnail_source_names:
                     metadata["thumbnail_source_explainer_names"] = thumbnail_source_names
+                if baseline_image is not None:
+                    # Drives the "View baseline" link on every visualiser card of
+                    # this explanation (HTML); the image itself is rendered once
+                    # in the per-explainer reference card via ``baseline_image``.
+                    metadata["has_baseline_image"] = True
                 group_images = images
                 if baseline_image is not None and not baseline_emitted:
                     group_images = (*images, baseline_image)
+                    # Stored as str (not Path) so group metadata stays JSON-serialisable
+                    # for the report manifest; the view model coerces it back.
+                    metadata["baseline_image"] = str(baseline_image)
                     baseline_emitted = True
                 sample_groups.append(
                     ReportGroup(

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -795,18 +795,18 @@ def _build_local_section(
                     metadata["visualiser_title"] = str(visualiser_title)
                 if thumbnail_source_names:
                     metadata["thumbnail_source_explainer_names"] = thumbnail_source_names
-                if baseline_image is not None:
-                    # Drives the "View baseline" link on every visualiser card of
-                    # this explanation (HTML); the image itself is rendered once
-                    # in the per-explainer reference card via ``baseline_image``.
-                    metadata["has_baseline_image"] = True
                 group_images = images
-                if baseline_image is not None and not baseline_emitted:
-                    group_images = (*images, baseline_image)
-                    # Stored as str (not Path) so group metadata stays JSON-serialisable
-                    # for the report manifest; the view model coerces it back.
+                if baseline_image is not None:
+                    # One field drives BOTH the "View baseline" link (every card)
+                    # and the anchored image in the reference card, so they cannot
+                    # drift into a dead anchor (issue #210 review #6). Stored as str
+                    # so group metadata stays JSON-serialisable for the manifest.
                     metadata["baseline_image"] = str(baseline_image)
-                    baseline_emitted = True
+                    if not baseline_emitted:
+                        # Add the file to group.images once per explanation so the
+                        # PDF reporter (which renders all group images) shows it once.
+                        group_images = (*images, baseline_image)
+                        baseline_emitted = True
                 sample_groups.append(
                     ReportGroup(
                         heading=(

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -1105,7 +1105,18 @@ def _transparency_table_rows(
     if output_space.requires_interpolation:
         rows.append(("requires_interpolation", "true"))
 
+    baseline = getattr(explanation, "baseline", None)
+    if baseline is not None:
+        rows.append(("baseline.mode", str(baseline.mode)))
+        if baseline.source is not None:
+            rows.append(("baseline.source", str(baseline.source)))
+        if baseline.n_samples is not None:
+            rows.append(("baseline.n_samples", str(baseline.n_samples)))
+        rows.append(("baseline.shape", _format_shape(baseline.shape)))
+
     for key, value in explanation.call_kwargs.items():
+        if baseline is not None and key == baseline.kwarg_name:
+            continue
         formatted = _format_table_value(value)
         if formatted is not None:
             rows.append((f"call.{key}", formatted))

--- a/src/raitap/reporting/templates/_explainer_reference.html.j2
+++ b/src/raitap/reporting/templates/_explainer_reference.html.j2
@@ -16,6 +16,12 @@
                   {% endfor %}
                 </tbody>
               </table>
+              {% if explainer.baseline_image_src %}
+                <figure class="baseline-figure" id="baseline-{{ explainer.explainer_name|slug }}">
+                  <img class="figure" src="{{ explainer.baseline_image_src }}" alt="Baseline reference for {{ explainer.explainer_name }}">
+                  <figcaption>Baseline ({{ explainer.explainer_name }})</figcaption>
+                </figure>
+              {% endif %}
             </article>
           {% endif %}
         {% endfor %}

--- a/src/raitap/reporting/templates/_local.html.j2
+++ b/src/raitap/reporting/templates/_local.html.j2
@@ -87,6 +87,7 @@
                   </details>
                 {% endif %}
                 <a class="text-link" href="#explainer-{{ explainer.explainer_name|slug }}">About this explainer</a>
+                {% if explainer.has_baseline_image %}<a class="text-link" href="#baseline-{{ explainer.explainer_name|slug }}">View baseline</a>{% endif %}
               </article>
             {% endfor %}
           </div>

--- a/src/raitap/reporting/templates/_local.html.j2
+++ b/src/raitap/reporting/templates/_local.html.j2
@@ -87,7 +87,7 @@
                   </details>
                 {% endif %}
                 <a class="text-link" href="#explainer-{{ explainer.explainer_name|slug }}">About this explainer</a>
-                {% if explainer.has_baseline_image %}<a class="text-link" href="#baseline-{{ explainer.explainer_name|slug }}">View baseline</a>{% endif %}
+                {% if explainer.baseline_image_src %}<a class="text-link" href="#baseline-{{ explainer.explainer_name|slug }}">View baseline</a>{% endif %}
               </article>
             {% endfor %}
           </div>

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -2199,6 +2199,14 @@ def test_stage_baseline_image_none_when_no_baseline_or_missing_file(tmp_path: Pa
     missing = SimpleNamespace(baseline=record, run_dir=tmp_path / "missing")
     assert _stage_baseline_image(missing, assets_dir=tmp_path / "a", stem="s") is None
 
+    # A baseline with no rendered image (e.g. tabular modality) stages nothing.
+    no_image_record = BaselineRecord(
+        kwarg_name="baselines", mode="zero", source=None, n_samples=None,
+        shape=(1, 4), dtype="torch.float32", sha256="h", image_path=None,
+    )
+    no_image = SimpleNamespace(baseline=no_image_record, run_dir=tmp_path)
+    assert _stage_baseline_image(no_image, assets_dir=tmp_path / "a", stem="s") is None
+
 
 def test_build_report_attaches_baseline_image_once_per_explanation(tmp_path: Path) -> None:
     from pathlib import Path as _Path

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -2111,6 +2111,16 @@ def _write_test_image(path: Path) -> Path:
     return path
 
 
+def test_baseline_mode_label_humanises_known_tokens() -> None:
+    from raitap.reporting.builder import _baseline_mode_label
+
+    assert _baseline_mode_label("configured") == "configured dataset"
+    assert _baseline_mode_label("user_tensor") == "user-provided tensor"
+    assert _baseline_mode_label("zero") == "all-zeros (method default)"
+    assert _baseline_mode_label("input_batch") == "input batch (method default)"
+    assert _baseline_mode_label("future_mode") == "future_mode"  # unknown -> passthrough
+
+
 def test_transparency_table_rows_include_baseline_and_hide_opaque_kwarg(tmp_path: Path) -> None:
     from pathlib import Path as _Path
 
@@ -2145,7 +2155,8 @@ def test_transparency_table_rows_include_baseline_and_hide_opaque_kwarg(tmp_path
 
     rows = dict(_transparency_table_rows(explanation, selected_samples=[], visualiser_index=0))
 
-    assert rows["baseline.mode"] == "configured"
+    # Mode token is humanised for the report; raw token stays in metadata.json.
+    assert rows["baseline.mode"] == "configured dataset"
     assert rows["baseline.source"] == "imagenet"
     assert rows["baseline.n_samples"] == "50"
     assert "baseline.shape" in rows

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -2169,8 +2169,13 @@ def test_stage_baseline_image_copies_when_present(tmp_path: Path) -> None:
     run_dir.mkdir()
     _write_test_image(run_dir / "baseline.png")  # existing helper in this module
     record = BaselineRecord(
-        kwarg_name="baselines", mode="zero", source=None, n_samples=None,
-        shape=(1, 1, 4, 4), dtype="torch.float32", sha256="h",
+        kwarg_name="baselines",
+        mode="zero",
+        source=None,
+        n_samples=None,
+        shape=(1, 1, 4, 4),
+        dtype="torch.float32",
+        sha256="h",
         image_path=_Path("baseline.png"),
     )
     explanation = SimpleNamespace(baseline=record, run_dir=run_dir)
@@ -2192,8 +2197,13 @@ def test_stage_baseline_image_none_when_no_baseline_or_missing_file(tmp_path: Pa
     assert _stage_baseline_image(no_baseline, assets_dir=tmp_path / "a", stem="s") is None
 
     record = BaselineRecord(
-        kwarg_name="baselines", mode="zero", source=None, n_samples=None,
-        shape=(1, 1, 4, 4), dtype="torch.float32", sha256="h",
+        kwarg_name="baselines",
+        mode="zero",
+        source=None,
+        n_samples=None,
+        shape=(1, 1, 4, 4),
+        dtype="torch.float32",
+        sha256="h",
         image_path=_Path("baseline.png"),
     )
     missing = SimpleNamespace(baseline=record, run_dir=tmp_path / "missing")
@@ -2201,8 +2211,14 @@ def test_stage_baseline_image_none_when_no_baseline_or_missing_file(tmp_path: Pa
 
     # A baseline with no rendered image (e.g. tabular modality) stages nothing.
     no_image_record = BaselineRecord(
-        kwarg_name="baselines", mode="zero", source=None, n_samples=None,
-        shape=(1, 4), dtype="torch.float32", sha256="h", image_path=None,
+        kwarg_name="baselines",
+        mode="zero",
+        source=None,
+        n_samples=None,
+        shape=(1, 4),
+        dtype="torch.float32",
+        sha256="h",
+        image_path=None,
     )
     no_image = SimpleNamespace(baseline=no_image_record, run_dir=tmp_path)
     assert _stage_baseline_image(no_image, assets_dir=tmp_path / "a", stem="s") is None
@@ -2222,8 +2238,13 @@ def test_build_report_attaches_baseline_image_once_per_explanation(tmp_path: Pat
     _write_test_image(run_dir / "baseline.png")
 
     record = BaselineRecord(
-        kwarg_name="baselines", mode="zero", source=None, n_samples=None,
-        shape=(1, 1, 4, 4), dtype="torch.float32", sha256="h",
+        kwarg_name="baselines",
+        mode="zero",
+        source=None,
+        n_samples=None,
+        shape=(1, 1, 4, 4),
+        dtype="torch.float32",
+        sha256="h",
         image_path=_Path("baseline.png"),
     )
     explanation = ExplanationResult(
@@ -2265,9 +2286,7 @@ def test_build_report_attaches_baseline_image_once_per_explanation(tmp_path: Pat
     baseline_imgs = [
         p for group in local.groups for p in group.images if p.name.startswith("baseline_")
     ]
-    local_vis_groups = [
-        g for g in local.groups if g.metadata.get("role") == "local_visualiser"
-    ]
+    local_vis_groups = [g for g in local.groups if g.metadata.get("role") == "local_visualiser"]
     # Two visualisers -> two local_visualiser groups, but the baseline renders once.
     assert len(local_vis_groups) == 2
     assert len(baseline_imgs) == 1

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -2109,3 +2109,50 @@ def _write_test_image(path: Path) -> Path:
     fig.savefig(path, bbox_inches="tight", dpi=80)
     plt.close(fig)
     return path
+
+
+def test_transparency_table_rows_include_baseline_and_hide_opaque_kwarg(tmp_path: Path) -> None:
+    from pathlib import Path as _Path
+
+    from raitap.reporting.builder import _transparency_table_rows
+    from raitap.transparency.contracts import BaselineRecord
+
+    record = BaselineRecord(
+        kwarg_name="background_data",
+        mode="configured",
+        source="imagenet",
+        n_samples=50,
+        shape=(50, 3, 4, 4),
+        dtype="torch.float32",
+        sha256="secret-hash",
+        image_path=_Path("baseline.png"),
+    )
+    explanation = ExplanationResult(
+        attributions=torch.rand(1, 1, 4, 4),
+        inputs=torch.rand(1, 1, 4, 4),
+        run_dir=tmp_path / "exp",
+        experiment_name="demo",
+        explainer_target="t",
+        algorithm="GradientExplainer",
+        explainer_name="shap_grad",
+        semantics=_local_image_semantics((1, 1, 4, 4)),
+        # Small tensor (numel == 4) so it WOULD render as call.background_data
+        # without suppression — proving the suppression branch is exercised.
+        call_kwargs={"background_data": torch.zeros(4), "target": 0},
+        visualisers=[ConfiguredVisualiser(visualiser=_LocalImageVisualiser())],
+        baseline=record,
+    )
+
+    rows = dict(_transparency_table_rows(explanation, selected_samples=[], visualiser_index=0))
+
+    assert rows["baseline.mode"] == "configured"
+    assert rows["baseline.source"] == "imagenet"
+    assert rows["baseline.n_samples"] == "50"
+    assert "baseline.shape" in rows
+    # sha256 never reaches the report.
+    assert "secret-hash" not in str(rows)
+    assert not any(k.startswith("baseline.sha2") for k in rows)
+    # The opaque tensor kwarg is suppressed in favour of the labelled rows.
+    assert "call.background_data" not in rows
+    # Non-baseline kwargs still render.
+    assert "call.target" in rows

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -2156,3 +2156,110 @@ def test_transparency_table_rows_include_baseline_and_hide_opaque_kwarg(tmp_path
     assert "call.background_data" not in rows
     # Non-baseline kwargs still render.
     assert "call.target" in rows
+
+
+def test_stage_baseline_image_copies_when_present(tmp_path: Path) -> None:
+    from pathlib import Path as _Path
+    from types import SimpleNamespace
+
+    from raitap.reporting.builder import _stage_baseline_image
+    from raitap.transparency.contracts import BaselineRecord
+
+    run_dir = tmp_path / "exp"
+    run_dir.mkdir()
+    _write_test_image(run_dir / "baseline.png")  # existing helper in this module
+    record = BaselineRecord(
+        kwarg_name="baselines", mode="zero", source=None, n_samples=None,
+        shape=(1, 1, 4, 4), dtype="torch.float32", sha256="h",
+        image_path=_Path("baseline.png"),
+    )
+    explanation = SimpleNamespace(baseline=record, run_dir=run_dir)
+
+    out = _stage_baseline_image(explanation, assets_dir=tmp_path / "assets", stem="s0")
+    assert out is not None
+    assert out.exists()
+    assert out.name == "baseline_s0.png"
+
+
+def test_stage_baseline_image_none_when_no_baseline_or_missing_file(tmp_path: Path) -> None:
+    from pathlib import Path as _Path
+    from types import SimpleNamespace
+
+    from raitap.reporting.builder import _stage_baseline_image
+    from raitap.transparency.contracts import BaselineRecord
+
+    no_baseline = SimpleNamespace(baseline=None, run_dir=tmp_path)
+    assert _stage_baseline_image(no_baseline, assets_dir=tmp_path / "a", stem="s") is None
+
+    record = BaselineRecord(
+        kwarg_name="baselines", mode="zero", source=None, n_samples=None,
+        shape=(1, 1, 4, 4), dtype="torch.float32", sha256="h",
+        image_path=_Path("baseline.png"),
+    )
+    missing = SimpleNamespace(baseline=record, run_dir=tmp_path / "missing")
+    assert _stage_baseline_image(missing, assets_dir=tmp_path / "a", stem="s") is None
+
+
+def test_build_report_attaches_baseline_image_once_per_explanation(tmp_path: Path) -> None:
+    from pathlib import Path as _Path
+
+    from raitap.transparency.contracts import BaselineRecord
+
+    config = AppConfig(experiment_name="bl")
+    set_output_root(config, tmp_path)
+    config.reporting = ReportingConfig(_target_="PDFReporter", filename="report.pdf")
+
+    run_dir = tmp_path / "transparency" / "exp"
+    run_dir.mkdir(parents=True)
+    _write_test_image(run_dir / "baseline.png")
+
+    record = BaselineRecord(
+        kwarg_name="baselines", mode="zero", source=None, n_samples=None,
+        shape=(1, 1, 4, 4), dtype="torch.float32", sha256="h",
+        image_path=_Path("baseline.png"),
+    )
+    explanation = ExplanationResult(
+        attributions=torch.rand(1, 1, 4, 4),
+        inputs=torch.rand(1, 1, 4, 4),
+        run_dir=run_dir,
+        experiment_name="bl",
+        explainer_target="t",
+        algorithm="IntegratedGradients",
+        explainer_name="captum_ig",
+        semantics=_local_image_semantics((1, 1, 4, 4)),
+        visualisers=[
+            ConfiguredVisualiser(visualiser=_LocalImageVisualiser()),
+            ConfiguredVisualiser(visualiser=_LocalImageVisualiser()),
+        ],
+        baseline=record,
+    )
+    outputs = RunOutputs(
+        explanations=[explanation],
+        visualisations=[],
+        metrics=None,
+        forward_output=_fo(torch.tensor([[0.1, 0.9]])),
+        sample_ids=["a"],
+        prediction_summaries=(
+            PredictionSummary(
+                sample_index=0,
+                sample_id="a",
+                predicted_class=1,
+                target_class=0,
+                confidence=0.9,
+                correct=False,
+            ),
+        ),
+    )
+
+    report = build_report(config, outputs)
+
+    local = next(s for s in report.sections if s.title == "Local Explanations")
+    baseline_imgs = [
+        p for group in local.groups for p in group.images if p.name.startswith("baseline_")
+    ]
+    local_vis_groups = [
+        g for g in local.groups if g.metadata.get("role") == "local_visualiser"
+    ]
+    # Two visualisers -> two local_visualiser groups, but the baseline renders once.
+    assert len(local_vis_groups) == 2
+    assert len(baseline_imgs) == 1

--- a/src/raitap/reporting/tests/test_html_reporter.py
+++ b/src/raitap/reporting/tests/test_html_reporter.py
@@ -213,7 +213,6 @@ def test_html_reporter_renders_baseline_image_and_view_link(tmp_path: Path) -> N
                         "explainer_name": "shap_grad",
                         "algorithm": "GradientExplainer",
                         "visualiser_name": "SHAP",
-                        "has_baseline_image": True,
                         "baseline_image": "reports/_assets/baseline_sample_0_shap_grad.png",
                     },
                 ),

--- a/src/raitap/reporting/tests/test_html_reporter.py
+++ b/src/raitap/reporting/tests/test_html_reporter.py
@@ -181,6 +181,68 @@ def test_html_reporter_renders_legacy_local_detail_images(tmp_path: Path) -> Non
     assert "No local explanations were configured" not in html
 
 
+def test_html_reporter_renders_baseline_image_and_view_link(tmp_path: Path) -> None:
+    sections = (
+        ReportSection.from_groups(
+            "Local Explanations",
+            [
+                ReportGroup(
+                    heading="Sample - correct",
+                    table_rows=(("sample_index", "0"), ("sample_id", "forest.jpg")),
+                    metadata={"role": "sample_header", "bucket": "correct", "sample_index": 0},
+                    images=(Path("reports/_assets/sample_0_original.png"),),
+                ),
+                ReportGroup(
+                    heading="Explainer: shap_grad - Visualiser: SHAP",
+                    images=(
+                        Path("reports/_assets/sample_0_shap_grad.png"),
+                        Path("reports/_assets/baseline_sample_0_shap_grad.png"),
+                    ),
+                    table_rows=(
+                        ("explainer", "shap_grad"),
+                        ("algorithm", "GradientExplainer"),
+                        ("baseline.mode", "configured"),
+                        ("baseline.source", "imagenet_val"),
+                        ("baseline.n_samples", "20"),
+                        ("baseline.shape", "20 x 3 x 96 x 96"),
+                    ),
+                    metadata={
+                        "role": "local_visualiser",
+                        "bucket": "correct",
+                        "sample_index": 0,
+                        "explainer_name": "shap_grad",
+                        "algorithm": "GradientExplainer",
+                        "visualiser_name": "SHAP",
+                        "has_baseline_image": True,
+                        "baseline_image": "reports/_assets/baseline_sample_0_shap_grad.png",
+                    },
+                ),
+            ],
+            metadata={"section_role": "local"},
+        ),
+    )
+
+    HTMLReporter(_config()).generate(sections, report_dir=tmp_path)
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+
+    # Baseline image rendered once in the per-explainer reference card, anchored.
+    assert 'id="baseline-shap_grad"' in html
+    assert 'src="_assets/baseline_sample_0_shap_grad.png"' in html
+    # Descriptor rows are shown (n_samples + shape); sha256 never reaches the report.
+    assert "baseline.n_samples" in html
+    assert "20 x 3 x 96 x 96" in html
+    assert "sha256" not in html
+    # Each explanation panel carries a working "View baseline" link.
+    assert "View baseline" in html
+    assert 'href="#baseline-shap_grad"' in html
+
+    parser = _ReportHTMLParser()
+    parser.feed(html)
+    # The baseline anchor exists and every fragment link resolves to an id.
+    assert "baseline-shap_grad" in parser.ids
+    assert [href for href in parser.fragment_hrefs if href not in parser.ids] == []
+
+
 def _config(*, filename: str = "report.pdf") -> AppConfig:
     config = AppConfig(experiment_name="html-report-test")
     config.reporting = ReportingConfig(

--- a/src/raitap/reporting/tests/test_view_model.py
+++ b/src/raitap/reporting/tests/test_view_model.py
@@ -97,7 +97,7 @@ def test_build_view_ignores_multirun_heading_prefixes_when_metadata_is_present()
     assert view.local_samples[0].explainers[0].algorithm == "LayerGradCam"
 
 
-def test_build_view_carries_baseline_image_and_link_flag_onto_explainer() -> None:
+def test_build_view_carries_baseline_image_onto_explainer() -> None:
     section = ReportSection.from_groups(
         "Local Explanations",
         [
@@ -118,7 +118,6 @@ def test_build_view_carries_baseline_image_and_link_flag_onto_explainer() -> Non
                     "explainer_name": "shap_grad",
                     "algorithm": "GradientExplainer",
                     "visualiser_name": "SHAP",
-                    "has_baseline_image": True,
                     "baseline_image": "reports/_assets/baseline_sample_0_shap_grad.png",
                 },
             ),
@@ -129,7 +128,7 @@ def test_build_view_carries_baseline_image_and_link_flag_onto_explainer() -> Non
     view = build_view((section,), {})
 
     explainer = view.local_samples[0].explainers[0]
-    assert explainer.has_baseline_image is True
+    # One field drives both the link and the reference-card anchor (review #6).
     assert explainer.baseline_image_src == "_assets/baseline_sample_0_shap_grad.png"
     # The local-panel image is the visualiser render, not the baseline.
     assert explainer.image_srcs[0] == "_assets/sample_0_shap_grad.png"

--- a/src/raitap/reporting/tests/test_view_model.py
+++ b/src/raitap/reporting/tests/test_view_model.py
@@ -97,6 +97,44 @@ def test_build_view_ignores_multirun_heading_prefixes_when_metadata_is_present()
     assert view.local_samples[0].explainers[0].algorithm == "LayerGradCam"
 
 
+def test_build_view_carries_baseline_image_and_link_flag_onto_explainer() -> None:
+    section = ReportSection.from_groups(
+        "Local Explanations",
+        [
+            ReportGroup(
+                heading="Explainer: shap_grad - Visualiser: SHAP",
+                images=(
+                    Path("_assets/sample_0_shap_grad.png"),
+                    Path("_assets/baseline_sample_0_shap_grad.png"),
+                ),
+                table_rows=(
+                    ("explainer", "shap_grad"),
+                    ("algorithm", "GradientExplainer"),
+                    ("baseline.n_samples", "20"),
+                ),
+                metadata={
+                    "role": "local_visualiser",
+                    "sample_index": 0,
+                    "explainer_name": "shap_grad",
+                    "algorithm": "GradientExplainer",
+                    "visualiser_name": "SHAP",
+                    "has_baseline_image": True,
+                    "baseline_image": "reports/_assets/baseline_sample_0_shap_grad.png",
+                },
+            ),
+        ],
+        metadata={"section_role": "local_explanations"},
+    )
+
+    view = build_view((section,), {})
+
+    explainer = view.local_samples[0].explainers[0]
+    assert explainer.has_baseline_image is True
+    assert explainer.baseline_image_src == "_assets/baseline_sample_0_shap_grad.png"
+    # The local-panel image is the visualiser render, not the baseline.
+    assert explainer.image_srcs[0] == "_assets/sample_0_shap_grad.png"
+
+
 def test_build_view_renders_legacy_local_detail_groups_as_samples() -> None:
     section = ReportSection.from_groups(
         "Local Explanations",

--- a/src/raitap/reporting/view_model.py
+++ b/src/raitap/reporting/view_model.py
@@ -50,11 +50,10 @@ class ExplainerView:
     headline: dict[str, str]
     context: dict[str, str]
     technical: dict[str, str]
-    # Baseline (issue #210): ``has_baseline_image`` flags every visualiser card
-    # of an explanation whose baseline rendered an image (drives the "View
-    # baseline" link); ``baseline_image_src`` is set only on the card that owns
-    # the rendered baseline (shown once in the per-explainer reference card).
-    has_baseline_image: bool = False
+    # Baseline (issue #210): ``baseline_image_src`` is set on every visualiser
+    # card of an explanation whose baseline rendered an image. It drives BOTH the
+    # "View baseline" link (each card) and the anchored image in the per-explainer
+    # reference card, so the link and its anchor cannot drift apart (review #6).
     baseline_image_src: str | None = None
 
 
@@ -420,7 +419,6 @@ def _build_explainer_view(group: ReportGroup) -> ExplainerView:
         headline=headline,
         context=context,
         technical=technical,
-        has_baseline_image=bool(group.metadata.get("has_baseline_image")),
         baseline_image_src=baseline_image_src,
     )
 

--- a/src/raitap/reporting/view_model.py
+++ b/src/raitap/reporting/view_model.py
@@ -50,6 +50,12 @@ class ExplainerView:
     headline: dict[str, str]
     context: dict[str, str]
     technical: dict[str, str]
+    # Baseline (issue #210): ``has_baseline_image`` flags every visualiser card
+    # of an explanation whose baseline rendered an image (drives the "View
+    # baseline" link); ``baseline_image_src`` is set only on the card that owns
+    # the rendered baseline (shown once in the per-explainer reference card).
+    has_baseline_image: bool = False
+    baseline_image_src: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -400,6 +406,11 @@ def _build_explainer_view(group: ReportGroup) -> ExplainerView:
         or "visualiser"
     )
 
+    baseline_image = group.metadata.get("baseline_image")
+    baseline_image_src = (
+        _image_src(Path(baseline_image)) if isinstance(baseline_image, str) else None
+    )
+
     return ExplainerView(
         explainer_name=explainer_name,
         algorithm=algorithm,
@@ -409,6 +420,8 @@ def _build_explainer_view(group: ReportGroup) -> ExplainerView:
         headline=headline,
         context=context,
         technical=technical,
+        has_baseline_image=bool(group.metadata.get("has_baseline_image")),
+        baseline_image_src=baseline_image_src,
     )
 
 

--- a/src/raitap/transparency/__init__.py
+++ b/src/raitap/transparency/__init__.py
@@ -30,6 +30,7 @@ from raitap._adapters import ALL as ALL
 from .contracts import (
     ExplainerAdapter,
     ExplainerCapability,
+    ExplainerSemanticsHints,
     ExplanationOutputSpace,
     ExplanationPayloadKind,
     ExplanationScope,
@@ -198,6 +199,7 @@ __all__ = [  # noqa: RUF022
     # Contracts
     "ExplainerAdapter",
     "ExplainerCapability",
+    "ExplainerSemanticsHints",
     "ExplanationOutputSpace",
     "ExplanationPayloadKind",
     "ExplanationScope",

--- a/src/raitap/transparency/baselines.py
+++ b/src/raitap/transparency/baselines.py
@@ -1,0 +1,143 @@
+"""Capture the reference input (baseline) an attribution method used.
+
+Single helper invoked once at the explain chokepoint
+(:meth:`AttributionOnlyExplainer.explain`). Resolves the baseline ``mode``,
+hashes the exact tensor used as baseline, and — for image modality — renders a
+first-sample preview. See issue #210 and the design doc
+``docs/superpowers/specs/2026-05-26-baseline-documentation-design.md``.
+
+The render helpers are inlined (not imported from ``input_thumbnail``) to avoid
+cross-module coupling on another module's private functions; ``matplotlib`` /
+``numpy`` are imported lazily inside the render function to keep importing
+``build_baseline_record`` light.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from raitap.utils.lazy import lazy_import
+
+from .contracts import BaselineRecord
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    import torch
+else:
+    torch = lazy_import("torch")
+
+_BASELINE_IMAGE_NAME = "baseline.png"
+
+
+def build_baseline_record(
+    *,
+    explainer: object,
+    inputs: torch.Tensor,
+    call_kwargs: Mapping[str, Any],
+    call_provenance: Mapping[str, Mapping[str, Any]] | None,
+    input_spec: object,
+    run_dir: Path,
+) -> BaselineRecord | None:
+    """Return a :class:`BaselineRecord` for *explainer*, or ``None``.
+
+    ``None`` when the explainer family takes no baseline, or the kwarg is absent
+    and the algorithm has no meaningful implicit default (e.g. Saliency,
+    TreeExplainer-without-background).
+    """
+    kwarg_name = getattr(explainer, "baseline_kwarg", None)
+    if kwarg_name is None:
+        return None
+
+    algorithm = str(getattr(explainer, "algorithm", ""))
+    value = call_kwargs.get(kwarg_name)
+
+    source: str | None = None
+    n_samples: int | None = None
+
+    if isinstance(value, torch.Tensor):
+        provenance = (call_provenance or {}).get(kwarg_name)
+        if provenance is not None:
+            mode = "configured"
+            raw_source = provenance.get("source")
+            source = None if raw_source is None else str(raw_source)
+            raw_n = provenance.get("n_samples")
+            n_samples = None if raw_n is None else int(raw_n)
+        else:
+            mode = "user_tensor"
+        baseline_tensor = value
+    else:
+        defaults = getattr(explainer, "baseline_defaults", {})
+        mode = defaults.get(algorithm)
+        if mode is None:
+            return None
+        if mode == "zero":
+            baseline_tensor = torch.zeros_like(inputs[:1])
+        elif mode == "input_batch":
+            baseline_tensor = inputs
+        else:  # defensive: unknown declared default
+            return None
+
+    sha256 = _hash_tensor(baseline_tensor)
+    image_path: Path | None = None
+    if _is_image_modality(input_spec):
+        image_path = _render_baseline_image(baseline_tensor, run_dir)
+
+    return BaselineRecord(
+        kwarg_name=str(kwarg_name),
+        mode=str(mode),
+        source=source,
+        n_samples=n_samples,
+        shape=tuple(int(dim) for dim in baseline_tensor.shape),
+        dtype=str(baseline_tensor.dtype),
+        sha256=sha256,
+        image_path=image_path,
+    )
+
+
+def _hash_tensor(tensor: torch.Tensor) -> str:
+    data = tensor.detach().cpu().contiguous().numpy().tobytes()
+    return hashlib.sha256(data).hexdigest()
+
+
+def _is_image_modality(input_spec: object) -> bool:
+    kind = getattr(input_spec, "kind", None)
+    if kind is not None:
+        return str(kind).lower() == "image"
+    layout = getattr(input_spec, "layout", None)
+    return str(layout or "").upper().replace(" ", "") == "NCHW"
+
+
+def _render_baseline_image(baseline: torch.Tensor, run_dir: Path) -> Path:
+    """Render the first sample of *baseline* to ``run_dir/baseline.png``.
+
+    Mirrors the normalisation/layout of ``InputThumbnailVisualiser`` (min-max
+    normalise, NCHW->HWC, grayscale handling) without importing its private
+    helpers. Returns the path relative to ``run_dir`` for storage in the record.
+    """
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    sample = baseline[0] if baseline.ndim >= 4 else baseline
+    image = np.asarray(sample.detach().cpu().numpy())
+    if image.ndim == 3:
+        image = np.transpose(image, (1, 2, 0))
+    lo, hi = float(image.min()), float(image.max())
+    if hi > lo:
+        image = (image - lo) / (hi - lo)
+
+    fig, ax = plt.subplots(1, 1, figsize=(4, 4))
+    try:
+        if image.ndim == 3 and image.shape[-1] == 1:
+            ax.imshow(image[..., 0], cmap="gray")
+        else:
+            ax.imshow(image, cmap="gray" if image.ndim == 2 else None)
+        ax.axis("off")
+        fig.tight_layout()
+        run_dir.mkdir(parents=True, exist_ok=True)
+        fig.savefig(run_dir / _BASELINE_IMAGE_NAME, bbox_inches="tight", dpi=150)
+    finally:
+        plt.close(fig)
+    return Path(_BASELINE_IMAGE_NAME)

--- a/src/raitap/transparency/baselines.py
+++ b/src/raitap/transparency/baselines.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from raitap.utils.lazy import lazy_import
 
-from .contracts import BaselineRecord
+from .contracts import BaselineMode, BaselineRecord
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -65,22 +65,23 @@ def build_baseline_record(
     if isinstance(value, torch.Tensor):
         provenance = (call_provenance or {}).get(kwarg_name)
         if provenance is not None:
-            mode = "configured"
+            mode: BaselineMode | None = BaselineMode.CONFIGURED
             raw_source = provenance.get("source")
             source = None if raw_source is None else str(raw_source)
             raw_n = provenance.get("n_samples")
             n_samples = None if raw_n is None else int(raw_n)
         else:
-            mode = "user_tensor"
+            mode = BaselineMode.USER_TENSOR
         baseline_tensor = value
     else:
-        defaults = getattr(explainer, "baseline_defaults", {})
-        mode = defaults.get(algorithm)
+        # ``baseline_defaults`` values are ``BaselineMode`` members; comparison
+        # also accepts the bare-string equivalents (StrEnum) for forward compat.
+        mode = getattr(explainer, "baseline_defaults", {}).get(algorithm)
         if mode is None:
             return None
-        if mode == "zero":
+        if mode == BaselineMode.ZERO:
             baseline_tensor = torch.zeros_like(inputs[:1])
-        elif mode == "input_batch":
+        elif mode == BaselineMode.INPUT_BATCH:
             baseline_tensor = inputs
         else:  # defensive: unknown declared default
             return None

--- a/src/raitap/transparency/baselines.py
+++ b/src/raitap/transparency/baselines.py
@@ -115,6 +115,11 @@ def _is_image_modality(input_spec: object) -> bool:
     return str(layout or "").upper().replace(" ", "") == "NCHW"
 
 
+def _montage_caption(shown: int, total: int) -> str | None:
+    """Label for a capped baseline montage, or ``None`` when all tiles are shown."""
+    return f"Showing {shown} of {total}" if shown < total else None
+
+
 def _render_baseline_image(baseline: torch.Tensor, run_dir: Path) -> Path:
     """Render a preview of *baseline* to ``run_dir/baseline.png``.
 
@@ -128,9 +133,9 @@ def _render_baseline_image(baseline: torch.Tensor, run_dir: Path) -> Path:
     import matplotlib.pyplot as plt
     import numpy as np
 
+    total = int(baseline.shape[0]) if baseline.ndim >= 4 else 1
     if baseline.ndim >= 4:
-        n_show = min(int(baseline.shape[0]), _BASELINE_GRID_CAP)
-        tiles = [baseline[index] for index in range(n_show)]
+        tiles = [baseline[index] for index in range(min(total, _BASELINE_GRID_CAP))]
     else:
         tiles = [baseline]
 
@@ -154,6 +159,9 @@ def _render_baseline_image(baseline: torch.Tensor, run_dir: Path) -> Path:
             ax.axis("off")
         for ax in flat_axes[count:]:
             ax.axis("off")
+        caption = _montage_caption(count, total)
+        if caption is not None:
+            fig.suptitle(caption, fontsize=10)
         fig.tight_layout()
         run_dir.mkdir(parents=True, exist_ok=True)
         fig.savefig(run_dir / _BASELINE_IMAGE_NAME, bbox_inches="tight", dpi=150)

--- a/src/raitap/transparency/baselines.py
+++ b/src/raitap/transparency/baselines.py
@@ -15,6 +15,7 @@ cross-module coupling on another module's private functions; ``matplotlib`` /
 from __future__ import annotations
 
 import hashlib
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -45,12 +46,18 @@ def build_baseline_record(
     call_provenance: Mapping[str, Mapping[str, Any]] | None,
     input_spec: object,
     run_dir: Path,
+    render_cache: dict[str, Path] | None = None,
 ) -> BaselineRecord | None:
     """Return a :class:`BaselineRecord` for *explainer*, or ``None``.
 
     ``None`` when the explainer family takes no baseline, or the kwarg is absent
     and the algorithm has no meaningful implicit default (e.g. Saliency,
     TreeExplainer-without-background).
+
+    ``render_cache`` (keyed by the baseline ``sha256``) lets callers that invoke
+    this helper repeatedly for the *same* baseline — e.g. the detection K-loop,
+    one ``explain`` per box — render the preview image once and copy it for the
+    rest, instead of re-running matplotlib per box.
     """
     kwarg_name = getattr(explainer, "baseline_kwarg", None)
     if kwarg_name is None:
@@ -89,7 +96,7 @@ def build_baseline_record(
     sha256 = _hash_tensor(baseline_tensor)
     image_path: Path | None = None
     if _is_image_modality(input_spec):
-        image_path = _render_baseline_image(baseline_tensor, run_dir)
+        image_path = _resolve_baseline_image(baseline_tensor, run_dir, sha256, render_cache)
 
     return BaselineRecord(
         kwarg_name=str(kwarg_name),
@@ -117,6 +124,35 @@ def _is_image_modality(input_spec: object) -> bool:
         return str(kind).lower() == "image"
     layout = getattr(input_spec, "layout", None)
     return str(layout or "").upper().replace(" ", "") == "NCHW"
+
+
+def _resolve_baseline_image(
+    baseline: torch.Tensor,
+    run_dir: Path,
+    sha256: str,
+    render_cache: dict[str, Path] | None,
+) -> Path:
+    """Render the baseline preview, or copy a cached render of the same content.
+
+    The expensive matplotlib render runs once per distinct ``sha256``; repeat
+    callers (detection's per-box K-loop) get a cheap file copy into their own
+    ``run_dir`` so every artefact stays self-contained.
+    """
+    if render_cache is not None:
+        cached = render_cache.get(sha256)
+        if cached is not None and cached.exists():
+            return _copy_baseline_image(cached, run_dir)
+
+    image_path = _render_baseline_image(baseline, run_dir)
+    if render_cache is not None:
+        render_cache[sha256] = run_dir / image_path
+    return image_path
+
+
+def _copy_baseline_image(source: Path, run_dir: Path) -> Path:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, run_dir / _BASELINE_IMAGE_NAME)
+    return Path(_BASELINE_IMAGE_NAME)
 
 
 def _montage_caption(shown: int, total: int) -> str | None:

--- a/src/raitap/transparency/baselines.py
+++ b/src/raitap/transparency/baselines.py
@@ -30,6 +30,11 @@ else:
     torch = lazy_import("torch")
 
 _BASELINE_IMAGE_NAME = "baseline.png"
+# A multi-image baseline (e.g. a SHAP background set) is rendered as a grid
+# preview: up to ``_BASELINE_GRID_CAP`` tiles, ``_BASELINE_GRID_COLS`` per row.
+# The full count is always recorded in the descriptor's ``n_samples``/``shape``.
+_BASELINE_GRID_CAP = 25
+_BASELINE_GRID_COLS = 5
 
 
 def build_baseline_record(
@@ -111,30 +116,44 @@ def _is_image_modality(input_spec: object) -> bool:
 
 
 def _render_baseline_image(baseline: torch.Tensor, run_dir: Path) -> Path:
-    """Render the first sample of *baseline* to ``run_dir/baseline.png``.
+    """Render a preview of *baseline* to ``run_dir/baseline.png``.
 
-    Mirrors the normalisation/layout of ``InputThumbnailVisualiser`` (min-max
-    normalise, NCHW->HWC, grayscale handling) without importing its private
-    helpers. Returns the path relative to ``run_dir`` for storage in the record.
+    A single-image baseline renders one tile; a multi-image baseline (e.g. a
+    SHAP background set) renders a capped grid of its images (see
+    ``_BASELINE_GRID_CAP``). Each tile mirrors ``InputThumbnailVisualiser``'s
+    normalisation/layout (min-max normalise, NCHW->HWC, grayscale handling)
+    without importing its private helpers. Returns the path relative to
+    ``run_dir`` for storage in the record.
     """
     import matplotlib.pyplot as plt
     import numpy as np
 
-    sample = baseline[0] if baseline.ndim >= 4 else baseline
-    image = np.asarray(sample.detach().cpu().numpy())
-    if image.ndim == 3:
-        image = np.transpose(image, (1, 2, 0))
-    lo, hi = float(image.min()), float(image.max())
-    if hi > lo:
-        image = (image - lo) / (hi - lo)
+    if baseline.ndim >= 4:
+        n_show = min(int(baseline.shape[0]), _BASELINE_GRID_CAP)
+        tiles = [baseline[index] for index in range(n_show)]
+    else:
+        tiles = [baseline]
 
-    fig, ax = plt.subplots(1, 1, figsize=(4, 4))
+    count = len(tiles)
+    cols = min(_BASELINE_GRID_COLS, count)
+    rows = (count + cols - 1) // cols
+    fig, axes = plt.subplots(rows, cols, figsize=(cols * 2.2, rows * 2.2), squeeze=False)
     try:
-        if image.ndim == 3 and image.shape[-1] == 1:
-            ax.imshow(image[..., 0], cmap="gray")
-        else:
-            ax.imshow(image, cmap="gray" if image.ndim == 2 else None)
-        ax.axis("off")
+        flat_axes = list(axes.flat)
+        for ax, tile in zip(flat_axes, tiles, strict=False):
+            image = np.asarray(tile.detach().cpu().numpy())
+            if image.ndim == 3:
+                image = np.transpose(image, (1, 2, 0))
+            lo, hi = float(image.min()), float(image.max())
+            if hi > lo:
+                image = (image - lo) / (hi - lo)
+            if image.ndim == 3 and image.shape[-1] == 1:
+                ax.imshow(image[..., 0], cmap="gray")
+            else:
+                ax.imshow(image, cmap="gray" if image.ndim == 2 else None)
+            ax.axis("off")
+        for ax in flat_axes[count:]:
+            ax.axis("off")
         fig.tight_layout()
         run_dir.mkdir(parents=True, exist_ok=True)
         fig.savefig(run_dir / _BASELINE_IMAGE_NAME, bbox_inches="tight", dpi=150)

--- a/src/raitap/transparency/baselines.py
+++ b/src/raitap/transparency/baselines.py
@@ -103,7 +103,10 @@ def build_baseline_record(
 
 
 def _hash_tensor(tensor: torch.Tensor) -> str:
-    data = tensor.detach().cpu().contiguous().numpy().tobytes()
+    # Cast to float32 first: NumPy has no bfloat16, so a bf16 baseline would
+    # otherwise raise in ``.numpy()``. The cast is a no-op for float32 inputs and
+    # keeps the hash deterministic across dtypes.
+    data = tensor.detach().cpu().to(torch.float32).contiguous().numpy().tobytes()
     return hashlib.sha256(data).hexdigest()
 
 
@@ -146,7 +149,8 @@ def _render_baseline_image(baseline: torch.Tensor, run_dir: Path) -> Path:
     try:
         flat_axes = list(axes.flat)
         for ax, tile in zip(flat_axes, tiles, strict=False):
-            image = np.asarray(tile.detach().cpu().numpy())
+            # float32 cast: NumPy has no bfloat16, so a bf16 tile would raise here.
+            image = np.asarray(tile.detach().cpu().to(torch.float32).numpy())
             if image.ndim == 3:
                 image = np.transpose(image, (1, 2, 0))
             lo, hi = float(image.min()), float(image.max())

--- a/src/raitap/transparency/baselines.py
+++ b/src/raitap/transparency/baselines.py
@@ -81,9 +81,14 @@ def build_baseline_record(
             mode = BaselineMode.USER_TENSOR
         baseline_tensor = value
     else:
-        # ``baseline_defaults`` values are ``BaselineMode`` members; comparison
-        # also accepts the bare-string equivalents (StrEnum) for forward compat.
-        mode = getattr(explainer, "baseline_defaults", {}).get(algorithm)
+        # The implicit default mode lives on the algorithm's
+        # ``ExplainerSemanticsHints.baseline_default`` in ``algorithm_registry``;
+        # read defensively so stubs without a registry simply yield no baseline.
+        # ``baseline_default`` is a ``BaselineMode`` member; comparison below also
+        # accepts the bare-string equivalent (StrEnum) for forward compat.
+        registry = getattr(explainer, "algorithm_registry", None) or {}
+        hints = registry.get(algorithm)
+        mode = getattr(hints, "baseline_default", None)
         if mode is None:
             return None
         if mode == BaselineMode.ZERO:

--- a/src/raitap/transparency/baselines.py
+++ b/src/raitap/transparency/baselines.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from raitap.utils.lazy import lazy_import
 
-from .contracts import BaselineMode, BaselineRecord
+from .contracts import BaselineCardinality, BaselineMode, BaselineRecord
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 else:
     torch = lazy_import("torch")
 
+_BASELINE_CONFIG_KEY = "baseline"
 _BASELINE_IMAGE_NAME = "baseline.png"
 # A multi-image baseline (e.g. a SHAP background set) is rendered as a grid
 # preview: up to ``_BASELINE_GRID_CAP`` tiles, ``_BASELINE_GRID_COLS`` per row.
@@ -59,7 +60,7 @@ def build_baseline_record(
     one ``explain`` per box — render the preview image once and copy it for the
     rest, instead of re-running matplotlib per box.
     """
-    kwarg_name = getattr(explainer, "baseline_kwarg", None)
+    kwarg_name = getattr(explainer, "baseline_kwarg_name", None)
     if kwarg_name is None:
         return None
 
@@ -112,6 +113,92 @@ def build_baseline_record(
         dtype=str(baseline_tensor.dtype),
         sha256=sha256,
         image_path=image_path,
+    )
+
+
+def apply_config_baseline(
+    *,
+    explainer: object,
+    call_kwargs: dict[str, Any],
+    raitap_kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Route the library-agnostic ``raitap.baseline`` field to the adapter's call kwarg.
+
+    Users set the baseline by one stable name — ``raitap.baseline`` — regardless of
+    the underlying library's own kwarg (Captum ``baselines``, SHAP ``background_data``);
+    the adapter's ``baseline_kwarg_name`` ClassVar names the destination. The value is the
+    same ``{source, n_samples}`` data-source descriptor (or a tensor via the Python API)
+    accepted under ``call:``, so the existing :func:`resolve_call_data_sources` /
+    :func:`build_baseline_record` path resolves and documents it unchanged.
+
+    Call this on the *final* call dict (config ``call:`` merged with any runtime
+    Python-API kwargs) so the precedence rule is uniform regardless of source.
+    Mutates and returns ``call_kwargs`` with the baseline injected; pops ``baseline``
+    from ``raitap_kwargs`` so it is not mistaken for a runtime option. Precedence: when
+    the baseline is *also* set via the adapter's own kwarg (in ``call:`` or passed at
+    runtime), ``raitap.baseline`` wins and a warning fires — it is never overridden
+    silently. Raises :class:`RaitapError` when ``raitap.baseline`` is set on an
+    explainer whose family takes no baseline.
+    """
+    baseline = raitap_kwargs.pop(_BASELINE_CONFIG_KEY, None)
+    if baseline is None:
+        return call_kwargs
+
+    kwarg_name = getattr(explainer, "baseline_kwarg_name", None)
+    if kwarg_name is None:
+        from raitap.utils.errors import RaitapError
+
+        algorithm = str(getattr(explainer, "algorithm", "")) or "<unknown>"
+        raise RaitapError(
+            f"raitap.baseline was set, but explainer {type(explainer).__name__} "
+            f"(algorithm {algorithm!r}) takes no baseline. Remove raitap.baseline."
+        )
+
+    if kwarg_name in call_kwargs:
+        from raitap import raitap_log
+
+        raitap_log.warn(
+            "Baseline set both via raitap.baseline and the %r kwarg (call: block or "
+            "runtime); using raitap.baseline and ignoring the %r kwarg.",
+            kwarg_name,
+            kwarg_name,
+        )
+
+    _warn_on_baseline_cardinality_mismatch(explainer=explainer, baseline=baseline)
+
+    call_kwargs[kwarg_name] = baseline
+    return call_kwargs
+
+
+def _warn_on_baseline_cardinality_mismatch(*, explainer: object, baseline: Any) -> None:
+    """Flag (never reshape) a baseline whose sample count contradicts the method.
+
+    A ``SINGLE``-reference method (e.g. Integrated Gradients) given a multi-sample
+    data-source baseline — typically a SHAP background set reused by mistake — will
+    fail unless it happens to match the input batch. We can't know the batch here,
+    so we warn rather than block the rare valid per-sample case. ``SET`` methods and
+    direct tensors (advanced Python-API use) are left alone.
+    """
+    if not isinstance(baseline, dict):
+        return
+    n_samples = baseline.get("n_samples")
+    if not isinstance(n_samples, int) or n_samples <= 1:
+        return
+
+    algorithm = str(getattr(explainer, "algorithm", ""))
+    registry = getattr(explainer, "algorithm_registry", None) or {}
+    hints = registry.get(algorithm)
+    if getattr(hints, "baseline_cardinality", None) is not BaselineCardinality.SINGLE:
+        return
+
+    from raitap import raitap_log
+
+    raitap_log.warn(
+        "%s takes a single baseline reference, but raitap.baseline sets "
+        "n_samples=%d (a sample-set baseline). It will fail unless it matches the "
+        "input batch; use n_samples=1 for a broadcast baseline.",
+        algorithm or type(explainer).__name__,
+        n_samples,
     )
 
 

--- a/src/raitap/transparency/contracts.py
+++ b/src/raitap/transparency/contracts.py
@@ -102,6 +102,21 @@ class MethodFamily(StrEnum):
     SURROGATE = "surrogate"
 
 
+@dataclass(frozen=True)
+class ExplainerSemanticsHints:
+    """Per-algorithm metadata carried by a transparency adapter's ``algorithm_registry``.
+
+    The transparency analogue of robustness's ``AssessorSemanticsHints``: one entry
+    per algorithm an adapter wraps, holding everything the framework tracks and
+    reports for that algorithm. ``baseline_default`` is the implicit
+    :class:`BaselineMode` used when the user omits the baseline kwarg (``None`` for
+    algorithms with no meaningful default, e.g. Saliency / TreeExplainer).
+    """
+
+    families: frozenset[MethodFamily]
+    baseline_default: BaselineMode | None = None
+
+
 def explainer_output_kind(explainer: object) -> ExplanationPayloadKind:
     raw = getattr(type(explainer), "output_payload_kind", None)
     if isinstance(raw, ExplanationPayloadKind):

--- a/src/raitap/transparency/contracts.py
+++ b/src/raitap/transparency/contracts.py
@@ -109,7 +109,7 @@ class ExplainerSemanticsHints:
     The transparency analogue of robustness's ``AssessorSemanticsHints``: one entry
     per algorithm an adapter wraps, holding everything the framework tracks and
     reports for that algorithm. ``baseline_default`` is the implicit
-    :class:`BaselineMode` used when the user omits the baseline kwarg (``None`` for
+    ``BaselineMode`` used when the user omits the baseline kwarg (``None`` for
     algorithms with no meaningful default, e.g. Saliency / TreeExplainer).
     """
 

--- a/src/raitap/transparency/contracts.py
+++ b/src/raitap/transparency/contracts.py
@@ -189,6 +189,26 @@ class DetectionBox:
 
 
 @dataclass(frozen=True)
+class BaselineRecord:
+    """Reference input an attribution method was computed against.
+
+    Captured once at the explain chokepoint for methods that take a baseline
+    (IG ``baselines``, SHAP ``background_data``), including implicit defaults.
+    ``image_path`` is relative to the explanation ``run_dir`` and set only for
+    image-modality runs; ``sha256`` hashes the tensor actually used as baseline.
+    """
+
+    kwarg_name: str
+    mode: str
+    source: str | None
+    n_samples: int | None
+    shape: tuple[int, ...]
+    dtype: str
+    sha256: str
+    image_path: Path | None
+
+
+@dataclass(frozen=True)
 class VisualSummarySpec:
     """Metadata for visualisers that summarize a set of local explanations."""
 

--- a/src/raitap/transparency/contracts.py
+++ b/src/raitap/transparency/contracts.py
@@ -102,6 +102,22 @@ class MethodFamily(StrEnum):
     SURROGATE = "surrogate"
 
 
+class BaselineCardinality(StrEnum):
+    """How many reference samples an algorithm's baseline is meant to hold.
+
+    Used to validate (never reshape) a configured baseline against the method:
+
+    * ``SINGLE`` — one reference input that broadcasts to the batch (Captum
+      Integrated Gradients, DeepLift). A many-sample baseline is almost always a
+      mistake (e.g. a SHAP background set reused here).
+    * ``SET`` — a distribution of samples (SHAP ``background_data``); any count is
+      meaningful, more is usually better.
+    """
+
+    SINGLE = "single"
+    SET = "set"
+
+
 @dataclass(frozen=True)
 class ExplainerSemanticsHints:
     """Per-algorithm metadata carried by a transparency adapter's ``algorithm_registry``.
@@ -111,10 +127,14 @@ class ExplainerSemanticsHints:
     reports for that algorithm. ``baseline_default`` is the implicit
     ``BaselineMode`` used when the user omits the baseline kwarg (``None`` for
     algorithms with no meaningful default, e.g. Saliency / TreeExplainer).
+    ``baseline_cardinality`` declares whether the baseline is a single reference or
+    a sample set, so a mismatched ``raitap.baseline`` is flagged (not reshaped);
+    ``None`` skips the check.
     """
 
     families: frozenset[MethodFamily]
     baseline_default: BaselineMode | None = None
+    baseline_cardinality: BaselineCardinality | None = None
 
 
 def explainer_output_kind(explainer: object) -> ExplanationPayloadKind:

--- a/src/raitap/transparency/contracts.py
+++ b/src/raitap/transparency/contracts.py
@@ -31,6 +31,19 @@ class ExplanationPayloadKind(StrEnum):
     STRUCTURED = "structured"
 
 
+class BaselineMode(StrEnum):
+    """How an attribution baseline (IG ``baselines`` / SHAP ``background_data``) was obtained.
+
+    Serialised by value into ``metadata.json`` and the report, so these string
+    values are a stable contract.
+    """
+
+    CONFIGURED = "configured"  # resolved from a YAML data source (has provenance)
+    USER_TENSOR = "user_tensor"  # tensor passed directly via the Python API
+    ZERO = "zero"  # synthesized all-zeros (Captum's implicit default)
+    INPUT_BATCH = "input_batch"  # the input batch (SHAP's implicit default)
+
+
 class ExplanationScope(StrEnum):
     """Semantic breadth represented by an explanation artifact."""
 

--- a/src/raitap/transparency/explainers/base_explainer.py
+++ b/src/raitap/transparency/explainers/base_explainer.py
@@ -117,7 +117,7 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
         explainer_name: str | None = None,
         visualisers: list[ConfiguredVisualiser] | None = None,
         raitap_kwargs: dict[str, Any] | None = None,
-        call_provenance: Mapping[str, Any] | None = None,
+        call_provenance: Mapping[str, Mapping[str, Any]] | None = None,
         **kwargs: Any,
     ) -> ExplanationResult:
         """

--- a/src/raitap/transparency/explainers/base_explainer.py
+++ b/src/raitap/transparency/explainers/base_explainer.py
@@ -21,6 +21,7 @@ else:
 
 from ..baselines import build_baseline_record
 from ..contracts import (
+    BaselineMode,
     ExplanationOutputSpace,
     ExplanationPayloadKind,
     ExplanationScope,
@@ -65,7 +66,7 @@ class BaseExplainer(AdapterMixin, ABC):
     # default mode used when that kwarg is absent. Declared per-algorithm
     # because one adapter class wraps many algorithms (most take no baseline).
     baseline_kwarg: ClassVar[str | None] = None
-    baseline_defaults: ClassVar[Mapping[str, str]] = {}
+    baseline_defaults: ClassVar[Mapping[str, BaselineMode]] = {}
 
     def check_backend_compat(self, backend: object) -> None:
         """Default: enforce the ONNX-allowlist contract.

--- a/src/raitap/transparency/explainers/base_explainer.py
+++ b/src/raitap/transparency/explainers/base_explainer.py
@@ -21,14 +21,13 @@ else:
 
 from ..baselines import build_baseline_record
 from ..contracts import (
-    BaselineMode,
+    ExplainerSemanticsHints,
     ExplanationOutputSpace,
     ExplanationPayloadKind,
     ExplanationScope,
     ExplanationSemantics,
     ExplanationTarget,
     InputSpec,
-    MethodFamily,
     SampleSelection,
     ScopeDefinitionStep,
     explainer_output_scope,
@@ -55,18 +54,17 @@ class BaseExplainer(AdapterMixin, ABC):
 
     output_payload_kind: ClassVar[ExplanationPayloadKind] = ExplanationPayloadKind.ATTRIBUTIONS
     output_scope: ClassVar[ExplanationScope] = ExplanationScope.LOCAL
-    algorithm_registry: ClassVar[Mapping[str, frozenset[MethodFamily]]]
+    algorithm_registry: ClassVar[Mapping[str, ExplainerSemanticsHints]]
     # Adapter-specific; defaults to "no ONNX support". The
     # ``@adapters.transparency`` decorator overrides per-adapter.
     ONNX_COMPATIBLE_ALGORITHMS: ClassVar[frozenset[str]] = frozenset()
 
     # Baseline documentation (issue #210). ``baseline_kwarg`` is the call kwarg
     # that holds this family's reference input (``None`` → family takes no
-    # baseline). ``baseline_defaults`` maps an algorithm name to the implicit
-    # default mode used when that kwarg is absent. Declared per-algorithm
-    # because one adapter class wraps many algorithms (most take no baseline).
+    # baseline); set via the ``@adapters.transparency`` decorator kwarg. The
+    # per-algorithm implicit default mode lives on each algorithm's
+    # ``ExplainerSemanticsHints.baseline_default`` in ``algorithm_registry``.
     baseline_kwarg: ClassVar[str | None] = None
-    baseline_defaults: ClassVar[Mapping[str, BaselineMode]] = {}
 
     def check_backend_compat(self, backend: object) -> None:
         """Default: enforce the ONNX-allowlist contract.

--- a/src/raitap/transparency/explainers/base_explainer.py
+++ b/src/raitap/transparency/explainers/base_explainer.py
@@ -57,6 +57,14 @@ class BaseExplainer(AdapterMixin, ABC):
     # ``@adapters.transparency`` decorator overrides per-adapter.
     ONNX_COMPATIBLE_ALGORITHMS: ClassVar[frozenset[str]] = frozenset()
 
+    # Baseline documentation (issue #210). ``baseline_kwarg`` is the call kwarg
+    # that holds this family's reference input (``None`` → family takes no
+    # baseline). ``baseline_defaults`` maps an algorithm name to the implicit
+    # default mode used when that kwarg is absent. Declared per-algorithm
+    # because one adapter class wraps many algorithms (most take no baseline).
+    baseline_kwarg: ClassVar[str | None] = None
+    baseline_defaults: ClassVar[Mapping[str, str]] = {}
+
     def check_backend_compat(self, backend: object) -> None:
         """Default: enforce the ONNX-allowlist contract.
 

--- a/src/raitap/transparency/explainers/base_explainer.py
+++ b/src/raitap/transparency/explainers/base_explainer.py
@@ -59,12 +59,12 @@ class BaseExplainer(AdapterMixin, ABC):
     # ``@adapters.transparency`` decorator overrides per-adapter.
     ONNX_COMPATIBLE_ALGORITHMS: ClassVar[frozenset[str]] = frozenset()
 
-    # Baseline documentation (issue #210). ``baseline_kwarg`` is the call kwarg
+    # Baseline documentation (issue #210). ``baseline_kwarg_name`` is the call kwarg
     # that holds this family's reference input (``None`` → family takes no
     # baseline); set via the ``@adapters.transparency`` decorator kwarg. The
     # per-algorithm implicit default mode lives on each algorithm's
     # ``ExplainerSemanticsHints.baseline_default`` in ``algorithm_registry``.
-    baseline_kwarg: ClassVar[str | None] = None
+    baseline_kwarg_name: ClassVar[str | None] = None
 
     def check_backend_compat(self, backend: object) -> None:
         """Default: enforce the ONNX-allowlist contract.

--- a/src/raitap/transparency/explainers/base_explainer.py
+++ b/src/raitap/transparency/explainers/base_explainer.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 else:
     torch = lazy_import("torch")
 
+from ..baselines import build_baseline_record
 from ..contracts import (
     ExplanationOutputSpace,
     ExplanationPayloadKind,
@@ -116,6 +117,7 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
         explainer_name: str | None = None,
         visualisers: list[ConfiguredVisualiser] | None = None,
         raitap_kwargs: dict[str, Any] | None = None,
+        call_provenance: Mapping[str, Any] | None = None,
         **kwargs: Any,
     ) -> ExplanationResult:
         """
@@ -169,17 +171,28 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
             output_space=output_space,
         )
 
+        resolved_run_dir = (
+            Path(run_dir)
+            if run_dir is not None
+            else resolve_run_dir(
+                output_root=output_root,
+                subdir="transparency",
+            )
+        )
+
+        baseline = build_baseline_record(
+            explainer=self,
+            inputs=inputs,
+            call_kwargs=call_kwargs,
+            call_provenance=call_provenance,
+            input_spec=input_spec,
+            run_dir=resolved_run_dir,
+        )
+
         explanation = ExplanationResult(
             attributions=attributions,
             inputs=inputs,
-            run_dir=(
-                Path(run_dir)
-                if run_dir is not None
-                else resolve_run_dir(
-                    output_root=output_root,
-                    subdir="transparency",
-                )
-            ),
+            run_dir=resolved_run_dir,
             experiment_name=experiment_name,
             explainer_target=(explainer_target or f"{type(self).__module__}.{type(self).__name__}"),
             algorithm=getattr(self, "algorithm", ""),
@@ -189,6 +202,7 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
             visualisers=visualisers_list,
             payload_kind=self.output_payload_kind,
             semantics=semantics,
+            baseline=baseline,
         )
         explanation.write_artifacts()
         return explanation

--- a/src/raitap/transparency/explainers/base_explainer.py
+++ b/src/raitap/transparency/explainers/base_explainer.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
+from raitap import raitap_log
 from raitap._adapters import AdapterMixin
 from raitap.configs import resolve_run_dir
 from raitap.utils.lazy import lazy_import
@@ -180,14 +181,24 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
             )
         )
 
-        baseline = build_baseline_record(
-            explainer=self,
-            inputs=inputs,
-            call_kwargs=call_kwargs,
-            call_provenance=call_provenance,
-            input_spec=input_spec,
-            run_dir=resolved_run_dir,
-        )
+        try:
+            baseline = build_baseline_record(
+                explainer=self,
+                inputs=inputs,
+                call_kwargs=call_kwargs,
+                call_provenance=call_provenance,
+                input_spec=input_spec,
+                run_dir=resolved_run_dir,
+            )
+        except Exception:
+            # Baseline capture is documentation only. A render/hash failure must
+            # never discard the just-computed attributions for this explainer (or
+            # abort not-yet-run explainers); degrade to no baseline (cf. #206/#207).
+            raitap_log.exception(
+                "Baseline documentation failed for %s; continuing without it.",
+                getattr(self, "algorithm", type(self).__name__),
+            )
+            baseline = None
 
         explanation = ExplanationResult(
             attributions=attributions,

--- a/src/raitap/transparency/explainers/base_explainer.py
+++ b/src/raitap/transparency/explainers/base_explainer.py
@@ -120,6 +120,7 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
         visualisers: list[ConfiguredVisualiser] | None = None,
         raitap_kwargs: dict[str, Any] | None = None,
         call_provenance: Mapping[str, Mapping[str, Any]] | None = None,
+        baseline_render_cache: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> ExplanationResult:
         """
@@ -190,6 +191,7 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
                 call_provenance=call_provenance,
                 input_spec=input_spec,
                 run_dir=resolved_run_dir,
+                render_cache=baseline_render_cache,
             )
         except Exception:
             # Baseline capture is documentation only. A render/hash failure must

--- a/src/raitap/transparency/explainers/captum_explainer.py
+++ b/src/raitap/transparency/explainers/captum_explainer.py
@@ -58,6 +58,9 @@ class CaptumExplainer(AttributionOnlyExplainer):
     Uses dynamic method loading - no need for class-per-method.
     """
 
+    baseline_kwarg = "baselines"
+    baseline_defaults = {"IntegratedGradients": "zero"}
+
     def __init__(self, algorithm: str, **init_kwargs):
         """
         Args:

--- a/src/raitap/transparency/explainers/captum_explainer.py
+++ b/src/raitap/transparency/explainers/captum_explainer.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from raitap.transparency.contracts import BaselineMode, ExplainerSemanticsHints, MethodFamily
+from raitap.transparency.contracts import (
+    BaselineCardinality,
+    BaselineMode,
+    ExplainerSemanticsHints,
+    MethodFamily,
+)
 from raitap.transparency.explainers.registration import transparency_adapter
 
 from .base_explainer import AttributionOnlyExplainer
@@ -26,7 +31,9 @@ if TYPE_CHECKING:
     # rest take no reference input, so their ``baseline_default`` stays ``None``.
     algorithm_registry={
         "IntegratedGradients": ExplainerSemanticsHints(
-            frozenset({MethodFamily.GRADIENT}), baseline_default=BaselineMode.ZERO
+            frozenset({MethodFamily.GRADIENT}),
+            baseline_default=BaselineMode.ZERO,
+            baseline_cardinality=BaselineCardinality.SINGLE,
         ),
         "Saliency": ExplainerSemanticsHints(frozenset({MethodFamily.GRADIENT})),
         "FeatureAblation": ExplainerSemanticsHints(frozenset({MethodFamily.PERTURBATION})),
@@ -55,7 +62,7 @@ if TYPE_CHECKING:
             frozenset({MethodFamily.GRADIENT, MethodFamily.CAM})
         ),
     },
-    baseline_kwarg="baselines",
+    baseline_kwarg_name="baselines",
     onnx_compatible_algorithms=frozenset(
         {
             "FeatureAblation",

--- a/src/raitap/transparency/explainers/captum_explainer.py
+++ b/src/raitap/transparency/explainers/captum_explainer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from raitap.transparency.contracts import MethodFamily
 from raitap.transparency.explainers.registration import transparency_adapter
@@ -10,6 +10,8 @@ from raitap.transparency.explainers.registration import transparency_adapter
 from .base_explainer import AttributionOnlyExplainer
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     import torch
     import torch.nn as nn
 
@@ -58,8 +60,8 @@ class CaptumExplainer(AttributionOnlyExplainer):
     Uses dynamic method loading - no need for class-per-method.
     """
 
-    baseline_kwarg = "baselines"
-    baseline_defaults = {"IntegratedGradients": "zero"}
+    baseline_kwarg: ClassVar[str | None] = "baselines"
+    baseline_defaults: ClassVar[Mapping[str, str]] = {"IntegratedGradients": "zero"}
 
     def __init__(self, algorithm: str, **init_kwargs):
         """

--- a/src/raitap/transparency/explainers/captum_explainer.py
+++ b/src/raitap/transparency/explainers/captum_explainer.py
@@ -2,16 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 
-from raitap.transparency.contracts import BaselineMode, MethodFamily
+from raitap.transparency.contracts import BaselineMode, ExplainerSemanticsHints, MethodFamily
 from raitap.transparency.explainers.registration import transparency_adapter
 
 from .base_explainer import AttributionOnlyExplainer
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     import torch
     import torch.nn as nn
 
@@ -24,23 +22,40 @@ if TYPE_CHECKING:
     # is pure noise. Scope ``module=`` to captum so unrelated UserWarnings
     # with matching messages aren't accidentally hidden.
     suppress_warnings=[(r"Input Tensor.*required_grads", UserWarning, r"captum.*")],
+    # Only IntegratedGradients has a meaningful implicit baseline (zeros); the
+    # rest take no reference input, so their ``baseline_default`` stays ``None``.
     algorithm_registry={
-        "IntegratedGradients": frozenset({MethodFamily.GRADIENT}),
-        "Saliency": frozenset({MethodFamily.GRADIENT}),
-        "FeatureAblation": frozenset({MethodFamily.PERTURBATION}),
-        "FeaturePermutation": frozenset({MethodFamily.PERTURBATION}),
-        "Occlusion": frozenset({MethodFamily.PERTURBATION}),
-        "ShapleyValueSampling": frozenset({MethodFamily.SHAPLEY, MethodFamily.PERTURBATION}),
-        "ShapleyValues": frozenset({MethodFamily.SHAPLEY, MethodFamily.PERTURBATION}),
-        "KernelShap": frozenset(
-            {MethodFamily.SHAPLEY, MethodFamily.PERTURBATION, MethodFamily.MODEL_AGNOSTIC}
+        "IntegratedGradients": ExplainerSemanticsHints(
+            frozenset({MethodFamily.GRADIENT}), baseline_default=BaselineMode.ZERO
         ),
-        "Lime": frozenset(
-            {MethodFamily.PERTURBATION, MethodFamily.MODEL_AGNOSTIC, MethodFamily.SURROGATE}
+        "Saliency": ExplainerSemanticsHints(frozenset({MethodFamily.GRADIENT})),
+        "FeatureAblation": ExplainerSemanticsHints(frozenset({MethodFamily.PERTURBATION})),
+        "FeaturePermutation": ExplainerSemanticsHints(frozenset({MethodFamily.PERTURBATION})),
+        "Occlusion": ExplainerSemanticsHints(frozenset({MethodFamily.PERTURBATION})),
+        "ShapleyValueSampling": ExplainerSemanticsHints(
+            frozenset({MethodFamily.SHAPLEY, MethodFamily.PERTURBATION})
         ),
-        "LayerGradCam": frozenset({MethodFamily.GRADIENT, MethodFamily.CAM}),
-        "GuidedGradCam": frozenset({MethodFamily.GRADIENT, MethodFamily.CAM}),
+        "ShapleyValues": ExplainerSemanticsHints(
+            frozenset({MethodFamily.SHAPLEY, MethodFamily.PERTURBATION})
+        ),
+        "KernelShap": ExplainerSemanticsHints(
+            frozenset(
+                {MethodFamily.SHAPLEY, MethodFamily.PERTURBATION, MethodFamily.MODEL_AGNOSTIC}
+            )
+        ),
+        "Lime": ExplainerSemanticsHints(
+            frozenset(
+                {MethodFamily.PERTURBATION, MethodFamily.MODEL_AGNOSTIC, MethodFamily.SURROGATE}
+            )
+        ),
+        "LayerGradCam": ExplainerSemanticsHints(
+            frozenset({MethodFamily.GRADIENT, MethodFamily.CAM})
+        ),
+        "GuidedGradCam": ExplainerSemanticsHints(
+            frozenset({MethodFamily.GRADIENT, MethodFamily.CAM})
+        ),
     },
+    baseline_kwarg="baselines",
     onnx_compatible_algorithms=frozenset(
         {
             "FeatureAblation",
@@ -59,11 +74,6 @@ class CaptumExplainer(AttributionOnlyExplainer):
 
     Uses dynamic method loading - no need for class-per-method.
     """
-
-    baseline_kwarg: ClassVar[str | None] = "baselines"
-    baseline_defaults: ClassVar[Mapping[str, BaselineMode]] = {
-        "IntegratedGradients": BaselineMode.ZERO
-    }
 
     def __init__(self, algorithm: str, **init_kwargs):
         """

--- a/src/raitap/transparency/explainers/captum_explainer.py
+++ b/src/raitap/transparency/explainers/captum_explainer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from raitap.transparency.contracts import MethodFamily
+from raitap.transparency.contracts import BaselineMode, MethodFamily
 from raitap.transparency.explainers.registration import transparency_adapter
 
 from .base_explainer import AttributionOnlyExplainer
@@ -61,7 +61,9 @@ class CaptumExplainer(AttributionOnlyExplainer):
     """
 
     baseline_kwarg: ClassVar[str | None] = "baselines"
-    baseline_defaults: ClassVar[Mapping[str, str]] = {"IntegratedGradients": "zero"}
+    baseline_defaults: ClassVar[Mapping[str, BaselineMode]] = {
+        "IntegratedGradients": BaselineMode.ZERO
+    }
 
     def __init__(self, algorithm: str, **init_kwargs):
         """

--- a/src/raitap/transparency/explainers/registration.py
+++ b/src/raitap/transparency/explainers/registration.py
@@ -42,7 +42,7 @@ def transparency_adapter(
     algorithm_registry: Mapping[str, ExplainerSemanticsHints],
     output_payload_kind: ExplanationPayloadKind = ExplanationPayloadKind.ATTRIBUTIONS,
     onnx_compatible_algorithms: frozenset[str] | _AllAlgorithmsSentinel = frozenset(),
-    baseline_kwarg: str | None = None,
+    baseline_kwarg_name: str | None = None,
     **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a transparency explainer.
@@ -58,7 +58,7 @@ def transparency_adapter(
         rare). Pass an explicit ``frozenset({"name1", "name2"})`` to enable a
         subset, or :data:`raitap.transparency.ALL` to enable every algorithm in
         ``algorithm_registry``.
-        ``baseline_kwarg`` is the call kwarg holding this family's reference
+        ``baseline_kwarg_name`` is the call kwarg holding this family's reference
         input (``"baselines"`` for Captum, ``"background_data"`` for SHAP);
         ``None`` (default) means the family takes no baseline. The per-algorithm
         implicit default mode lives on each ``ExplainerSemanticsHints.baseline_default``.
@@ -67,7 +67,7 @@ def transparency_adapter(
     def wrap(cls: type[T]) -> type[T]:
         cls.algorithm_registry = algorithm_registry  # type: ignore[misc]
         cls.output_payload_kind = output_payload_kind
-        cls.baseline_kwarg = baseline_kwarg
+        cls.baseline_kwarg_name = baseline_kwarg_name
         cls.ONNX_COMPATIBLE_ALGORITHMS = (  # type: ignore[misc]
             frozenset(algorithm_registry.keys())
             if onnx_compatible_algorithms is ALL

--- a/src/raitap/transparency/explainers/registration.py
+++ b/src/raitap/transparency/explainers/registration.py
@@ -25,7 +25,7 @@ from raitap.transparency.contracts import ExplanationPayloadKind
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
-    from raitap.transparency.contracts import MethodFamily
+    from raitap.transparency.contracts import ExplainerSemanticsHints
     from raitap.transparency.explainers.base_explainer import BaseExplainer
 
 TRANSPARENCY = FamilyConfig(
@@ -39,16 +39,17 @@ T = TypeVar("T", bound="BaseExplainer")
 
 def transparency_adapter(
     *,
-    algorithm_registry: Mapping[str, frozenset[MethodFamily]],
+    algorithm_registry: Mapping[str, ExplainerSemanticsHints],
     output_payload_kind: ExplanationPayloadKind = ExplanationPayloadKind.ATTRIBUTIONS,
     onnx_compatible_algorithms: frozenset[str] | _AllAlgorithmsSentinel = frozenset(),
+    baseline_kwarg: str | None = None,
     **common: Unpack[AdapterDecoratorOptions],
 ) -> Callable[[type[T]], type[T]]:
     """Decorator: register a transparency explainer.
 
     Required:
         ``registry_name`` (via ``AdapterDecoratorOptions.Required[str]``) and
-        ``algorithm_registry``.
+        ``algorithm_registry`` (algorithm name → :class:`ExplainerSemanticsHints`).
 
     Optional:
         ``output_payload_kind`` defaults to ``ATTRIBUTIONS`` — the common case;
@@ -57,11 +58,16 @@ def transparency_adapter(
         rare). Pass an explicit ``frozenset({"name1", "name2"})`` to enable a
         subset, or :data:`raitap.transparency.ALL` to enable every algorithm in
         ``algorithm_registry``.
+        ``baseline_kwarg`` is the call kwarg holding this family's reference
+        input (``"baselines"`` for Captum, ``"background_data"`` for SHAP);
+        ``None`` (default) means the family takes no baseline. The per-algorithm
+        implicit default mode lives on each ``ExplainerSemanticsHints.baseline_default``.
     """
 
     def wrap(cls: type[T]) -> type[T]:
         cls.algorithm_registry = algorithm_registry  # type: ignore[misc]
         cls.output_payload_kind = output_payload_kind
+        cls.baseline_kwarg = baseline_kwarg
         cls.ONNX_COMPATIBLE_ALGORITHMS = (  # type: ignore[misc]
             frozenset(algorithm_registry.keys())
             if onnx_compatible_algorithms is ALL

--- a/src/raitap/transparency/explainers/shap_explainer.py
+++ b/src/raitap/transparency/explainers/shap_explainer.py
@@ -98,6 +98,13 @@ class ShapExplainer(AttributionOnlyExplainer):
     Uses dynamic explainer loading - no need for class-per-explainer.
     """
 
+    baseline_kwarg = "background_data"
+    baseline_defaults = {
+        "GradientExplainer": "input_batch",
+        "DeepExplainer": "input_batch",
+        "KernelExplainer": "input_batch",
+    }
+
     def __init__(self, algorithm: str, **init_kwargs):
         """
         Args:

--- a/src/raitap/transparency/explainers/shap_explainer.py
+++ b/src/raitap/transparency/explainers/shap_explainer.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 else:
     torch = lazy_import("torch")
     nn = lazy_import("torch.nn")
-from raitap.transparency.contracts import MethodFamily
+from raitap.transparency.contracts import BaselineMode, MethodFamily
 from raitap.transparency.explainers.registration import transparency_adapter
 
 from .base_explainer import AttributionOnlyExplainer
@@ -99,10 +99,10 @@ class ShapExplainer(AttributionOnlyExplainer):
     """
 
     baseline_kwarg: ClassVar[str | None] = "background_data"
-    baseline_defaults: ClassVar[Mapping[str, str]] = {
-        "GradientExplainer": "input_batch",
-        "DeepExplainer": "input_batch",
-        "KernelExplainer": "input_batch",
+    baseline_defaults: ClassVar[Mapping[str, BaselineMode]] = {
+        "GradientExplainer": BaselineMode.INPUT_BATCH,
+        "DeepExplainer": BaselineMode.INPUT_BATCH,
+        "KernelExplainer": BaselineMode.INPUT_BATCH,
     }
 
     def __init__(self, algorithm: str, **init_kwargs):

--- a/src/raitap/transparency/explainers/shap_explainer.py
+++ b/src/raitap/transparency/explainers/shap_explainer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from raitap import raitap_log
 from raitap.utils.lazy import lazy_import
@@ -20,7 +20,7 @@ from raitap.transparency.explainers.registration import transparency_adapter
 from .base_explainer import AttributionOnlyExplainer
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
 
 def _normalise_target_indices(
@@ -98,8 +98,8 @@ class ShapExplainer(AttributionOnlyExplainer):
     Uses dynamic explainer loading - no need for class-per-explainer.
     """
 
-    baseline_kwarg = "background_data"
-    baseline_defaults = {
+    baseline_kwarg: ClassVar[str | None] = "background_data"
+    baseline_defaults: ClassVar[Mapping[str, str]] = {
         "GradientExplainer": "input_batch",
         "DeepExplainer": "input_batch",
         "KernelExplainer": "input_batch",

--- a/src/raitap/transparency/explainers/shap_explainer.py
+++ b/src/raitap/transparency/explainers/shap_explainer.py
@@ -14,7 +14,12 @@ if TYPE_CHECKING:
 else:
     torch = lazy_import("torch")
     nn = lazy_import("torch.nn")
-from raitap.transparency.contracts import BaselineMode, ExplainerSemanticsHints, MethodFamily
+from raitap.transparency.contracts import (
+    BaselineCardinality,
+    BaselineMode,
+    ExplainerSemanticsHints,
+    MethodFamily,
+)
 from raitap.transparency.explainers.registration import transparency_adapter
 
 from .base_explainer import AttributionOnlyExplainer
@@ -87,22 +92,25 @@ def _select_target_attributions(
         "GradientExplainer": ExplainerSemanticsHints(
             frozenset({MethodFamily.SHAPLEY, MethodFamily.GRADIENT}),
             baseline_default=BaselineMode.INPUT_BATCH,
+            baseline_cardinality=BaselineCardinality.SET,
         ),
         "DeepExplainer": ExplainerSemanticsHints(
             frozenset({MethodFamily.SHAPLEY, MethodFamily.GRADIENT}),
             baseline_default=BaselineMode.INPUT_BATCH,
+            baseline_cardinality=BaselineCardinality.SET,
         ),
         "KernelExplainer": ExplainerSemanticsHints(
             frozenset(
                 {MethodFamily.SHAPLEY, MethodFamily.PERTURBATION, MethodFamily.MODEL_AGNOSTIC}
             ),
             baseline_default=BaselineMode.INPUT_BATCH,
+            baseline_cardinality=BaselineCardinality.SET,
         ),
         "TreeExplainer": ExplainerSemanticsHints(
             frozenset({MethodFamily.SHAPLEY, MethodFamily.TREE})
         ),
     },
-    baseline_kwarg="background_data",
+    baseline_kwarg_name="background_data",
     onnx_compatible_algorithms=frozenset({"KernelExplainer"}),
 )
 class ShapExplainer(AttributionOnlyExplainer):

--- a/src/raitap/transparency/explainers/shap_explainer.py
+++ b/src/raitap/transparency/explainers/shap_explainer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from raitap import raitap_log
 from raitap.utils.lazy import lazy_import
@@ -14,13 +14,13 @@ if TYPE_CHECKING:
 else:
     torch = lazy_import("torch")
     nn = lazy_import("torch.nn")
-from raitap.transparency.contracts import BaselineMode, MethodFamily
+from raitap.transparency.contracts import BaselineMode, ExplainerSemanticsHints, MethodFamily
 from raitap.transparency.explainers.registration import transparency_adapter
 
 from .base_explainer import AttributionOnlyExplainer
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable
 
 
 def _normalise_target_indices(
@@ -81,14 +81,28 @@ def _select_target_attributions(
             "limitations. Use alternatives like GradientExplainer."
         ),
     },
+    # Gradient/Deep/Kernel fall back to the input batch when ``background_data``
+    # is omitted; TreeExplainer takes no reference input (``baseline_default`` None).
     algorithm_registry={
-        "GradientExplainer": frozenset({MethodFamily.SHAPLEY, MethodFamily.GRADIENT}),
-        "DeepExplainer": frozenset({MethodFamily.SHAPLEY, MethodFamily.GRADIENT}),
-        "KernelExplainer": frozenset(
-            {MethodFamily.SHAPLEY, MethodFamily.PERTURBATION, MethodFamily.MODEL_AGNOSTIC}
+        "GradientExplainer": ExplainerSemanticsHints(
+            frozenset({MethodFamily.SHAPLEY, MethodFamily.GRADIENT}),
+            baseline_default=BaselineMode.INPUT_BATCH,
         ),
-        "TreeExplainer": frozenset({MethodFamily.SHAPLEY, MethodFamily.TREE}),
+        "DeepExplainer": ExplainerSemanticsHints(
+            frozenset({MethodFamily.SHAPLEY, MethodFamily.GRADIENT}),
+            baseline_default=BaselineMode.INPUT_BATCH,
+        ),
+        "KernelExplainer": ExplainerSemanticsHints(
+            frozenset(
+                {MethodFamily.SHAPLEY, MethodFamily.PERTURBATION, MethodFamily.MODEL_AGNOSTIC}
+            ),
+            baseline_default=BaselineMode.INPUT_BATCH,
+        ),
+        "TreeExplainer": ExplainerSemanticsHints(
+            frozenset({MethodFamily.SHAPLEY, MethodFamily.TREE})
+        ),
     },
+    baseline_kwarg="background_data",
     onnx_compatible_algorithms=frozenset({"KernelExplainer"}),
 )
 class ShapExplainer(AttributionOnlyExplainer):
@@ -97,13 +111,6 @@ class ShapExplainer(AttributionOnlyExplainer):
 
     Uses dynamic explainer loading - no need for class-per-explainer.
     """
-
-    baseline_kwarg: ClassVar[str | None] = "background_data"
-    baseline_defaults: ClassVar[Mapping[str, BaselineMode]] = {
-        "GradientExplainer": BaselineMode.INPUT_BATCH,
-        "DeepExplainer": BaselineMode.INPUT_BATCH,
-        "KernelExplainer": BaselineMode.INPUT_BATCH,
-    }
 
     def __init__(self, algorithm: str, **init_kwargs):
         """

--- a/src/raitap/transparency/explainers/tests/test_base_explainer.py
+++ b/src/raitap/transparency/explainers/tests/test_base_explainer.py
@@ -526,3 +526,27 @@ def test_explain_classification_unchanged_when_backend_has_no_task_kind() -> Non
         raitap_kwargs=_raitap_kwargs_for(inputs),
     )
     assert result.semantics.output_space.space is ExplanationOutputSpace.INPUT_FEATURES
+
+
+def test_explainer_baseline_declarations() -> None:
+    from raitap.transparency.explainers.base_explainer import BaseExplainer
+    from raitap.transparency.explainers.captum_explainer import CaptumExplainer
+    from raitap.transparency.explainers.shap_explainer import ShapExplainer
+
+    # Base default: no baseline kwarg, no implicit defaults.
+    assert BaseExplainer.baseline_kwarg is None
+    assert BaseExplainer.baseline_defaults == {}
+
+    # Captum: only IntegratedGradients has a meaningful zero default.
+    assert CaptumExplainer.baseline_kwarg == "baselines"
+    assert CaptumExplainer.baseline_defaults == {"IntegratedGradients": "zero"}
+    assert "Saliency" not in CaptumExplainer.baseline_defaults
+
+    # SHAP: Gradient/Deep/Kernel fall back to the input batch; Tree does not.
+    assert ShapExplainer.baseline_kwarg == "background_data"
+    assert ShapExplainer.baseline_defaults == {
+        "GradientExplainer": "input_batch",
+        "DeepExplainer": "input_batch",
+        "KernelExplainer": "input_batch",
+    }
+    assert "TreeExplainer" not in ShapExplainer.baseline_defaults

--- a/src/raitap/transparency/explainers/tests/test_base_explainer.py
+++ b/src/raitap/transparency/explainers/tests/test_base_explainer.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
 import raitap.transparency.explainers.base_explainer as base_explainer_module
@@ -92,7 +93,7 @@ class _BatchRecordingExplainer(AttributionOnlyExplainer):
 class _BaselineDeclaringExplainer(AttributionOnlyExplainer):
     algorithm = "IntegratedGradients"
     baseline_kwarg = "baselines"
-    baseline_defaults: ClassVar[dict[str, str]] = {"IntegratedGradients": "zero"}
+    baseline_defaults: ClassVar[Mapping[str, str]] = {"IntegratedGradients": "zero"}
 
     def compute_attributions(
         self,

--- a/src/raitap/transparency/explainers/tests/test_base_explainer.py
+++ b/src/raitap/transparency/explainers/tests/test_base_explainer.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import pytest
 import torch
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 import raitap.transparency.explainers.base_explainer as base_explainer_module
 from raitap.transparency.contracts import (
@@ -83,6 +86,23 @@ class _BatchRecordingExplainer(AttributionOnlyExplainer):
 
         background_size = -1 if background_data is None else int(background_data.shape[0])
         self.seen_background_sizes.append(background_size)
+        return inputs
+
+
+class _BaselineDeclaringExplainer(AttributionOnlyExplainer):
+    algorithm = "IntegratedGradients"
+    baseline_kwarg = "baselines"
+    baseline_defaults: ClassVar[dict[str, str]] = {"IntegratedGradients": "zero"}
+
+    def compute_attributions(
+        self,
+        model: torch.nn.Module,
+        inputs: torch.Tensor,
+        target: int | None = None,
+        baselines: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        del model, target, baselines, kwargs
         return inputs
 
 
@@ -550,3 +570,49 @@ def test_explainer_baseline_declarations() -> None:
         "KernelExplainer": "input_batch",
     }
     assert "TreeExplainer" not in ShapExplainer.baseline_defaults
+
+
+def test_explain_attaches_zero_baseline_when_absent(tmp_path: Path) -> None:
+    explainer = _BaselineDeclaringExplainer()
+    inputs = torch.randn(2, 3, 4, 4)
+
+    result = explainer.explain(
+        torch.nn.Identity(),
+        inputs,
+        run_dir=tmp_path / "exp",
+        target=0,
+        raitap_kwargs=_raitap_kwargs_for(inputs),
+    )
+
+    assert result.baseline is not None
+    assert result.baseline.mode == "zero"
+    assert result.baseline.kwarg_name == "baselines"
+    assert result.baseline.shape == (1, 3, 4, 4)  # torch.zeros_like(inputs[:1])
+    assert result.baseline.sha256
+    # Image modality -> a baseline PNG was rendered into run_dir.
+    assert result.baseline.image_path is not None
+    assert (result.run_dir / result.baseline.image_path).exists()
+
+
+def test_explain_records_configured_baseline_with_provenance(tmp_path: Path) -> None:
+    explainer = _BaselineDeclaringExplainer()
+    inputs = torch.randn(1, 3, 4, 4)
+    baseline_tensor = torch.zeros(1, 3, 4, 4)
+
+    result = explainer.explain(
+        torch.nn.Identity(),
+        inputs,
+        run_dir=tmp_path / "exp",
+        target=0,
+        baselines=baseline_tensor,
+        call_provenance={"baselines": {"source": "zeros_cfg", "n_samples": 1}},
+        raitap_kwargs=_raitap_kwargs_for(inputs),
+    )
+
+    assert result.baseline is not None
+    assert result.baseline.mode == "configured"
+    assert result.baseline.source == "zeros_cfg"
+    assert result.baseline.n_samples == 1
+    # call_provenance is a named kwarg, not forwarded into compute_attributions
+    # kwargs, so it never lands in call_kwargs.
+    assert "call_provenance" not in result.call_kwargs

--- a/src/raitap/transparency/explainers/tests/test_base_explainer.py
+++ b/src/raitap/transparency/explainers/tests/test_base_explainer.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 import raitap.transparency.explainers.base_explainer as base_explainer_module
 from raitap.transparency.contracts import (
+    BaselineMode,
     ExplanationOutputSpace,
     ExplanationPayloadKind,
     ExplanationScope,
@@ -93,7 +94,9 @@ class _BatchRecordingExplainer(AttributionOnlyExplainer):
 class _BaselineDeclaringExplainer(AttributionOnlyExplainer):
     algorithm = "IntegratedGradients"
     baseline_kwarg = "baselines"
-    baseline_defaults: ClassVar[Mapping[str, str]] = {"IntegratedGradients": "zero"}
+    baseline_defaults: ClassVar[Mapping[str, BaselineMode]] = {
+        "IntegratedGradients": BaselineMode.ZERO
+    }
 
     def compute_attributions(
         self,

--- a/src/raitap/transparency/explainers/tests/test_base_explainer.py
+++ b/src/raitap/transparency/explainers/tests/test_base_explainer.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 import raitap.transparency.explainers.base_explainer as base_explainer_module
 from raitap.transparency.contracts import (
     BaselineMode,
+    ExplainerSemanticsHints,
     ExplanationOutputSpace,
     ExplanationPayloadKind,
     ExplanationScope,
@@ -94,8 +95,10 @@ class _BatchRecordingExplainer(AttributionOnlyExplainer):
 class _BaselineDeclaringExplainer(AttributionOnlyExplainer):
     algorithm = "IntegratedGradients"
     baseline_kwarg = "baselines"
-    baseline_defaults: ClassVar[Mapping[str, BaselineMode]] = {
-        "IntegratedGradients": BaselineMode.ZERO
+    algorithm_registry: ClassVar[Mapping[str, ExplainerSemanticsHints]] = {
+        "IntegratedGradients": ExplainerSemanticsHints(
+            frozenset({MethodFamily.GRADIENT}), baseline_default=BaselineMode.ZERO
+        )
     }
 
     def compute_attributions(
@@ -557,23 +560,26 @@ def test_explainer_baseline_declarations() -> None:
     from raitap.transparency.explainers.captum_explainer import CaptumExplainer
     from raitap.transparency.explainers.shap_explainer import ShapExplainer
 
-    # Base default: no baseline kwarg, no implicit defaults.
+    # Base default: no baseline kwarg.
     assert BaseExplainer.baseline_kwarg is None
-    assert BaseExplainer.baseline_defaults == {}
 
-    # Captum: only IntegratedGradients has a meaningful zero default.
+    # Captum: only IntegratedGradients has a meaningful zero default; the rest
+    # carry no implicit baseline (``baseline_default`` is None).
     assert CaptumExplainer.baseline_kwarg == "baselines"
-    assert CaptumExplainer.baseline_defaults == {"IntegratedGradients": "zero"}
-    assert "Saliency" not in CaptumExplainer.baseline_defaults
+    assert CaptumExplainer.algorithm_registry["IntegratedGradients"].baseline_default == "zero"
+    assert CaptumExplainer.algorithm_registry["Saliency"].baseline_default is None
 
     # SHAP: Gradient/Deep/Kernel fall back to the input batch; Tree does not.
     assert ShapExplainer.baseline_kwarg == "background_data"
-    assert ShapExplainer.baseline_defaults == {
+    assert {
+        algorithm: hints.baseline_default
+        for algorithm, hints in ShapExplainer.algorithm_registry.items()
+    } == {
         "GradientExplainer": "input_batch",
         "DeepExplainer": "input_batch",
         "KernelExplainer": "input_batch",
+        "TreeExplainer": None,
     }
-    assert "TreeExplainer" not in ShapExplainer.baseline_defaults
 
 
 def test_explain_attaches_zero_baseline_when_absent(tmp_path: Path) -> None:

--- a/src/raitap/transparency/explainers/tests/test_base_explainer.py
+++ b/src/raitap/transparency/explainers/tests/test_base_explainer.py
@@ -595,6 +595,32 @@ def test_explain_attaches_zero_baseline_when_absent(tmp_path: Path) -> None:
     assert (result.run_dir / result.baseline.image_path).exists()
 
 
+def test_explain_survives_baseline_documentation_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _boom(**_kwargs: Any) -> None:
+        raise RuntimeError("baseline render exploded")
+
+    monkeypatch.setattr(base_explainer_module, "build_baseline_record", _boom)
+
+    explainer = _BaselineDeclaringExplainer()
+    inputs = torch.randn(2, 3, 4, 4)
+
+    result = explainer.explain(
+        torch.nn.Identity(),
+        inputs,
+        run_dir=tmp_path / "exp",
+        target=0,
+        raitap_kwargs=_raitap_kwargs_for(inputs),
+    )
+
+    # Documentation failure must not discard the scientific output.
+    assert result.baseline is None
+    assert torch.equal(result.attributions, inputs)
+    assert (result.run_dir / "metadata.json").exists()
+    assert (result.run_dir / "attributions.pt").exists()
+
+
 def test_explain_records_configured_baseline_with_provenance(tmp_path: Path) -> None:
     explainer = _BaselineDeclaringExplainer()
     inputs = torch.randn(1, 3, 4, 4)

--- a/src/raitap/transparency/explainers/tests/test_base_explainer.py
+++ b/src/raitap/transparency/explainers/tests/test_base_explainer.py
@@ -94,7 +94,7 @@ class _BatchRecordingExplainer(AttributionOnlyExplainer):
 
 class _BaselineDeclaringExplainer(AttributionOnlyExplainer):
     algorithm = "IntegratedGradients"
-    baseline_kwarg = "baselines"
+    baseline_kwarg_name = "baselines"
     algorithm_registry: ClassVar[Mapping[str, ExplainerSemanticsHints]] = {
         "IntegratedGradients": ExplainerSemanticsHints(
             frozenset({MethodFamily.GRADIENT}), baseline_default=BaselineMode.ZERO
@@ -561,16 +561,16 @@ def test_explainer_baseline_declarations() -> None:
     from raitap.transparency.explainers.shap_explainer import ShapExplainer
 
     # Base default: no baseline kwarg.
-    assert BaseExplainer.baseline_kwarg is None
+    assert BaseExplainer.baseline_kwarg_name is None
 
     # Captum: only IntegratedGradients has a meaningful zero default; the rest
     # carry no implicit baseline (``baseline_default`` is None).
-    assert CaptumExplainer.baseline_kwarg == "baselines"
+    assert CaptumExplainer.baseline_kwarg_name == "baselines"
     assert CaptumExplainer.algorithm_registry["IntegratedGradients"].baseline_default == "zero"
     assert CaptumExplainer.algorithm_registry["Saliency"].baseline_default is None
 
     # SHAP: Gradient/Deep/Kernel fall back to the input batch; Tree does not.
-    assert ShapExplainer.baseline_kwarg == "background_data"
+    assert ShapExplainer.baseline_kwarg_name == "background_data"
     assert {
         algorithm: hints.baseline_default
         for algorithm, hints in ShapExplainer.algorithm_registry.items()

--- a/src/raitap/transparency/explainers/tests/test_registration.py
+++ b/src/raitap/transparency/explainers/tests/test_registration.py
@@ -7,7 +7,11 @@ import torch
 import torch.nn as nn
 
 from raitap import adapters
-from raitap.transparency.contracts import ExplanationPayloadKind, MethodFamily
+from raitap.transparency.contracts import (
+    ExplainerSemanticsHints,
+    ExplanationPayloadKind,
+    MethodFamily,
+)
 from raitap.transparency.explainers.base_explainer import AttributionOnlyExplainer
 
 
@@ -16,7 +20,7 @@ def test_transparency_adapter_registers_and_assigns_classvars() -> None:
         registry_name="_stub_xai",
         extra="_stub_extra",
         library="_stub_lib",
-        algorithm_registry={"alg": frozenset({MethodFamily.GRADIENT})},
+        algorithm_registry={"alg": ExplainerSemanticsHints(frozenset({MethodFamily.GRADIENT}))},
     )
     class _StubExplainer(AttributionOnlyExplainer):
         def __init__(self, algorithm: str):
@@ -42,4 +46,6 @@ def test_transparency_adapter_registers_and_assigns_classvars() -> None:
     assert ADAPTER_EXTRAS["_StubExplainer"] == "_stub_extra"
     # output_payload_kind defaults to ATTRIBUTIONS when the decorator kwarg is omitted.
     assert _StubExplainer.output_payload_kind is ExplanationPayloadKind.ATTRIBUTIONS
-    assert _StubExplainer.algorithm_registry == {"alg": frozenset({MethodFamily.GRADIENT})}
+    assert _StubExplainer.algorithm_registry == {
+        "alg": ExplainerSemanticsHints(frozenset({MethodFamily.GRADIENT}))
+    }

--- a/src/raitap/transparency/factory.py
+++ b/src/raitap/transparency/factory.py
@@ -223,6 +223,7 @@ class Explanation:
                         source=source,
                     )
 
+            call_provenance: dict[str, dict[str, Any]] = {}
             merged_kwargs = resolve_call_data_sources(
                 {**call_from_config, **kwargs},
                 log_label="call",
@@ -230,6 +231,7 @@ class Explanation:
                     config,
                     resolved_preprocessing=resolved_preprocessing,
                 ),
+                provenance_out=call_provenance,
             )
             merged_kwargs = backend._prepare_kwargs(merged_kwargs)
 
@@ -243,6 +245,7 @@ class Explanation:
                 explainer_name=explainer_name,
                 visualisers=visualisers,
                 raitap_kwargs=raitap_cfg,
+                call_provenance=call_provenance,
                 **merged_kwargs,
             )
         finally:

--- a/src/raitap/transparency/factory.py
+++ b/src/raitap/transparency/factory.py
@@ -17,6 +17,7 @@ from raitap.configs.adapter_factory import (
     resolve_per_image_transform,
 )
 from raitap.models.backend import ModelBackend
+from raitap.transparency.baselines import apply_config_baseline
 from raitap.utils.errors import SampleNamesLengthError
 from raitap.utils.lazy import lazy_import
 
@@ -66,6 +67,9 @@ _SCHEMA = AdapterSchema(
             "sample_ids",
             "sample_names",
             "show_sample_names",
+            # Library-agnostic baseline / reference input, routed to the
+            # adapter's ``baseline_kwarg_name`` by ``apply_config_baseline``.
+            "baseline",
             # Detection-task knobs consumed by ``explain_detection`` —
             # ``score_threshold`` / ``max_boxes`` / ``iou_threshold``.
             "detection",
@@ -223,9 +227,18 @@ class Explanation:
                         source=source,
                     )
 
+            # Route raitap.baseline on the *merged* call dict (config + runtime
+            # kwargs) so raitap.baseline wins — with a warning — over the adapter's
+            # own kwarg whether it came from ``call:`` or a runtime override.
+            merged_call = apply_config_baseline(
+                explainer=explainer,
+                call_kwargs={**call_from_config, **kwargs},
+                raitap_kwargs=raitap_cfg,
+            )
+
             call_provenance: dict[str, dict[str, Any]] = {}
             merged_kwargs = resolve_call_data_sources(
-                {**call_from_config, **kwargs},
+                merged_call,
                 log_label="call",
                 per_image_transform=resolve_per_image_transform(
                     config,

--- a/src/raitap/transparency/results.py
+++ b/src/raitap/transparency/results.py
@@ -21,6 +21,7 @@ else:
     torch = lazy_import("torch")
 
 from .contracts import (
+    BaselineRecord,
     DetectionBox,
     ExplanationPayloadKind,
     ExplanationScope,
@@ -146,6 +147,7 @@ class ExplanationResult(Trackable):
     payload_kind: ExplanationPayloadKind = ExplanationPayloadKind.ATTRIBUTIONS
     detection_box: DetectionBox | None = None
     original_sample_index: int | None = None
+    baseline: BaselineRecord | None = None
     semantics: ExplanationSemantics = field(kw_only=True)
 
     def __post_init__(self) -> None:
@@ -181,7 +183,9 @@ class ExplanationResult(Trackable):
             "semantics": _serialisable_semantics(self.semantics),
             "kwargs": {key: _serialisable(value) for key, value in self.kwargs.items()},
             "call_kwargs": {
-                key: _serialisable_call_kwarg(value) for key, value in self.call_kwargs.items()
+                key: _serialisable_call_kwarg(value)
+                for key, value in self.call_kwargs.items()
+                if not (self.baseline is not None and key == self.baseline.kwarg_name)
             },
         }
         if self.detection_box is not None:
@@ -195,6 +199,21 @@ class ExplanationResult(Trackable):
             }
         if self.original_sample_index is not None:
             metadata["original_sample_index"] = self.original_sample_index
+        if self.baseline is not None:
+            metadata["baseline"] = {
+                "kwarg_name": self.baseline.kwarg_name,
+                "mode": self.baseline.mode,
+                "source": self.baseline.source,
+                "n_samples": self.baseline.n_samples,
+                "shape": list(self.baseline.shape),
+                "dtype": self.baseline.dtype,
+                "sha256": self.baseline.sha256,
+                "image_path": (
+                    str(self.baseline.image_path)
+                    if self.baseline.image_path is not None
+                    else None
+                ),
+            }
         return metadata
 
     def _write_metadata(self) -> None:

--- a/src/raitap/transparency/results.py
+++ b/src/raitap/transparency/results.py
@@ -209,9 +209,7 @@ class ExplanationResult(Trackable):
                 "dtype": self.baseline.dtype,
                 "sha256": self.baseline.sha256,
                 "image_path": (
-                    str(self.baseline.image_path)
-                    if self.baseline.image_path is not None
-                    else None
+                    str(self.baseline.image_path) if self.baseline.image_path is not None else None
                 ),
             }
         return metadata

--- a/src/raitap/transparency/semantics.py
+++ b/src/raitap/transparency/semantics.py
@@ -42,7 +42,7 @@ def method_families_for_explainer(explainer: object) -> frozenset[MethodFamily]:
 
     cls_registry = getattr(type(explainer), "algorithm_registry", None)
     if isinstance(cls_registry, Mapping) and algorithm in cls_registry:
-        return cls_registry[algorithm]
+        return cls_registry[algorithm].families
 
     framework = _explainer_framework(explainer)
     if framework is not None:
@@ -50,7 +50,7 @@ def method_families_for_explainer(explainer: object) -> frozenset[MethodFamily]:
         if adapter_cls is not None:
             registry = adapter_cls.algorithm_registry
             if algorithm in registry:
-                return registry[algorithm]
+                return registry[algorithm].families
             raise _method_family_error(framework, algorithm)
 
     # No framework hint: try unique cross-framework match via algorithm name.
@@ -279,7 +279,7 @@ def _method_families_for_algorithm(algorithm: str) -> frozenset[MethodFamily]:
     for label, adapter_cls in (("SHAP", ShapExplainer), ("Captum", CaptumExplainer)):
         registry = adapter_cls.algorithm_registry
         if algorithm in registry:
-            matches.append((label, registry[algorithm]))
+            matches.append((label, registry[algorithm].families))
 
     if len(matches) == 1:
         return matches[0][1]

--- a/src/raitap/transparency/tests/e2e_case_matrix.py
+++ b/src/raitap/transparency/tests/e2e_case_matrix.py
@@ -309,7 +309,7 @@ def _assert_metadata_invariants(
     case: MatrixCase,
     has_visualisers: bool,
 ) -> None:
-    assert set(metadata) == {
+    required_keys = {
         "experiment_name",
         "target",
         "algorithm",
@@ -319,6 +319,11 @@ def _assert_metadata_invariants(
         "payload_kind",
         "semantics",
     }
+    assert required_keys <= set(metadata)
+    # ``baseline`` is an optional key, present only for attribution methods that
+    # take a reference input (IG ``baselines`` / SHAP ``background_data``); see
+    # issue #210. No other keys are permitted.
+    assert set(metadata) - required_keys <= {"baseline"}
     assert metadata["payload_kind"] == "attributions"
     semantics = cast("dict[str, object]", metadata["semantics"])
     assert semantics["scope"] == "local"

--- a/src/raitap/transparency/tests/test_baselines.py
+++ b/src/raitap/transparency/tests/test_baselines.py
@@ -103,6 +103,21 @@ def test_configured_when_provenance_present(tmp_path: Path) -> None:
     assert record.shape == (5, 3, 4, 4)
 
 
+def test_bfloat16_baseline_renders_and_hashes(tmp_path: Path) -> None:
+    record = build_baseline_record(
+        explainer=_captum_ig(),
+        inputs=torch.rand(2, 3, 4, 4, dtype=torch.bfloat16),
+        call_kwargs={},
+        call_provenance=None,
+        input_spec=_image_input_spec((2, 3, 4, 4)),
+        run_dir=tmp_path,
+    )
+    assert record is not None
+    assert record.sha256  # bf16 hashed without crashing
+    assert record.image_path is not None
+    assert (tmp_path / record.image_path).exists()  # bf16 rendered without crashing
+
+
 def test_montage_caption_only_when_capped() -> None:
     from raitap.transparency.baselines import _montage_caption
 

--- a/src/raitap/transparency/tests/test_baselines.py
+++ b/src/raitap/transparency/tests/test_baselines.py
@@ -62,6 +62,7 @@ def test_captum_zero_default_when_baseline_absent(tmp_path: Path) -> None:
         input_spec=_image_input_spec((2, 3, 4, 4)),
         run_dir=tmp_path,
     )
+    assert expected is not None
     assert record.sha256 == expected.sha256
     assert record.image_path is not None
     assert (tmp_path / record.image_path).exists()

--- a/src/raitap/transparency/tests/test_baselines.py
+++ b/src/raitap/transparency/tests/test_baselines.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import torch
+
+from raitap.transparency.baselines import build_baseline_record
+from raitap.transparency.contracts import InputSpec
+
+
+def _image_input_spec(shape: tuple[int, ...]) -> InputSpec:
+    # InputSpec.__init__ normalises string kind/layout via normalise_* helpers;
+    # passing strings avoids depending on enum member names (TensorLayout's NCHW
+    # member is BATCH_CHANNEL_HEIGHT_WIDTH, value "NCHW").
+    return InputSpec(kind="image", shape=shape, layout="NCHW")
+
+
+def _tabular_input_spec(shape: tuple[int, ...]) -> InputSpec:
+    return InputSpec(kind="tabular", shape=shape, layout="(B,F)")
+
+
+def _captum_ig() -> SimpleNamespace:
+    return SimpleNamespace(
+        algorithm="IntegratedGradients",
+        baseline_kwarg="baselines",
+        baseline_defaults={"IntegratedGradients": "zero"},
+    )
+
+
+def _shap_gradient() -> SimpleNamespace:
+    return SimpleNamespace(
+        algorithm="GradientExplainer",
+        baseline_kwarg="background_data",
+        baseline_defaults={"GradientExplainer": "input_batch"},
+    )
+
+
+def test_captum_zero_default_when_baseline_absent(tmp_path: Path) -> None:
+    inputs = torch.rand(2, 3, 4, 4)
+    record = build_baseline_record(
+        explainer=_captum_ig(),
+        inputs=inputs,
+        call_kwargs={},
+        call_provenance=None,
+        input_spec=_image_input_spec((2, 3, 4, 4)),
+        run_dir=tmp_path,
+    )
+    assert record is not None
+    assert record.mode == "zero"
+    assert record.kwarg_name == "baselines"
+    assert record.source is None
+    assert record.shape == (1, 3, 4, 4)  # torch.zeros_like(inputs[:1])
+    expected = build_baseline_record(
+        explainer=_captum_ig(),
+        inputs=inputs,
+        call_kwargs={},
+        call_provenance=None,
+        input_spec=_image_input_spec((2, 3, 4, 4)),
+        run_dir=tmp_path,
+    )
+    assert record.sha256 == expected.sha256
+    assert record.image_path is not None
+    assert (tmp_path / record.image_path).exists()
+
+
+def test_user_tensor_when_baseline_present_without_provenance(tmp_path: Path) -> None:
+    inputs = torch.rand(2, 3, 4, 4)
+    baseline = torch.rand(1, 3, 4, 4)
+    record = build_baseline_record(
+        explainer=_captum_ig(),
+        inputs=inputs,
+        call_kwargs={"baselines": baseline},
+        call_provenance=None,
+        input_spec=_image_input_spec((2, 3, 4, 4)),
+        run_dir=tmp_path,
+    )
+    assert record is not None
+    assert record.mode == "user_tensor"
+    assert record.source is None
+    assert record.shape == (1, 3, 4, 4)
+
+
+def test_configured_when_provenance_present(tmp_path: Path) -> None:
+    inputs = torch.rand(2, 3, 4, 4)
+    background = torch.rand(5, 3, 4, 4)
+    record = build_baseline_record(
+        explainer=_shap_gradient(),
+        inputs=inputs,
+        call_kwargs={"background_data": background},
+        call_provenance={"background_data": {"source": "imagenet", "n_samples": 5}},
+        input_spec=_image_input_spec((2, 3, 4, 4)),
+        run_dir=tmp_path,
+    )
+    assert record is not None
+    assert record.mode == "configured"
+    assert record.source == "imagenet"
+    assert record.n_samples == 5
+    assert record.shape == (5, 3, 4, 4)
+
+
+def test_shap_input_batch_default_when_absent(tmp_path: Path) -> None:
+    inputs = torch.rand(3, 3, 4, 4)
+    record = build_baseline_record(
+        explainer=_shap_gradient(),
+        inputs=inputs,
+        call_kwargs={},
+        call_provenance=None,
+        input_spec=_image_input_spec((3, 3, 4, 4)),
+        run_dir=tmp_path,
+    )
+    assert record is not None
+    assert record.mode == "input_batch"
+    assert record.shape == (3, 3, 4, 4)  # the full input batch
+
+
+def test_no_record_for_algorithm_without_baseline(tmp_path: Path) -> None:
+    saliency = SimpleNamespace(
+        algorithm="Saliency",
+        baseline_kwarg="baselines",
+        baseline_defaults={"IntegratedGradients": "zero"},
+    )
+    record = build_baseline_record(
+        explainer=saliency,
+        inputs=torch.rand(2, 3, 4, 4),
+        call_kwargs={},
+        call_provenance=None,
+        input_spec=_image_input_spec((2, 3, 4, 4)),
+        run_dir=tmp_path,
+    )
+    assert record is None
+
+
+def test_no_record_when_family_takes_no_baseline(tmp_path: Path) -> None:
+    explainer = SimpleNamespace(algorithm="X", baseline_kwarg=None, baseline_defaults={})
+    record = build_baseline_record(
+        explainer=explainer,
+        inputs=torch.rand(2, 3, 4, 4),
+        call_kwargs={},
+        call_provenance=None,
+        input_spec=_image_input_spec((2, 3, 4, 4)),
+        run_dir=tmp_path,
+    )
+    assert record is None
+
+
+def test_no_image_for_non_image_modality(tmp_path: Path) -> None:
+    record = build_baseline_record(
+        explainer=_captum_ig(),
+        inputs=torch.rand(2, 4),
+        call_kwargs={},
+        call_provenance=None,
+        input_spec=_tabular_input_spec((2, 4)),
+        run_dir=tmp_path,
+    )
+    assert record is not None
+    assert record.mode == "zero"
+    assert record.image_path is None
+    assert not (tmp_path / "baseline.png").exists()

--- a/src/raitap/transparency/tests/test_baselines.py
+++ b/src/raitap/transparency/tests/test_baselines.py
@@ -6,17 +6,18 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
-
+import pytest
 import torch
 
 from raitap.transparency.baselines import (
     _render_baseline_image as _original_render_baseline_image,
 )
 from raitap.transparency.baselines import (
+    apply_config_baseline,
     build_baseline_record,
 )
 from raitap.transparency.contracts import (
+    BaselineCardinality,
     BaselineMode,
     ExplainerSemanticsHints,
     InputSpec,
@@ -38,7 +39,7 @@ def _tabular_input_spec(shape: tuple[int, ...]) -> InputSpec:
 def _captum_ig() -> SimpleNamespace:
     return SimpleNamespace(
         algorithm="IntegratedGradients",
-        baseline_kwarg="baselines",
+        baseline_kwarg_name="baselines",
         algorithm_registry={
             "IntegratedGradients": ExplainerSemanticsHints(
                 frozenset({MethodFamily.GRADIENT}), baseline_default=BaselineMode.ZERO
@@ -50,7 +51,7 @@ def _captum_ig() -> SimpleNamespace:
 def _shap_gradient() -> SimpleNamespace:
     return SimpleNamespace(
         algorithm="GradientExplainer",
-        baseline_kwarg="background_data",
+        baseline_kwarg_name="background_data",
         algorithm_registry={
             "GradientExplainer": ExplainerSemanticsHints(
                 frozenset({MethodFamily.SHAPLEY, MethodFamily.GRADIENT}),
@@ -225,7 +226,7 @@ def test_shap_input_batch_default_when_absent(tmp_path: Path) -> None:
 def test_no_record_for_algorithm_without_baseline(tmp_path: Path) -> None:
     saliency = SimpleNamespace(
         algorithm="Saliency",
-        baseline_kwarg="baselines",
+        baseline_kwarg_name="baselines",
         # Saliency is absent from the registry → no implicit baseline.
         algorithm_registry={
             "IntegratedGradients": ExplainerSemanticsHints(
@@ -245,7 +246,7 @@ def test_no_record_for_algorithm_without_baseline(tmp_path: Path) -> None:
 
 
 def test_no_record_when_family_takes_no_baseline(tmp_path: Path) -> None:
-    explainer = SimpleNamespace(algorithm="X", baseline_kwarg=None, algorithm_registry={})
+    explainer = SimpleNamespace(algorithm="X", baseline_kwarg_name=None, algorithm_registry={})
     record = build_baseline_record(
         explainer=explainer,
         inputs=torch.rand(2, 3, 4, 4),
@@ -270,3 +271,98 @@ def test_no_image_for_non_image_modality(tmp_path: Path) -> None:
     assert record.mode == "zero"
     assert record.image_path is None
     assert not (tmp_path / "baseline.png").exists()
+
+
+def test_apply_config_baseline_routes_to_adapter_kwarg() -> None:
+    explainer = SimpleNamespace(algorithm="IntegratedGradients", baseline_kwarg_name="baselines")
+    raitap_kwargs = {"baseline": {"source": "./bg"}, "batch_size": 1}
+    call_kwargs = apply_config_baseline(
+        explainer=explainer, call_kwargs={"target": 0}, raitap_kwargs=raitap_kwargs
+    )
+    # Routed under the adapter's own kwarg name; popped from the raitap block.
+    assert call_kwargs == {"target": 0, "baselines": {"source": "./bg"}}
+    assert "baseline" not in raitap_kwargs
+    assert raitap_kwargs == {"batch_size": 1}
+
+
+def test_apply_config_baseline_noop_when_absent() -> None:
+    explainer = SimpleNamespace(algorithm="IntegratedGradients", baseline_kwarg_name="baselines")
+    raitap_kwargs = {"batch_size": 1}
+    call_kwargs = apply_config_baseline(
+        explainer=explainer, call_kwargs={"target": 0}, raitap_kwargs=raitap_kwargs
+    )
+    assert call_kwargs == {"target": 0}
+    assert raitap_kwargs == {"batch_size": 1}
+
+
+def test_apply_config_baseline_raitap_wins_over_call_kwarg() -> None:
+    explainer = SimpleNamespace(
+        algorithm="GradientExplainer", baseline_kwarg_name="background_data"
+    )
+    raitap_kwargs = {"baseline": {"source": "./preferred"}}
+    call_kwargs = apply_config_baseline(
+        explainer=explainer,
+        call_kwargs={"background_data": {"source": "./ignored"}},
+        raitap_kwargs=raitap_kwargs,
+    )
+    assert call_kwargs == {"background_data": {"source": "./preferred"}}
+
+
+def test_apply_config_baseline_errors_when_family_takes_no_baseline() -> None:
+    from raitap.utils.errors import RaitapError
+
+    explainer = SimpleNamespace(algorithm="Saliency", baseline_kwarg_name=None)
+    with pytest.raises(RaitapError, match="takes no baseline"):
+        apply_config_baseline(
+            explainer=explainer, call_kwargs={}, raitap_kwargs={"baseline": {"source": "./bg"}}
+        )
+
+
+def _explainer_with_cardinality(
+    algorithm: str, kwarg: str, cardinality: BaselineCardinality
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        algorithm=algorithm,
+        baseline_kwarg_name=kwarg,
+        algorithm_registry={
+            algorithm: ExplainerSemanticsHints(frozenset(), baseline_cardinality=cardinality)
+        },
+    )
+
+
+def test_single_cardinality_warns_on_multi_sample_baseline() -> None:
+    explainer = _explainer_with_cardinality(
+        "IntegratedGradients", "baselines", BaselineCardinality.SINGLE
+    )
+    with pytest.warns(UserWarning, match="single baseline reference"):
+        call_kwargs = apply_config_baseline(
+            explainer=explainer,
+            call_kwargs={},
+            raitap_kwargs={"baseline": {"source": "./bg", "n_samples": 32}},
+        )
+    # Warns but still routes (never reshapes or drops).
+    assert call_kwargs == {"baselines": {"source": "./bg", "n_samples": 32}}
+
+
+def test_single_cardinality_silent_for_single_sample(recwarn: pytest.WarningsRecorder) -> None:
+    explainer = _explainer_with_cardinality(
+        "IntegratedGradients", "baselines", BaselineCardinality.SINGLE
+    )
+    apply_config_baseline(
+        explainer=explainer,
+        call_kwargs={},
+        raitap_kwargs={"baseline": {"source": "./bg", "n_samples": 1}},
+    )
+    assert not recwarn.list
+
+
+def test_set_cardinality_silent_for_multi_sample(recwarn: pytest.WarningsRecorder) -> None:
+    explainer = _explainer_with_cardinality(
+        "GradientExplainer", "background_data", BaselineCardinality.SET
+    )
+    apply_config_baseline(
+        explainer=explainer,
+        call_kwargs={},
+        raitap_kwargs={"baseline": {"source": "./bg", "n_samples": 32}},
+    )
+    assert not recwarn.list

--- a/src/raitap/transparency/tests/test_baselines.py
+++ b/src/raitap/transparency/tests/test_baselines.py
@@ -103,6 +103,30 @@ def test_configured_when_provenance_present(tmp_path: Path) -> None:
     assert record.shape == (5, 3, 4, 4)
 
 
+def test_multi_image_baseline_renders_grid_montage(tmp_path: Path) -> None:
+    from PIL import Image
+
+    background = torch.rand(6, 3, 8, 8)
+    record = build_baseline_record(
+        explainer=_shap_gradient(),
+        inputs=torch.rand(1, 3, 8, 8),
+        call_kwargs={"background_data": background},
+        call_provenance={"background_data": {"source": "bg", "n_samples": 6}},
+        input_spec=_image_input_spec((1, 3, 8, 8)),
+        run_dir=tmp_path,
+    )
+    assert record is not None
+    assert record.image_path is not None
+    rendered = tmp_path / record.image_path
+    assert rendered.exists()
+    # 6 images -> 5 cols x 2 rows grid -> wider than a single square tile.
+    with Image.open(rendered) as image:
+        assert image.width > image.height
+    # The descriptor still records the full set, not just the previewed tiles.
+    assert record.shape == (6, 3, 8, 8)
+    assert record.n_samples == 6
+
+
 def test_shap_input_batch_default_when_absent(tmp_path: Path) -> None:
     inputs = torch.rand(3, 3, 4, 4)
     record = build_baseline_record(

--- a/src/raitap/transparency/tests/test_baselines.py
+++ b/src/raitap/transparency/tests/test_baselines.py
@@ -16,7 +16,12 @@ from raitap.transparency.baselines import (
 from raitap.transparency.baselines import (
     build_baseline_record,
 )
-from raitap.transparency.contracts import InputSpec
+from raitap.transparency.contracts import (
+    BaselineMode,
+    ExplainerSemanticsHints,
+    InputSpec,
+    MethodFamily,
+)
 
 
 def _image_input_spec(shape: tuple[int, ...]) -> InputSpec:
@@ -34,7 +39,11 @@ def _captum_ig() -> SimpleNamespace:
     return SimpleNamespace(
         algorithm="IntegratedGradients",
         baseline_kwarg="baselines",
-        baseline_defaults={"IntegratedGradients": "zero"},
+        algorithm_registry={
+            "IntegratedGradients": ExplainerSemanticsHints(
+                frozenset({MethodFamily.GRADIENT}), baseline_default=BaselineMode.ZERO
+            )
+        },
     )
 
 
@@ -42,7 +51,12 @@ def _shap_gradient() -> SimpleNamespace:
     return SimpleNamespace(
         algorithm="GradientExplainer",
         baseline_kwarg="background_data",
-        baseline_defaults={"GradientExplainer": "input_batch"},
+        algorithm_registry={
+            "GradientExplainer": ExplainerSemanticsHints(
+                frozenset({MethodFamily.SHAPLEY, MethodFamily.GRADIENT}),
+                baseline_default=BaselineMode.INPUT_BATCH,
+            )
+        },
     )
 
 
@@ -212,7 +226,12 @@ def test_no_record_for_algorithm_without_baseline(tmp_path: Path) -> None:
     saliency = SimpleNamespace(
         algorithm="Saliency",
         baseline_kwarg="baselines",
-        baseline_defaults={"IntegratedGradients": "zero"},
+        # Saliency is absent from the registry → no implicit baseline.
+        algorithm_registry={
+            "IntegratedGradients": ExplainerSemanticsHints(
+                frozenset({MethodFamily.GRADIENT}), baseline_default=BaselineMode.ZERO
+            )
+        },
     )
     record = build_baseline_record(
         explainer=saliency,
@@ -226,7 +245,7 @@ def test_no_record_for_algorithm_without_baseline(tmp_path: Path) -> None:
 
 
 def test_no_record_when_family_takes_no_baseline(tmp_path: Path) -> None:
-    explainer = SimpleNamespace(algorithm="X", baseline_kwarg=None, baseline_defaults={})
+    explainer = SimpleNamespace(algorithm="X", baseline_kwarg=None, algorithm_registry={})
     record = build_baseline_record(
         explainer=explainer,
         inputs=torch.rand(2, 3, 4, 4),

--- a/src/raitap/transparency/tests/test_baselines.py
+++ b/src/raitap/transparency/tests/test_baselines.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
 import torch
 
 from raitap.transparency.baselines import build_baseline_record
@@ -116,6 +118,45 @@ def test_bfloat16_baseline_renders_and_hashes(tmp_path: Path) -> None:
     assert record.sha256  # bf16 hashed without crashing
     assert record.image_path is not None
     assert (tmp_path / record.image_path).exists()  # bf16 rendered without crashing
+
+
+def test_render_cache_reuses_rendered_baseline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import raitap.transparency.baselines as baselines_module
+
+    render_calls: list[Path] = []
+    original = baselines_module._render_baseline_image
+
+    def _counting_render(baseline: torch.Tensor, run_dir: Path) -> Path:
+        render_calls.append(run_dir)
+        return original(baseline, run_dir)
+
+    monkeypatch.setattr(baselines_module, "_render_baseline_image", _counting_render)
+
+    cache: dict[str, Path] = {}
+    common = {
+        "explainer": _captum_ig(),
+        "inputs": torch.rand(1, 3, 4, 4),
+        "call_kwargs": {},
+        "call_provenance": None,
+        "input_spec": _image_input_spec((1, 3, 4, 4)),
+    }
+    box0 = tmp_path / "box0"
+    box1 = tmp_path / "box1"
+    record0 = build_baseline_record(**common, run_dir=box0, render_cache=cache)
+    record1 = build_baseline_record(**common, run_dir=box1, render_cache=cache)
+
+    assert record0 is not None
+    assert record1 is not None
+    assert record0.sha256 == record1.sha256
+    # matplotlib ran exactly once; the second box reused the rendered image.
+    assert len(render_calls) == 1
+    assert record0.image_path is not None
+    assert record1.image_path is not None
+    assert (box0 / record0.image_path).exists()
+    assert (box1 / record1.image_path).exists()
+    assert (box0 / "baseline.png").read_bytes() == (box1 / "baseline.png").read_bytes()
 
 
 def test_montage_caption_only_when_capped() -> None:

--- a/src/raitap/transparency/tests/test_baselines.py
+++ b/src/raitap/transparency/tests/test_baselines.py
@@ -103,6 +103,14 @@ def test_configured_when_provenance_present(tmp_path: Path) -> None:
     assert record.shape == (5, 3, 4, 4)
 
 
+def test_montage_caption_only_when_capped() -> None:
+    from raitap.transparency.baselines import _montage_caption
+
+    assert _montage_caption(25, 200) == "Showing 25 of 200"
+    assert _montage_caption(20, 20) is None  # all tiles shown -> no label
+    assert _montage_caption(1, 1) is None
+
+
 def test_multi_image_baseline_renders_grid_montage(tmp_path: Path) -> None:
     from PIL import Image
 

--- a/src/raitap/transparency/tests/test_baselines.py
+++ b/src/raitap/transparency/tests/test_baselines.py
@@ -10,7 +10,12 @@ if TYPE_CHECKING:
 
 import torch
 
-from raitap.transparency.baselines import build_baseline_record
+from raitap.transparency.baselines import (
+    _render_baseline_image as _original_render_baseline_image,
+)
+from raitap.transparency.baselines import (
+    build_baseline_record,
+)
 from raitap.transparency.contracts import InputSpec
 
 
@@ -123,16 +128,13 @@ def test_bfloat16_baseline_renders_and_hashes(tmp_path: Path) -> None:
 def test_render_cache_reuses_rendered_baseline(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    import raitap.transparency.baselines as baselines_module
-
     render_calls: list[Path] = []
-    original = baselines_module._render_baseline_image
 
     def _counting_render(baseline: torch.Tensor, run_dir: Path) -> Path:
         render_calls.append(run_dir)
-        return original(baseline, run_dir)
+        return _original_render_baseline_image(baseline, run_dir)
 
-    monkeypatch.setattr(baselines_module, "_render_baseline_image", _counting_render)
+    monkeypatch.setattr("raitap.transparency.baselines._render_baseline_image", _counting_render)
 
     cache: dict[str, Path] = {}
     common = {

--- a/src/raitap/transparency/tests/test_contracts.py
+++ b/src/raitap/transparency/tests/test_contracts.py
@@ -267,3 +267,25 @@ def test_visualisation_context_detection_box_defaults_to_none() -> None:
 
     ctx = VisualisationContext(algorithm="x", sample_names=None, show_sample_names=False)
     assert ctx.detection_box is None
+
+
+def test_baseline_record_is_frozen_and_carries_descriptor() -> None:
+    from pathlib import Path
+
+    from raitap.transparency.contracts import BaselineRecord
+
+    record = BaselineRecord(
+        kwarg_name="background_data",
+        mode="configured",
+        source="imagenet_samples",
+        n_samples=50,
+        shape=(50, 3, 224, 224),
+        dtype="torch.float32",
+        sha256="abc123",
+        image_path=Path("baseline.png"),
+    )
+    assert record.kwarg_name == "background_data"
+    assert record.mode == "configured"
+    assert record.shape == (50, 3, 224, 224)
+    with pytest.raises(Exception):
+        record.mode = "zero"  # type: ignore[misc]  # frozen

--- a/src/raitap/transparency/tests/test_contracts.py
+++ b/src/raitap/transparency/tests/test_contracts.py
@@ -270,6 +270,7 @@ def test_visualisation_context_detection_box_defaults_to_none() -> None:
 
 
 def test_baseline_record_is_frozen_and_carries_descriptor() -> None:
+    import dataclasses
     from pathlib import Path
 
     from raitap.transparency.contracts import BaselineRecord
@@ -287,5 +288,5 @@ def test_baseline_record_is_frozen_and_carries_descriptor() -> None:
     assert record.kwarg_name == "background_data"
     assert record.mode == "configured"
     assert record.shape == (50, 3, 224, 224)
-    with pytest.raises(Exception):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         record.mode = "zero"  # type: ignore[misc]  # frozen

--- a/src/raitap/transparency/tests/test_factory.py
+++ b/src/raitap/transparency/tests/test_factory.py
@@ -28,6 +28,7 @@ from raitap.transparency.factory import (
     check_explainer_visualiser_compat,
     create_explainer,
     create_visualisers,
+    resolve_call_data_sources,
 )
 from raitap.transparency.results import ConfiguredVisualiser, ExplanationResult
 from raitap.transparency.visualisers.base_visualiser import BaseVisualiser
@@ -1667,6 +1668,34 @@ class TestResolveCallDataSources:
         bg_tensor = explainer.last_explain_kwargs["background_data"]
         assert isinstance(bg_tensor, torch.Tensor)
         assert bg_tensor.shape == (2, 3, 5, 5)
+
+    def test_provenance_out_captures_source_and_n_samples(self, tmp_path: Path) -> None:
+        import numpy as np
+        from PIL import Image
+
+        img_dir = tmp_path / "bg"
+        img_dir.mkdir()
+        for i in range(6):
+            arr = np.zeros((8, 8, 3), dtype=np.uint8)
+            Image.fromarray(arr, "RGB").save(img_dir / f"img{i}.png")
+
+        provenance: dict[str, dict[str, object]] = {}
+        result = resolve_call_data_sources(
+            {"background_data": {"source": str(img_dir), "n_samples": 3}, "target": 0},
+            provenance_out=provenance,
+        )
+
+        assert isinstance(result["background_data"], torch.Tensor)
+        assert provenance == {
+            "background_data": {"source": str(img_dir), "n_samples": 3}
+        }
+        # Non-source kwargs do not appear in provenance.
+        assert "target" not in provenance
+
+    def test_provenance_out_unaffected_when_not_passed(self, tmp_path: Path) -> None:
+        # Robustness/back-compat callers pass no out-param; behaviour unchanged.
+        out = resolve_call_data_sources({"target": 1})
+        assert out == {"target": 1}
 
 
 # ---------------------------------------------------------------------------

--- a/src/raitap/transparency/tests/test_factory.py
+++ b/src/raitap/transparency/tests/test_factory.py
@@ -1686,9 +1686,7 @@ class TestResolveCallDataSources:
         )
 
         assert isinstance(result["background_data"], torch.Tensor)
-        assert provenance == {
-            "background_data": {"source": str(img_dir), "n_samples": 3}
-        }
+        assert provenance == {"background_data": {"source": str(img_dir), "n_samples": 3}}
         # Non-source kwargs do not appear in provenance.
         assert "target" not in provenance
 

--- a/src/raitap/transparency/tests/test_factory.py
+++ b/src/raitap/transparency/tests/test_factory.py
@@ -883,6 +883,130 @@ def test_explanation_merges_call_before_run_kwargs(
     assert explainer.last_explain_kwargs["baselines"] == "from_yaml"
 
 
+def test_explanation_routes_raitap_baseline_to_adapter_kwarg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    sample_images: torch.Tensor,
+) -> None:
+    """``raitap.baseline`` is routed to the adapter's own call kwarg end-to-end."""
+
+    class RecordingExplainer:
+        algorithm = "IntegratedGradients"
+        baseline_kwarg_name = "baselines"
+
+        def __init__(self) -> None:
+            self.last_explain_kwargs: dict[str, Any] = {}
+
+        def check_backend_compat(self, backend: object) -> None:
+            del backend
+            return None
+
+        def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
+            self.last_explain_kwargs = dict(kwargs)
+            return MagicMock(spec=ExplanationResult)
+
+    explainer = RecordingExplainer()
+    config = _make_config(
+        tmp_path,
+        OmegaConf.create(
+            {
+                "_target_": "raitap.transparency.CaptumExplainer",
+                "algorithm": "IntegratedGradients",
+                "call": {"target": 0},
+                "raitap": {"baseline": "ROUTED"},
+                "visualisers": [{"_target_": "raitap.transparency.CaptumImageVisualiser"}],
+            }
+        ),
+    )
+
+    vis = MagicMock()
+    vis.compatible_algorithms = frozenset({"IntegratedGradients"})
+
+    monkeypatch.setattr(
+        "raitap.transparency.factory.create_explainer",
+        lambda _cfg: (explainer, "raitap.transparency.CaptumExplainer"),
+    )
+    monkeypatch.setattr(
+        "raitap.transparency.factory.create_visualisers",
+        lambda _cfg: [ConfiguredVisualiser(visualiser=vis, call_kwargs={})],
+    )
+
+    model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
+    Explanation(
+        config,
+        "test_explainer",
+        model=model,  # type: ignore[arg-type]
+        inputs=sample_images,
+        target=0,
+    )
+
+    # Routed under the adapter's own kwarg, and popped from the raitap block.
+    assert explainer.last_explain_kwargs["baselines"] == "ROUTED"
+    assert "baseline" not in explainer.last_explain_kwargs["raitap_kwargs"]
+
+
+def test_raitap_baseline_wins_over_runtime_kwarg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    sample_images: torch.Tensor,
+) -> None:
+    """A runtime baseline kwarg must not silently override ``raitap.baseline``."""
+
+    class RecordingExplainer:
+        algorithm = "IntegratedGradients"
+        baseline_kwarg_name = "baselines"
+
+        def __init__(self) -> None:
+            self.last_explain_kwargs: dict[str, Any] = {}
+
+        def check_backend_compat(self, backend: object) -> None:
+            del backend
+            return None
+
+        def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
+            self.last_explain_kwargs = dict(kwargs)
+            return MagicMock(spec=ExplanationResult)
+
+    explainer = RecordingExplainer()
+    config = _make_config(
+        tmp_path,
+        OmegaConf.create(
+            {
+                "_target_": "raitap.transparency.CaptumExplainer",
+                "algorithm": "IntegratedGradients",
+                "call": {"target": 0},
+                "raitap": {"baseline": "ROUTED"},
+                "visualisers": [{"_target_": "raitap.transparency.CaptumImageVisualiser"}],
+            }
+        ),
+    )
+
+    vis = MagicMock()
+    vis.compatible_algorithms = frozenset({"IntegratedGradients"})
+
+    monkeypatch.setattr(
+        "raitap.transparency.factory.create_explainer",
+        lambda _cfg: (explainer, "raitap.transparency.CaptumExplainer"),
+    )
+    monkeypatch.setattr(
+        "raitap.transparency.factory.create_visualisers",
+        lambda _cfg: [ConfiguredVisualiser(visualiser=vis, call_kwargs={})],
+    )
+
+    model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
+    Explanation(
+        config,
+        "test_explainer",
+        model=model,  # type: ignore[arg-type]
+        inputs=sample_images,
+        target=0,
+        baselines="RUNTIME",  # runtime Python-API override of the same kwarg
+    )
+
+    # raitap.baseline wins over the runtime kwarg (and a warning is logged).
+    assert explainer.last_explain_kwargs["baselines"] == "ROUTED"
+
+
 def test_explanation_uses_real_shap_preset_defaults_and_runtime_overrides(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/src/raitap/transparency/tests/test_results.py
+++ b/src/raitap/transparency/tests/test_results.py
@@ -12,6 +12,7 @@ import torch
 from raitap.configs import resolve_run_dir, set_output_root
 from raitap.configs.schema import AppConfig
 from raitap.transparency.contracts import (
+    BaselineRecord,
     ExplanationOutputSpace,
     ExplanationPayloadKind,
     ExplanationScope,
@@ -888,3 +889,101 @@ def test_render_visualisation_for_scope_raises_on_mismatched_sample_names(
         explanation.render_visualisation_for_scope(0, scope="local")
     assert info.value.got == 3
     assert info.value.expected == 2
+
+
+# ---------------------------------------------------------------------------
+# BaselineRecord persistence in ExplanationResult metadata — Task 4
+# ---------------------------------------------------------------------------
+
+
+def _semantics_simple(shape: tuple[int, ...]) -> ExplanationSemantics:
+    # Built locally to keep these tests free of cross-module test coupling.
+    return ExplanationSemantics(
+        scope=ExplanationScope.LOCAL,
+        scope_definition_step=ScopeDefinitionStep.EXPLAINER_OUTPUT,
+        payload_kind=ExplanationPayloadKind.ATTRIBUTIONS,
+        method_families=frozenset({MethodFamily.GRADIENT}),
+        target=None,
+        sample_selection=None,
+        input_spec=InputSpec(kind="image", shape=shape, layout="NCHW"),
+        output_space=OutputSpaceSpec(
+            space=ExplanationOutputSpace.INPUT_FEATURES,
+            shape=shape,
+            layout="NCHW",
+        ),
+    )
+
+
+def _result_with_baseline(
+    tmp_path: Path, *, baseline: BaselineRecord | None = None, call_kwargs: dict | None = None
+) -> ExplanationResult:
+    return ExplanationResult(
+        attributions=torch.rand(1, 1, 4, 4),
+        inputs=torch.rand(1, 1, 4, 4),
+        run_dir=tmp_path / "exp",
+        experiment_name="demo",
+        explainer_target="t",
+        algorithm="IntegratedGradients",
+        semantics=_semantics_simple((1, 1, 4, 4)),
+        call_kwargs=call_kwargs or {},
+        baseline=baseline,
+    )
+
+
+def test_metadata_omits_baseline_when_none(tmp_path: Path) -> None:
+    result = _result_with_baseline(tmp_path)
+    result.write_artifacts()
+    meta = json.loads((result.run_dir / "metadata.json").read_text())
+    assert "baseline" not in meta
+
+
+def test_metadata_serializes_baseline_block(tmp_path: Path) -> None:
+    from pathlib import Path as _Path
+
+    record = BaselineRecord(
+        kwarg_name="baselines",
+        mode="zero",
+        source=None,
+        n_samples=None,
+        shape=(1, 1, 4, 4),
+        dtype="torch.float32",
+        sha256="deadbeef",
+        image_path=_Path("baseline.png"),
+    )
+    result = _result_with_baseline(tmp_path, baseline=record)
+    result.write_artifacts()
+    meta = json.loads((result.run_dir / "metadata.json").read_text())
+    assert meta["baseline"] == {
+        "kwarg_name": "baselines",
+        "mode": "zero",
+        "source": None,
+        "n_samples": None,
+        "shape": [1, 1, 4, 4],
+        "dtype": "torch.float32",
+        "sha256": "deadbeef",
+        "image_path": "baseline.png",
+    }
+
+
+def test_metadata_suppresses_recognized_baseline_kwarg(tmp_path: Path) -> None:
+    record = BaselineRecord(
+        kwarg_name="baselines",
+        mode="user_tensor",
+        source=None,
+        n_samples=None,
+        shape=(1, 1, 4, 4),
+        dtype="torch.float32",
+        sha256="d",
+        image_path=None,
+    )
+    result = _result_with_baseline(
+        tmp_path,
+        baseline=record,
+        call_kwargs={"baselines": torch.zeros(1, 1, 4, 4), "target": 0},
+    )
+    result.write_artifacts()
+    meta = json.loads((result.run_dir / "metadata.json").read_text())
+    # The opaque tensor row is suppressed; the clean baseline block stands alone.
+    assert "baselines" not in meta["call_kwargs"]
+    assert meta["call_kwargs"]["target"] == 0
+    assert meta["baseline"]["kwarg_name"] == "baselines"

--- a/src/raitap/transparency/tests/test_semantics.py
+++ b/src/raitap/transparency/tests/test_semantics.py
@@ -45,6 +45,7 @@ ExplanationScope = contracts.ExplanationScope
 InputKind = contracts.InputKind
 InputSpec = contracts.InputSpec
 MethodFamily = contracts.MethodFamily
+ExplainerSemanticsHints = contracts.ExplainerSemanticsHints
 ScopeDefinitionStep = contracts.ScopeDefinitionStep
 TensorLayout = contracts.TensorLayout
 from raitap.transparency.explainers.captum_explainer import CaptumExplainer  # noqa: E402
@@ -113,7 +114,9 @@ def test_captum_method_family_registry_exactly_matches_adr_v1_list() -> None:
         "GuidedGradCam": frozenset({MethodFamily.GRADIENT, MethodFamily.CAM}),
     }
 
-    assert expected == CAPTUM_METHOD_FAMILIES
+    assert expected == {
+        algorithm: hints.families for algorithm, hints in CAPTUM_METHOD_FAMILIES.items()
+    }
     for algorithm, families in expected.items():
         assert method_families_for_explainer(_explainer("captum", algorithm)) == families
 
@@ -297,12 +300,12 @@ def test_infer_output_space_rejects_ambiguous_algorithm_only_signal(
     monkeypatch.setitem(
         SHAP_METHOD_FAMILIES,
         "SharedAlgorithm",
-        frozenset({MethodFamily.SHAPLEY}),
+        ExplainerSemanticsHints(frozenset({MethodFamily.SHAPLEY})),
     )
     monkeypatch.setitem(
         CAPTUM_METHOD_FAMILIES,
         "SharedAlgorithm",
-        frozenset({MethodFamily.GRADIENT}),
+        ExplainerSemanticsHints(frozenset({MethodFamily.GRADIENT})),
     )
 
     with pytest.raises(


### PR DESCRIPTION
## Summary

Record the reference input (baseline) that Integrated Gradients (Captum `baselines`) and SHAP (`background_data`) are computed against, so it is documented in the artefact and inspectable in the report. Previously the baseline reached `metadata.json` only as opaque tensor facts and was never shown in the report, leaving "no baseline field" ambiguous (user-omitted vs. method default).

Captured at the single chokepoint `AttributionOnlyExplainer.explain` via one helper `build_baseline_record` (new `transparency/baselines.py`). Each explainer declares its implicit-default mode **per algorithm** (Captum `IntegratedGradients`->`zero`; SHAP `GradientExplainer`/`DeepExplainer`/`KernelExplainer`->`input_batch`); methods without a reference (Saliency, GradCam, TreeExplainer-without-background) produce no record. YAML provenance (`source`, `n_samples`) is collected via an additive `provenance_out` out-param on the shared `resolve_call_data_sources` (the robustness caller is untouched) and threaded into `explain` as a new keyword-only `call_provenance`.

- `metadata.json` gains a `baseline` block — `{kwarg_name, mode, source, n_samples, shape, dtype, sha256, image_path}` — covering all three origins: `configured` (YAML source), implicit default (`zero` / `input_batch`), and direct `user_tensor`.
- The report shows labelled `baseline.*` descriptor rows plus the rendered baseline image (image modality, attached once per explanation). `sha256` stays in JSON only — never in the report.
- The recognized baseline kwarg is suppressed from the generic `call.*` rows and metadata serialization to avoid a redundant opaque entry next to the labelled block.

Backward-compatible: `ExplanationResult.baseline` defaults to `None`; artefacts/results without a baseline still load and render (report + metadata guard on `baseline is not None`). Added optional fields/params and additive output only — no API/config/format break — hence `feat(transparency):` without `!`.

Closes #210.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — If this PR breaks compatibility (API, configs, file formats, etc.), the title uses `!` after the type or scope (e.g. `feat!:` or `feat(transparency)!:`). This change is backward-compatible (added optional `ExplanationResult.baseline` field, optional `call_provenance`/`provenance_out` params, additive metadata + report content), so no `!` is used.
- [x] **Contributor guide** — I've read [**Pull requests and commit messages**](https://caiivs.github.io/raitap/contributor/pull-requests.html) before requesting review.

## Optional

- [x] **Issue** _(optional)_ — Closes #210.
- [x] **Docs** _(optional)_ — Module/class/function docstrings document the baseline capture (`baselines.py`), the `BaselineRecord` contract, and the `provenance_out` side-channel.
- [x] **Tests** _(optional)_ — Unit tests for every baseline mode (zero / input_batch / configured / user_tensor) incl. hash determinism + image-modality gating; metadata serialization + kwarg suppression; the `provenance_out` out-param (with robustness regression); report descriptor rows (sha256 absent) + image-attached-once; and an updated e2e metadata-invariant.
