### PR TITLE
feat(transparency): shared image-attribution renderer; detection renders per-library (#221)

### DIFF
--- a/.github/workflows/regen-baselines.yml
+++ b/.github/workflows/regen-baselines.yml
@@ -41,7 +41,9 @@ jobs:
         # baseline to the *raw* (relative) generate-path at test time — so a relative path
         # would land in the ephemeral tmp dir instead of the workspace. See #217.
         run: |
-          uv run pytest src/raitap/transparency/tests/test_e2e_mpl_baseline.py \
+          uv run pytest \
+            src/raitap/transparency/tests/test_e2e_mpl_baseline.py \
+            src/raitap/transparency/tests/test_detection_mpl_baseline.py \
             -m "e2e and visual" \
             --mpl-generate-path="$GITHUB_WORKSPACE/regenerated_baselines" -v
 

--- a/docs/contributor/architecture.md
+++ b/docs/contributor/architecture.md
@@ -42,6 +42,10 @@ Every concrete adapter (explainer, assessor, metric, reporter, tracker, visualis
 
 See {doc}`adding-an-adapter` / {doc}`adding-an-algorithm` / {doc}`adding-a-module` for the contributor workflow.
 
+## Visualisers and renderers
+
+A **visualiser** owns the figure layout and is selected via YAML config (`@visualisers.transparency`). A **renderer** paints one attribution map onto a single axes and is auto-resolved from the explainer's library name at render time. If no renderer is registered for a library, a built-in dependency-free default is used. Plugin authors can register a custom renderer via `@adapters.image_renderer(for_library="<registry_name>")`.
+
 ## Directory structure
 
 ```text

--- a/docs/contributor/writing-a-plugin.md
+++ b/docs/contributor/writing-a-plugin.md
@@ -104,6 +104,19 @@ modules — add more decorated classes to your `__init__.py` (e.g. an
 `@adapters.robustness(...)` assessor next to the explainer). Every decorator
 fires when the plugin is imported on discovery.
 
+**Custom rendering.** By default your plugin's image attributions render with raitap's built-in style — nothing extra to declare. If you want to ship a custom look, register one renderer:
+
+```python
+from raitap import adapters
+
+@adapters.image_renderer(for_library="superxai")  # your registry_name
+class SuperXAIRenderer:
+    def draw(self, ax, attr, image, *, sign="all", **style):
+        ...  # paint attr onto ax; return the mappable (or None)
+```
+
+The renderer then applies automatically to both classification and detection attribution maps.
+
 ## 3. Declare the entry point and version pin
 
 Two things to add to your `pyproject.toml`:

--- a/src/raitap/adapters.py
+++ b/src/raitap/adapters.py
@@ -26,5 +26,6 @@ from raitap.reporting.registration import reporter
 from raitap.robustness.assessors.registration import robustness_adapter as robustness
 from raitap.tracking.registration import tracker
 from raitap.transparency.explainers.registration import transparency_adapter as transparency
+from raitap.transparency.visualisers.image_rendering import image_renderer
 
-__all__ = ["metrics", "reporter", "robustness", "tracker", "transparency"]
+__all__ = ["image_renderer", "metrics", "reporter", "robustness", "tracker", "transparency"]

--- a/src/raitap/transparency/contracts.py
+++ b/src/raitap/transparency/contracts.py
@@ -13,7 +13,7 @@ APIs before every code path is complete — for example
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence  # noqa: TC003
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path  # noqa: TC003
 from typing import Any, Protocol, runtime_checkable
@@ -275,6 +275,8 @@ class VisualisationContext:
     sample_names: list[str] | None
     show_sample_names: bool
     detection_box: DetectionBox | None = None
+    source_library: str | None = None
+    method_families: frozenset[MethodFamily] = field(default_factory=frozenset)
 
 
 @runtime_checkable

--- a/src/raitap/transparency/explainers/base_explainer.py
+++ b/src/raitap/transparency/explainers/base_explainer.py
@@ -175,6 +175,7 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
             experiment_name=experiment_name,
             explainer_target=(explainer_target or f"{type(self).__module__}.{type(self).__name__}"),
             algorithm=getattr(self, "algorithm", ""),
+            source_library=getattr(self, "registry_name", None),
             explainer_name=explainer_name,
             kwargs=metadata_kwargs,
             call_kwargs=call_kwargs,

--- a/src/raitap/transparency/results.py
+++ b/src/raitap/transparency/results.py
@@ -146,6 +146,7 @@ class ExplanationResult(Trackable):
     payload_kind: ExplanationPayloadKind = ExplanationPayloadKind.ATTRIBUTIONS
     detection_box: DetectionBox | None = None
     original_sample_index: int | None = None
+    source_library: str | None = None
     semantics: ExplanationSemantics = field(kw_only=True)
 
     def __post_init__(self) -> None:
@@ -195,6 +196,8 @@ class ExplanationResult(Trackable):
             }
         if self.original_sample_index is not None:
             metadata["original_sample_index"] = self.original_sample_index
+        if self.source_library is not None:
+            metadata["source_library"] = self.source_library
         return metadata
 
     def _write_metadata(self) -> None:
@@ -233,6 +236,8 @@ class ExplanationResult(Trackable):
                 sample_names=sample_names,
                 show_sample_names=show_sample_names,
                 detection_box=self.detection_box,
+                source_library=self.source_library,
+                method_families=self.semantics.method_families,
             )
 
             vis.validate_explanation(self, attributions, inputs)
@@ -376,6 +381,8 @@ class ExplanationResult(Trackable):
             sample_names=sample_names,
             show_sample_names=show_sample_names,
             detection_box=self.detection_box,
+            source_library=self.source_library,
+            method_families=self.semantics.method_families,
         )
         vis.validate_explanation(self, attributions, inputs)
         original_visualiser_sample_index = getattr(vis, "sample_index", None)

--- a/src/raitap/transparency/tests/e2e_case_matrix.py
+++ b/src/raitap/transparency/tests/e2e_case_matrix.py
@@ -313,12 +313,14 @@ def _assert_metadata_invariants(
         "experiment_name",
         "target",
         "algorithm",
+        "source_library",
         "visualisers",
         "kwargs",
         "call_kwargs",
         "payload_kind",
         "semantics",
     }
+    assert metadata["source_library"] in {"captum", "shap"}
     assert metadata["payload_kind"] == "attributions"
     semantics = cast("dict[str, object]", metadata["semantics"])
     assert semantics["scope"] == "local"

--- a/src/raitap/transparency/tests/test_detection_image_visualiser.py
+++ b/src/raitap/transparency/tests/test_detection_image_visualiser.py
@@ -114,15 +114,27 @@ def test_detection_image_visualiser_is_importable_from_visualisers_package() -> 
     import importlib
     import sys
 
-    for mod in list(sys.modules):
-        if mod.startswith("raitap.transparency.visualisers"):
-            del sys.modules[mod]
+    saved = {
+        name: module
+        for name, module in list(sys.modules.items())
+        if name.startswith("raitap.transparency.visualisers")
+    }
+    for name in saved:
+        del sys.modules[name]
 
-    pkg = importlib.import_module("raitap.transparency.visualisers")
-    assert hasattr(pkg, "DetectionImageVisualiser")
-    assert pkg.DetectionImageVisualiser is DetectionImageVisualiser or (
-        pkg.DetectionImageVisualiser.__name__ == "DetectionImageVisualiser"
-    )
+    try:
+        pkg = importlib.import_module("raitap.transparency.visualisers")
+        assert hasattr(pkg, "DetectionImageVisualiser")
+        assert pkg.DetectionImageVisualiser is DetectionImageVisualiser or (
+            pkg.DetectionImageVisualiser.__name__ == "DetectionImageVisualiser"
+        )
+    finally:
+        # Restore the original module instances. Re-importing the package builds
+        # fresh module objects (and a fresh image-renderer registry); leaving
+        # those in sys.modules would desync the singleton registry from
+        # references cached at import time elsewhere (e.g. raitap.adapters),
+        # breaking later tests that rely on the registry being a singleton.
+        sys.modules.update(saved)
 
 
 def test_visualiser_upsamples_low_res_cam_to_full_image_extent() -> None:

--- a/src/raitap/transparency/tests/test_detection_mpl_baseline.py
+++ b/src/raitap/transparency/tests/test_detection_mpl_baseline.py
@@ -1,0 +1,61 @@
+"""MPL regression for DetectionImageVisualiser (house renderer, synthetic input).
+
+Self-contained: no shap/captum, no model — builds the figure directly from a
+deterministic synthetic attribution so the detection layout + sign-aware house
+rendering is pixel-regressed. Library-specific (shap/captum) detection baselines
+are deferred to a CI follow-up (need optional extras on the Linux image).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import matplotlib
+matplotlib.use("Agg")
+import numpy as np
+import pytest
+import torch
+
+from raitap.transparency.contracts import DetectionBox, VisualisationContext
+from raitap.transparency.visualisers.detection_image_visualiser import DetectionImageVisualiser
+
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="pytest-mpl baselines are generated on ubuntu-24.04; pixel diffs are not portable",
+)
+
+
+def _deterministic_detection_figure():
+    # deterministic synthetic data — no RNG, fully reproducible
+    grid = np.linspace(-1.0, 1.0, 16 * 16, dtype=np.float32).reshape(16, 16)
+    attr = torch.from_numpy(np.stack([grid, -grid, grid * 0.5]))  # (3,16,16) signed
+    img = torch.from_numpy(
+        np.clip(np.stack([grid, grid, grid]) * 0.5 + 0.5, 0.0, 1.0).astype(np.float32)
+    )  # (3,16,16) in [0,1]
+    ctx = VisualisationContext(
+        algorithm="HouseDemo",
+        sample_names=None,
+        show_sample_names=False,
+        detection_box=DetectionBox(0, 0, (2.0, 2.0, 12.0, 12.0), 0.87, 1, "cat"),
+        source_library=None,        # -> RaitapHouseRenderer (no shap/captum dependency)
+        method_families=frozenset(),
+    )
+    return DetectionImageVisualiser().visualise(attr, inputs=img, context=ctx)
+
+
+@pytest.mark.e2e
+@pytest.mark.mpl
+@pytest.mark.visual
+@pytest.mark.mpl_image_compare(
+    baseline_dir="mpl_baseline",
+    filename="detection_house_heat_map.png",
+    remove_text=True,
+    savefig_kwargs={"dpi": 150},
+    tolerance=2,
+)
+def test_detection_house_visual_regression() -> "Figure":
+    return _deterministic_detection_figure()

--- a/src/raitap/transparency/tests/test_detection_mpl_baseline.py
+++ b/src/raitap/transparency/tests/test_detection_mpl_baseline.py
@@ -12,6 +12,7 @@ import sys
 from typing import TYPE_CHECKING
 
 import matplotlib
+
 matplotlib.use("Agg")
 import numpy as np
 import pytest
@@ -29,7 +30,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _deterministic_detection_figure():
+def _deterministic_detection_figure() -> Figure:
     # deterministic synthetic data — no RNG, fully reproducible
     grid = np.linspace(-1.0, 1.0, 16 * 16, dtype=np.float32).reshape(16, 16)
     attr = torch.from_numpy(np.stack([grid, -grid, grid * 0.5]))  # (3,16,16) signed
@@ -41,7 +42,7 @@ def _deterministic_detection_figure():
         sample_names=None,
         show_sample_names=False,
         detection_box=DetectionBox(0, 0, (2.0, 2.0, 12.0, 12.0), 0.87, 1, "cat"),
-        source_library=None,        # -> RaitapHouseRenderer (no shap/captum dependency)
+        source_library=None,  # -> RaitapHouseRenderer (no shap/captum dependency)
         method_families=frozenset(),
     )
     return DetectionImageVisualiser().visualise(attr, inputs=img, context=ctx)
@@ -57,5 +58,5 @@ def _deterministic_detection_figure():
     savefig_kwargs={"dpi": 150},
     tolerance=2,
 )
-def test_detection_house_visual_regression() -> "Figure":
+def test_detection_house_visual_regression() -> Figure:
     return _deterministic_detection_figure()

--- a/src/raitap/transparency/tests/test_detection_mpl_baseline.py
+++ b/src/raitap/transparency/tests/test_detection_mpl_baseline.py
@@ -9,6 +9,7 @@ are deferred to a CI follow-up (need optional extras on the Linux image).
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import matplotlib
@@ -28,6 +29,8 @@ pytestmark = pytest.mark.skipif(
     not sys.platform.startswith("linux"),
     reason="pytest-mpl baselines are generated on ubuntu-24.04; pixel diffs are not portable",
 )
+
+_BASELINE_FILE = Path(__file__).with_name("mpl_baseline") / "detection_house_heat_map.png"
 
 
 def _deterministic_detection_figure() -> Figure:
@@ -58,5 +61,12 @@ def _deterministic_detection_figure() -> Figure:
     savefig_kwargs={"dpi": 150},
     tolerance=2,
 )
-def test_detection_house_visual_regression() -> Figure:
+def test_detection_house_visual_regression(request: pytest.FixtureRequest) -> Figure:
+    # The baseline PNG is generated on the canonical Linux image via the
+    # regen-baselines workflow. Until it is committed, skip the comparison
+    # (instead of erroring) so the E2E gate stays green; in generate mode we
+    # still render so the workflow can produce the baseline.
+    generating = getattr(request.config.option, "mpl_generate_path", None)
+    if not generating and not _BASELINE_FILE.exists():
+        pytest.skip("detection MPL baseline pending generation via the regen-baselines workflow")
     return _deterministic_detection_figure()

--- a/src/raitap/transparency/tests/test_results.py
+++ b/src/raitap/transparency/tests/test_results.py
@@ -97,8 +97,9 @@ class _IdentityExplainer(AttributionOnlyExplainer):
         return inputs.clone()
 
 
-def test_visualisation_context_carries_source_library_and_families():
+def test_visualisation_context_carries_source_library_and_families() -> None:
     from raitap.transparency.contracts import MethodFamily, VisualisationContext
+
     ctx = VisualisationContext(
         algorithm="GradientExplainer",
         sample_names=None,

--- a/src/raitap/transparency/tests/test_results.py
+++ b/src/raitap/transparency/tests/test_results.py
@@ -97,6 +97,19 @@ class _IdentityExplainer(AttributionOnlyExplainer):
         return inputs.clone()
 
 
+def test_visualisation_context_carries_source_library_and_families():
+    from raitap.transparency.contracts import MethodFamily, VisualisationContext
+    ctx = VisualisationContext(
+        algorithm="GradientExplainer",
+        sample_names=None,
+        show_sample_names=False,
+        source_library="shap",
+        method_families=frozenset({MethodFamily.SHAPLEY}),
+    )
+    assert ctx.source_library == "shap"
+    assert MethodFamily.SHAPLEY in ctx.method_families
+
+
 def test_resolve_run_dir_uses_hydra_runtime(monkeypatch: MonkeyPatch) -> None:
     class _HydraRuntime:
         output_dir = "hydra-output"

--- a/src/raitap/transparency/visualisers/captum_visualisers.py
+++ b/src/raitap/transparency/visualisers/captum_visualisers.py
@@ -13,13 +13,15 @@ from raitap.transparency.contracts import (
     ExplanationScope,
     MethodFamily,
 )
-from raitap.transparency.visualisers.image_rendering import CaptumNativeRenderer
+from raitap.transparency.visualisers.image_rendering import IMAGE_RENDERER_REGISTRY
 from raitap.transparency.visualisers.registration import transparency_visualiser
 
 from .base_visualiser import BaseVisualiser
 
 if TYPE_CHECKING:
     import torch
+    from matplotlib.axes import Axes
+    from matplotlib.cm import ScalarMappable
     from matplotlib.figure import Figure
 
     from raitap.transparency.contracts import VisualisationContext
@@ -672,3 +674,52 @@ class CaptumTextVisualiser(BaseVisualiser):
         ax.grid(axis="x", alpha=0.3)
         fig.tight_layout()
         return fig
+
+
+class CaptumNativeRenderer:
+    """Captum-native recipe via ``captum.attr.visualization.visualize_image_attr``.
+
+    ``attr`` channels-last (H,W,C); ``image`` normalised (H,W,C). ``method``
+    (default ``"blended_heat_map"``) and other Captum styling are forwarded via
+    ``**style``. Returns the drawn mappable, or ``None`` when the slice is a valid
+    all-zero map (rendered flat instead of crashing — see #206/#207).
+    """
+
+    def draw(
+        self,
+        ax: Axes,
+        attr: np.ndarray,
+        image: np.ndarray | None,
+        *,
+        sign: str = "all",
+        **style: Any,
+    ) -> ScalarMappable | None:
+        from captum.attr import visualization as viz
+        from matplotlib.figure import Figure
+
+        method = style.pop("method", "blended_heat_map")
+        title = style.pop("title", None)
+        show_colorbar = bool(style.pop("show_colorbar", False))
+        outlier_perc = float(style.get("outlier_perc", 2.0))
+        if _captum_normalisation_degenerate(np.asarray(attr), sign, outlier_perc):
+            _render_flat_attribution(ax, sign, title)
+            return None
+        # ``ax.figure`` is typed ``Figure | SubFigure``; visualisers always pass a
+        # top-level ``Figure``'s axes, and visualize_image_attr's stub requires ``Figure``.
+        fig = ax.figure
+        assert isinstance(fig, Figure)
+        viz.visualize_image_attr(
+            attr,
+            image,
+            method=method,
+            sign=sign,
+            show_colorbar=show_colorbar,
+            plt_fig_axis=(fig, ax),
+            use_pyplot=False,
+            **({"title": title} if title is not None else {}),
+            **style,
+        )
+        return _last_mappable(ax)
+
+
+IMAGE_RENDERER_REGISTRY["captum"] = CaptumNativeRenderer()

--- a/src/raitap/transparency/visualisers/captum_visualisers.py
+++ b/src/raitap/transparency/visualisers/captum_visualisers.py
@@ -13,6 +13,7 @@ from raitap.transparency.contracts import (
     ExplanationScope,
     MethodFamily,
 )
+from raitap.transparency.visualisers.image_rendering import CaptumNativeRenderer
 from raitap.transparency.visualisers.registration import transparency_visualiser
 
 from .base_visualiser import BaseVisualiser
@@ -448,23 +449,15 @@ class CaptumImageVisualiser(BaseVisualiser):
                         title=original_title,
                     )
 
-                attr_viz_kwargs = dict(kwargs)
-                attr_viz_kwargs["title"] = attr_title
-                if _captum_normalisation_degenerate(
-                    attr_i, self.sign, float(kwargs.get("outlier_perc", 2))
-                ):
-                    _render_flat_attribution(attr_ax, self.sign, attr_title)
-                else:
-                    _, _ = viz.visualize_image_attr(
-                        attr_i,
-                        orig_i,
-                        method=self.method,
-                        sign=self.sign,
-                        show_colorbar=False,
-                        plt_fig_axis=(fig, attr_ax),
-                        use_pyplot=False,
-                        **attr_viz_kwargs,
-                    )
+                CaptumNativeRenderer().draw(
+                    attr_ax,
+                    attr_i,
+                    orig_i,
+                    sign=self.sign,
+                    method=self.method,
+                    title=attr_title,
+                    **{k: v for k, v in kwargs.items() if k != "title"},
+                )
                 if self.show_colorbar and colorbar_ax is not None:
                     mappable = _last_mappable(attr_ax)
                     if mappable is None:
@@ -478,22 +471,16 @@ class CaptumImageVisualiser(BaseVisualiser):
             if self.title is not None and "title" not in viz_kwargs:
                 viz_kwargs["title"] = self.title
 
-            if _captum_normalisation_degenerate(
-                attr_i, self.sign, float(kwargs.get("outlier_perc", 2))
-            ):
-                _render_flat_attribution(ax, self.sign, viz_kwargs.get("title"))
-            else:
-                # Let Captum render into our existing axes
-                _, _ = viz.visualize_image_attr(
-                    attr_i,
-                    orig_i,
-                    method=self.method,
-                    sign=self.sign,
-                    show_colorbar=self.show_colorbar,
-                    plt_fig_axis=(fig, ax),
-                    use_pyplot=False,
-                    **viz_kwargs,
-                )
+            CaptumNativeRenderer().draw(
+                ax,
+                attr_i,
+                orig_i,
+                sign=self.sign,
+                method=self.method,
+                show_colorbar=self.show_colorbar,
+                title=viz_kwargs.get("title"),
+                **{k: v for k, v in viz_kwargs.items() if k != "title"},
+            )
             if show_sample_names and i < len(names):
                 base_title = ax.get_title().strip()
                 label = f"{base_title}: {names[i]}" if base_title else names[i]

--- a/src/raitap/transparency/visualisers/detection_image_visualiser.py
+++ b/src/raitap/transparency/visualisers/detection_image_visualiser.py
@@ -94,30 +94,21 @@ class DetectionImageVisualiser(BaseVisualiser):
         if img_hwc.dtype != np.uint8:
             img_hwc = np.clip(img_hwc, 0.0, 1.0)
 
-        attr_arr = attr.numpy() if hasattr(attr, "numpy") else np.asarray(attr)
-        if attr_arr.ndim == 3:
-            attr_2d = np.abs(attr_arr).sum(axis=0)
-        elif attr_arr.ndim == 2:
-            attr_2d = attr_arr
-        else:
-            raise ValueError(
-                f"DetectionImageVisualiser expected (C, H, W) or (H, W) attribution; "
-                f"got shape {attr_arr.shape!r}."
-            )
+        from raitap.transparency.visualisers.image_rendering import resolve_image_renderer
+
+        renderer, sign = resolve_image_renderer(context.source_library, context.method_families)
+
+        fig, ax = plt.subplots(figsize=(6, 6))
+        attr_np = attr.numpy() if hasattr(attr, "numpy") else np.asarray(attr)
+        if attr_np.ndim == 3:
+            attr_np = np.transpose(attr_np, (1, 2, 0))
         # Layer methods (e.g. LayerGradCam) yield low-res spatial maps; bilinear-
         # upsample to the image so the heat overlay spans the full frame instead
         # of a top-left corner patch. Mirrors the classification path
         # (captum_visualisers._resize_attr_to_hw). Issue #203.
-        target_hw = img_hwc.shape[:2]
-        if attr_2d.shape != target_hw:
-            attr_2d = _resize_attr_to_hw(attr_2d, target_hw)
-        attr_max = float(np.max(np.abs(attr_2d))) if attr_2d.size else 0.0
-        if attr_max > 0:
-            attr_2d = attr_2d / attr_max
-
-        fig, ax = plt.subplots(figsize=(6, 6))
-        ax.imshow(img_hwc, interpolation="nearest")
-        ax.imshow(attr_2d, cmap="seismic", alpha=0.45, vmin=-1.0, vmax=1.0)
+        if attr_np.shape[:2] != img_hwc.shape[:2]:
+            attr_np = _resize_attr_to_hw(attr_np, img_hwc.shape[:2])
+        renderer.draw(ax, attr_np, img_hwc, sign=sign)
 
         x1, y1, x2, y2 = box.xyxy
         rect = mpatches.Rectangle(

--- a/src/raitap/transparency/visualisers/image_rendering.py
+++ b/src/raitap/transparency/visualisers/image_rendering.py
@@ -8,7 +8,7 @@ automatically from explainer provenance via :func:`resolve_image_renderer`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
 
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
 
     from matplotlib.axes import Axes
     from matplotlib.cm import ScalarMappable
-    from matplotlib.figure import Figure
 
 
 class ImageAttributionRenderer(Protocol):
@@ -33,7 +32,8 @@ class ImageAttributionRenderer(Protocol):
         *,
         sign: str = "all",
         **style: Any,
-    ) -> ScalarMappable | None: ...
+    ) -> ScalarMappable | None:
+        """Render ``attr`` onto ``ax``; return the drawn mappable (or ``None``)."""
 
 
 def _signed_channel_sum(attr: np.ndarray) -> np.ndarray:
@@ -177,6 +177,7 @@ class CaptumNativeRenderer:
         **style: Any,
     ) -> ScalarMappable | None:
         from captum.attr import visualization as viz
+        from matplotlib.figure import Figure
 
         from raitap.transparency.visualisers.captum_visualisers import (
             _captum_normalisation_degenerate,
@@ -191,16 +192,17 @@ class CaptumNativeRenderer:
         if _captum_normalisation_degenerate(np.asarray(attr), sign, outlier_perc):
             _render_flat_attribution(ax, sign, title)
             return None
+        # ``ax.figure`` is typed ``Figure | SubFigure``; visualisers always pass a
+        # top-level ``Figure``'s axes, and visualize_image_attr's stub requires ``Figure``.
+        fig = ax.figure
+        assert isinstance(fig, Figure)
         viz.visualize_image_attr(
             attr,
             image,
             method=method,
             sign=sign,
             show_colorbar=show_colorbar,
-            # ``ax.figure`` is typed ``Figure | SubFigure``; visualisers always
-            # pass a top-level ``Figure``'s axes, and visualize_image_attr's stub
-            # requires ``Figure``.
-            plt_fig_axis=(cast("Figure", ax.figure), ax),
+            plt_fig_axis=(fig, ax),
             use_pyplot=False,
             **({"title": title} if title is not None else {}),
             **style,

--- a/src/raitap/transparency/visualisers/image_rendering.py
+++ b/src/raitap/transparency/visualisers/image_rendering.py
@@ -8,7 +8,7 @@ automatically from explainer provenance via :func:`resolve_image_renderer`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import numpy as np
 
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
     from matplotlib.axes import Axes
     from matplotlib.cm import ScalarMappable
+    from matplotlib.figure import Figure
 
 
 class ImageAttributionRenderer(Protocol):
@@ -196,7 +197,10 @@ class CaptumNativeRenderer:
             method=method,
             sign=sign,
             show_colorbar=show_colorbar,
-            plt_fig_axis=(ax.figure, ax),
+            # ``ax.figure`` is typed ``Figure | SubFigure``; visualisers always
+            # pass a top-level ``Figure``'s axes, and visualize_image_attr's stub
+            # requires ``Figure``.
+            plt_fig_axis=(cast("Figure", ax.figure), ax),
             use_pyplot=False,
             **({"title": title} if title is not None else {}),
             **style,

--- a/src/raitap/transparency/visualisers/image_rendering.py
+++ b/src/raitap/transparency/visualisers/image_rendering.py
@@ -138,3 +138,42 @@ class ShapNativeRenderer:
         if image is not None:
             ax.imshow(_rgb_to_grayscale(image), cmap="gray", alpha=overlay_alpha)
         return ax.imshow(heatmap, cmap=cmap, vmin=vmin, vmax=vmax)
+
+
+class CaptumNativeRenderer:
+    """Captum-native recipe via ``captum.attr.visualization.visualize_image_attr``.
+
+    ``attr`` channels-last (H,W,C); ``image`` normalised (H,W,C). ``method``
+    (default ``"blended_heat_map"``) and other Captum styling are forwarded via
+    ``**style``. Returns the drawn mappable, or ``None`` when the slice is a valid
+    all-zero map (rendered flat instead of crashing — see #206/#207).
+    """
+
+    def draw(self, ax, attr, image, *, sign: str = "all", **style: Any):
+        from captum.attr import visualization as viz
+
+        from raitap.transparency.visualisers.captum_visualisers import (
+            _captum_normalisation_degenerate,
+            _last_mappable,
+            _render_flat_attribution,
+        )
+
+        method = style.pop("method", "blended_heat_map")
+        title = style.pop("title", None)
+        show_colorbar = bool(style.pop("show_colorbar", False))
+        outlier_perc = float(style.get("outlier_perc", 2.0))
+        if _captum_normalisation_degenerate(np.asarray(attr), sign, outlier_perc):
+            _render_flat_attribution(ax, sign, title)
+            return None
+        viz.visualize_image_attr(
+            attr,
+            image,
+            method=method,
+            sign=sign,
+            show_colorbar=show_colorbar,
+            plt_fig_axis=(ax.figure, ax),
+            use_pyplot=False,
+            **({"title": title} if title is not None else {}),
+            **style,
+        )
+        return _last_mappable(ax)

--- a/src/raitap/transparency/visualisers/image_rendering.py
+++ b/src/raitap/transparency/visualisers/image_rendering.py
@@ -177,3 +177,7 @@ class CaptumNativeRenderer:
             **style,
         )
         return _last_mappable(ax)
+
+
+IMAGE_RENDERER_REGISTRY["shap"] = ShapNativeRenderer()
+IMAGE_RENDERER_REGISTRY["captum"] = CaptumNativeRenderer()

--- a/src/raitap/transparency/visualisers/image_rendering.py
+++ b/src/raitap/transparency/visualisers/image_rendering.py
@@ -8,9 +8,12 @@ automatically from explainer provenance via :func:`resolve_image_renderer`.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
+
+from raitap.transparency.contracts import MethodFamily
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -82,3 +85,30 @@ class RaitapHouseRenderer:
         ax.set_xticks([])
         ax.set_yticks([])
         return im
+
+
+IMAGE_RENDERER_REGISTRY: dict[str, ImageAttributionRenderer] = {}
+
+
+def image_renderer(*, for_library: str) -> Callable[[type], type]:
+    """Register a renderer instance under a library name (``source_library``).
+
+    Public surface for plugin authors. The renderer auto-applies to any explainer
+    whose ``registry_name`` equals ``for_library``.
+    """
+
+    def wrap(cls: type) -> type:
+        IMAGE_RENDERER_REGISTRY[for_library] = cls()
+        return cls
+
+    return wrap
+
+
+def resolve_image_renderer(
+    source_library: str | None,
+    method_families: frozenset[MethodFamily],
+) -> tuple[ImageAttributionRenderer, str]:
+    """Pick (renderer, sign) from provenance. Unknown/None library -> house."""
+    renderer = IMAGE_RENDERER_REGISTRY.get(source_library or "", RaitapHouseRenderer())
+    sign = "positive" if MethodFamily.CAM in method_families else "all"
+    return renderer, sign

--- a/src/raitap/transparency/visualisers/image_rendering.py
+++ b/src/raitap/transparency/visualisers/image_rendering.py
@@ -65,7 +65,7 @@ def _grayscale(image: np.ndarray) -> np.ndarray:
 
 
 class RaitapHouseRenderer:
-    """Dependency-free default renderer (no shap/captum import).
+    """Dependency-free default renderer (no optional-extra imports).
 
     ``sign="all"`` -> signed diverging (``bwr``, symmetric 99.9-percentile scale).
     ``sign="positive"`` -> non-negative sequential (``inferno``, ``[0, p99.9]``).
@@ -122,58 +122,3 @@ def resolve_image_renderer(
     renderer = IMAGE_RENDERER_REGISTRY.get(source_library or "", RaitapHouseRenderer())
     sign = "positive" if MethodFamily.CAM in method_families else "all"
     return renderer, sign
-
-
-class CaptumNativeRenderer:
-    """Captum-native recipe via ``captum.attr.visualization.visualize_image_attr``.
-
-    ``attr`` channels-last (H,W,C); ``image`` normalised (H,W,C). ``method``
-    (default ``"blended_heat_map"``) and other Captum styling are forwarded via
-    ``**style``. Returns the drawn mappable, or ``None`` when the slice is a valid
-    all-zero map (rendered flat instead of crashing — see #206/#207).
-    """
-
-    def draw(
-        self,
-        ax: Axes,
-        attr: np.ndarray,
-        image: np.ndarray | None,
-        *,
-        sign: str = "all",
-        **style: Any,
-    ) -> ScalarMappable | None:
-        from captum.attr import visualization as viz
-        from matplotlib.figure import Figure
-
-        from raitap.transparency.visualisers.captum_visualisers import (
-            _captum_normalisation_degenerate,
-            _last_mappable,
-            _render_flat_attribution,
-        )
-
-        method = style.pop("method", "blended_heat_map")
-        title = style.pop("title", None)
-        show_colorbar = bool(style.pop("show_colorbar", False))
-        outlier_perc = float(style.get("outlier_perc", 2.0))
-        if _captum_normalisation_degenerate(np.asarray(attr), sign, outlier_perc):
-            _render_flat_attribution(ax, sign, title)
-            return None
-        # ``ax.figure`` is typed ``Figure | SubFigure``; visualisers always pass a
-        # top-level ``Figure``'s axes, and visualize_image_attr's stub requires ``Figure``.
-        fig = ax.figure
-        assert isinstance(fig, Figure)
-        viz.visualize_image_attr(
-            attr,
-            image,
-            method=method,
-            sign=sign,
-            show_colorbar=show_colorbar,
-            plt_fig_axis=(fig, ax),
-            use_pyplot=False,
-            **({"title": title} if title is not None else {}),
-            **style,
-        )
-        return _last_mappable(ax)
-
-
-IMAGE_RENDERER_REGISTRY["captum"] = CaptumNativeRenderer()

--- a/src/raitap/transparency/visualisers/image_rendering.py
+++ b/src/raitap/transparency/visualisers/image_rendering.py
@@ -8,7 +8,6 @@ automatically from explainer provenance via :func:`resolve_image_renderer`.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
@@ -16,6 +15,8 @@ import numpy as np
 from raitap.transparency.contracts import MethodFamily
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from matplotlib.axes import Axes
     from matplotlib.cm import ScalarMappable
 
@@ -70,7 +71,15 @@ class RaitapHouseRenderer:
     Grayscale background of ``image`` at alpha 0.15 when provided.
     """
 
-    def draw(self, ax: Axes, attr: np.ndarray, image: np.ndarray | None, *, sign: str = "all", **style: Any) -> ScalarMappable | None:
+    def draw(
+        self,
+        ax: Axes,
+        attr: np.ndarray,
+        image: np.ndarray | None,
+        *,
+        sign: str = "all",
+        **style: Any,
+    ) -> ScalarMappable | None:
         heat = _signed_channel_sum(attr)
         if image is not None:
             ax.imshow(_grayscale(image), cmap="gray", alpha=0.15)
@@ -122,7 +131,15 @@ class ShapNativeRenderer:
     SHAP attributions are always signed-diverging.
     """
 
-    def draw(self, ax: "Axes", attr: np.ndarray, image: "np.ndarray | None", *, sign: str = "all", **style: Any) -> "ScalarMappable":
+    def draw(
+        self,
+        ax: Axes,
+        attr: np.ndarray,
+        image: np.ndarray | None,
+        *,
+        sign: str = "all",
+        **style: Any,
+    ) -> ScalarMappable:
         from raitap.transparency.visualisers.shap_visualisers import (
             _image_heatmap,
             _red_transparent_blue,
@@ -149,7 +166,15 @@ class CaptumNativeRenderer:
     all-zero map (rendered flat instead of crashing — see #206/#207).
     """
 
-    def draw(self, ax, attr, image, *, sign: str = "all", **style: Any):
+    def draw(
+        self,
+        ax: Axes,
+        attr: np.ndarray,
+        image: np.ndarray | None,
+        *,
+        sign: str = "all",
+        **style: Any,
+    ) -> ScalarMappable | None:
         from captum.attr import visualization as viz
 
         from raitap.transparency.visualisers.captum_visualisers import (

--- a/src/raitap/transparency/visualisers/image_rendering.py
+++ b/src/raitap/transparency/visualisers/image_rendering.py
@@ -112,3 +112,29 @@ def resolve_image_renderer(
     renderer = IMAGE_RENDERER_REGISTRY.get(source_library or "", RaitapHouseRenderer())
     sign = "positive" if MethodFamily.CAM in method_families else "all"
     return renderer, sign
+
+
+class ShapNativeRenderer:
+    """SHAP-native recipe (red_transparent_blue, grayscale bg, +/-99.9 percentile).
+
+    Mirrors ``shap.plots.image``. ``attr`` is channels-last (H,W,C) or (H,W);
+    ``image`` is the normalised (H,W,C) original or None. ``sign`` is ignored —
+    SHAP attributions are always signed-diverging.
+    """
+
+    def draw(self, ax: "Axes", attr: np.ndarray, image: "np.ndarray | None", *, sign: str = "all", **style: Any) -> "ScalarMappable":
+        from raitap.transparency.visualisers.shap_visualisers import (
+            _image_heatmap,
+            _red_transparent_blue,
+            _rgb_to_grayscale,
+            _symmetric_vmin_vmax,
+        )
+
+        cmap = style.get("cmap") or _red_transparent_blue()
+        overlay_alpha = float(style.get("overlay_alpha", 0.15))
+        outlier_perc = float(style.get("outlier_perc", 99.9))
+        heatmap = _image_heatmap(np.asarray(attr, dtype=np.float32))
+        vmin, vmax = _symmetric_vmin_vmax(heatmap, outlier_perc)
+        if image is not None:
+            ax.imshow(_rgb_to_grayscale(image), cmap="gray", alpha=overlay_alpha)
+        return ax.imshow(heatmap, cmap=cmap, vmin=vmin, vmax=vmax)

--- a/src/raitap/transparency/visualisers/image_rendering.py
+++ b/src/raitap/transparency/visualisers/image_rendering.py
@@ -1,0 +1,84 @@
+"""Shared per-Axes attribution renderers.
+
+A *renderer* paints ONE attribution map onto ONE existing matplotlib Axes. It
+owns no figure, no layout, and is not user-selected — visualisers (which own the
+figure/layout) delegate the inner paint to a renderer. Renderers are chosen
+automatically from explainer provenance via :func:`resolve_image_renderer`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.cm import ScalarMappable
+
+
+class ImageAttributionRenderer(Protocol):
+    """Paint one attribution onto ``ax``; return the mappable (for a colorbar)."""
+
+    def draw(
+        self,
+        ax: Axes,
+        attr: np.ndarray,
+        image: np.ndarray | None,
+        *,
+        sign: str = "all",
+        **style: Any,
+    ) -> ScalarMappable | None: ...
+
+
+def _signed_channel_sum(attr: np.ndarray) -> np.ndarray:
+    """Collapse ``(C, H, W)`` / ``(H, W, C)`` / ``(H, W)`` to a 2-D signed map."""
+    arr = np.asarray(attr, dtype=np.float32)
+    if arr.ndim == 3:
+        if arr.shape[0] in (1, 3) and arr.shape[0] < arr.shape[-1]:
+            arr = np.transpose(arr, (1, 2, 0))
+        return arr[..., 0] if arr.shape[-1] == 1 else arr.sum(axis=-1)
+    return arr
+
+
+def _symmetric_clim(values: np.ndarray, outlier_perc: float = 99.9) -> tuple[float, float]:
+    abs_vals = np.abs(values)
+    if abs_vals.size == 0:
+        return -1.0, 1.0
+    max_val = float(np.nanpercentile(abs_vals, outlier_perc))
+    if not np.isfinite(max_val) or max_val == 0.0:
+        return -1.0, 1.0
+    return -max_val, max_val
+
+
+def _grayscale(image: np.ndarray) -> np.ndarray:
+    if image.ndim == 2:
+        return image
+    if image.shape[-1] == 3:
+        return 0.2989 * image[..., 0] + 0.5870 * image[..., 1] + 0.1140 * image[..., 2]
+    return image.mean(axis=-1)
+
+
+class RaitapHouseRenderer:
+    """Dependency-free default renderer (no shap/captum import).
+
+    ``sign="all"`` -> signed diverging (``bwr``, symmetric 99.9-percentile scale).
+    ``sign="positive"`` -> non-negative sequential (``inferno``, ``[0, p99.9]``).
+    Grayscale background of ``image`` at alpha 0.15 when provided.
+    """
+
+    def draw(self, ax: Axes, attr: np.ndarray, image: np.ndarray | None, *, sign: str = "all", **style: Any) -> ScalarMappable | None:
+        heat = _signed_channel_sum(attr)
+        if image is not None:
+            ax.imshow(_grayscale(image), cmap="gray", alpha=0.15)
+        if sign == "positive":
+            heat = np.abs(heat)
+            vmax = float(np.nanpercentile(heat, 99.9)) if heat.size else 1.0
+            vmax = vmax if (np.isfinite(vmax) and vmax > 0) else 1.0
+            im = ax.imshow(heat, cmap="inferno", vmin=0.0, vmax=vmax)
+        else:
+            vmin, vmax = _symmetric_clim(heat)
+            im = ax.imshow(heat, cmap="bwr", vmin=vmin, vmax=vmax)
+        ax.set_xticks([])
+        ax.set_yticks([])
+        return im

--- a/src/raitap/transparency/visualisers/image_rendering.py
+++ b/src/raitap/transparency/visualisers/image_rendering.py
@@ -124,40 +124,6 @@ def resolve_image_renderer(
     return renderer, sign
 
 
-class ShapNativeRenderer:
-    """SHAP-native recipe (red_transparent_blue, grayscale bg, +/-99.9 percentile).
-
-    Mirrors ``shap.plots.image``. ``attr`` is channels-last (H,W,C) or (H,W);
-    ``image`` is the normalised (H,W,C) original or None. ``sign`` is ignored —
-    SHAP attributions are always signed-diverging.
-    """
-
-    def draw(
-        self,
-        ax: Axes,
-        attr: np.ndarray,
-        image: np.ndarray | None,
-        *,
-        sign: str = "all",
-        **style: Any,
-    ) -> ScalarMappable:
-        from raitap.transparency.visualisers.shap_visualisers import (
-            _image_heatmap,
-            _red_transparent_blue,
-            _rgb_to_grayscale,
-            _symmetric_vmin_vmax,
-        )
-
-        cmap = style.get("cmap") or _red_transparent_blue()
-        overlay_alpha = float(style.get("overlay_alpha", 0.15))
-        outlier_perc = float(style.get("outlier_perc", 99.9))
-        heatmap = _image_heatmap(np.asarray(attr, dtype=np.float32))
-        vmin, vmax = _symmetric_vmin_vmax(heatmap, outlier_perc)
-        if image is not None:
-            ax.imshow(_rgb_to_grayscale(image), cmap="gray", alpha=overlay_alpha)
-        return ax.imshow(heatmap, cmap=cmap, vmin=vmin, vmax=vmax)
-
-
 class CaptumNativeRenderer:
     """Captum-native recipe via ``captum.attr.visualization.visualize_image_attr``.
 
@@ -210,5 +176,4 @@ class CaptumNativeRenderer:
         return _last_mappable(ax)
 
 
-IMAGE_RENDERER_REGISTRY["shap"] = ShapNativeRenderer()
 IMAGE_RENDERER_REGISTRY["captum"] = CaptumNativeRenderer()

--- a/src/raitap/transparency/visualisers/shap_visualisers.py
+++ b/src/raitap/transparency/visualisers/shap_visualisers.py
@@ -27,6 +27,7 @@ from raitap.transparency.contracts import (
     ScopeDefinitionStep,
     VisualSummarySpec,
 )
+from raitap.transparency.visualisers.image_rendering import ShapNativeRenderer
 from raitap.transparency.visualisers.registration import transparency_visualiser
 
 from .base_visualiser import BaseVisualiser
@@ -682,9 +683,6 @@ class ShapImageVisualiser(BaseVisualiser):
             shap_i = (
                 np.transpose(shap_vals[i], (1, 2, 0)) if shap_vals[i].ndim == 3 else shap_vals[i]
             )
-            heatmap = _image_heatmap(shap_i)
-            vmin, vmax = _symmetric_vmin_vmax(heatmap, outlier_perc)
-
             sample_name = names[i] if show_sample_names and i < len(names) else None
             original_title = _compose_title("Original Image", sample_name)
             attr_title = _resolve_title(
@@ -713,17 +711,13 @@ class ShapImageVisualiser(BaseVisualiser):
                     attr_ax = axes[i]
                     colorbar_ax = None
 
-            if image_i is not None:
-                attr_ax.imshow(
-                    _rgb_to_grayscale(image_i),
-                    cmap="gray",
-                    alpha=overlay_alpha,
-                )
-            im = attr_ax.imshow(
-                heatmap,
+            im = ShapNativeRenderer().draw(
+                attr_ax,
+                shap_i,
+                image_i,
                 cmap=cmap,
-                vmin=vmin,
-                vmax=vmax,
+                overlay_alpha=overlay_alpha,
+                outlier_perc=outlier_perc,
             )
             attr_ax.set_title(attr_title or "")
             attr_ax.axis("off")

--- a/src/raitap/transparency/visualisers/shap_visualisers.py
+++ b/src/raitap/transparency/visualisers/shap_visualisers.py
@@ -27,13 +27,15 @@ from raitap.transparency.contracts import (
     ScopeDefinitionStep,
     VisualSummarySpec,
 )
-from raitap.transparency.visualisers.image_rendering import ShapNativeRenderer
+from raitap.transparency.visualisers.image_rendering import IMAGE_RENDERER_REGISTRY
 from raitap.transparency.visualisers.registration import transparency_visualiser
 
 from .base_visualiser import BaseVisualiser
 
 if TYPE_CHECKING:
     import torch
+    from matplotlib.axes import Axes
+    from matplotlib.cm import ScalarMappable
     from matplotlib.colors import Colormap
     from matplotlib.figure import Figure
 
@@ -727,3 +729,33 @@ class ShapImageVisualiser(BaseVisualiser):
                 colorbar_ax.set_ylabel("SHAP value")
 
         return fig
+
+
+class ShapNativeRenderer:
+    """SHAP-native recipe (red_transparent_blue, grayscale bg, +/-99.9 percentile).
+
+    Mirrors ``shap.plots.image``. ``attr`` is channels-last (H,W,C) or (H,W);
+    ``image`` is the normalised (H,W,C) original or None. ``sign`` is ignored —
+    SHAP attributions are always signed-diverging.
+    """
+
+    def draw(
+        self,
+        ax: Axes,
+        attr: np.ndarray,
+        image: np.ndarray | None,
+        *,
+        sign: str = "all",
+        **style: Any,
+    ) -> ScalarMappable:
+        cmap = style.get("cmap") or _red_transparent_blue()
+        overlay_alpha = float(style.get("overlay_alpha", 0.15))
+        outlier_perc = float(style.get("outlier_perc", 99.9))
+        heatmap = _image_heatmap(np.asarray(attr, dtype=np.float32))
+        vmin, vmax = _symmetric_vmin_vmax(heatmap, outlier_perc)
+        if image is not None:
+            ax.imshow(_rgb_to_grayscale(image), cmap="gray", alpha=overlay_alpha)
+        return ax.imshow(heatmap, cmap=cmap, vmin=vmin, vmax=vmax)
+
+
+IMAGE_RENDERER_REGISTRY["shap"] = ShapNativeRenderer()

--- a/src/raitap/transparency/visualisers/tests/test_image_rendering.py
+++ b/src/raitap/transparency/visualisers/tests/test_image_rendering.py
@@ -74,3 +74,28 @@ def test_shap_native_matches_manual_recipe():
     assert im.get_clim() == (vmin, vmax)
     np.testing.assert_allclose(im.get_array(), expected)
     plt.close(fig)
+
+
+def test_captum_native_draws_and_returns_mappable():
+    pytest.importorskip("captum")
+    import matplotlib.pyplot as plt
+    from raitap.transparency.visualisers.image_rendering import CaptumNativeRenderer
+
+    attr = np.linspace(-1, 1, 8 * 8 * 3).reshape(8, 8, 3).astype(np.float32)
+    image = np.abs(attr)
+    fig, ax = plt.subplots()
+    im = CaptumNativeRenderer().draw(ax, attr, image, sign="all", method="heat_map")
+    assert im is not None
+    plt.close(fig)
+
+
+def test_captum_native_flat_for_degenerate():
+    pytest.importorskip("captum")
+    import matplotlib.pyplot as plt
+    from raitap.transparency.visualisers.image_rendering import CaptumNativeRenderer
+
+    attr = np.zeros((8, 8, 3), dtype=np.float32)
+    fig, ax = plt.subplots()
+    im = CaptumNativeRenderer().draw(ax, attr, np.zeros_like(attr), sign="all")
+    assert im is None  # flat-rendered, no mappable; must not raise
+    plt.close(fig)

--- a/src/raitap/transparency/visualisers/tests/test_image_rendering.py
+++ b/src/raitap/transparency/visualisers/tests/test_image_rendering.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
@@ -15,7 +16,7 @@ from raitap.transparency.visualisers.image_rendering import (
 )
 
 
-def test_house_renderer_signed_returns_mappable():
+def test_house_renderer_signed_returns_mappable() -> None:
     fig, ax = plt.subplots()
     attr = np.linspace(-1.0, 1.0, 3 * 4 * 4).reshape(3, 4, 4).astype(np.float32)
     image = np.zeros((4, 4, 3), dtype=np.float32)
@@ -26,30 +27,33 @@ def test_house_renderer_signed_returns_mappable():
     plt.close(fig)
 
 
-def test_house_renderer_positive_is_non_negative_floor():
+def test_house_renderer_positive_is_non_negative_floor() -> None:
     fig, ax = plt.subplots()
     attr = np.abs(np.linspace(0.0, 1.0, 16)).reshape(1, 4, 4).astype(np.float32)
     mappable = RaitapHouseRenderer().draw(ax, attr, None, sign="positive")
+    assert mappable is not None
     vmin, vmax = mappable.get_clim()
     assert vmin == 0.0 and vmax > 0.0
     plt.close(fig)
 
 
-def test_unknown_library_resolves_to_house():
+def test_unknown_library_resolves_to_house() -> None:
     renderer, sign = resolve_image_renderer("does-not-exist", frozenset())
     assert isinstance(renderer, RaitapHouseRenderer)
     assert sign == "all"
 
 
-def test_cam_family_resolves_to_positive_sign():
+def test_cam_family_resolves_to_positive_sign() -> None:
     _, sign = resolve_image_renderer(None, frozenset({MethodFamily.CAM}))
     assert sign == "positive"
 
 
-def test_decorator_registers_by_library():
+def test_decorator_registers_by_library() -> None:
     @image_renderer(for_library="unittest-lib")
     class _Dummy:
-        def draw(self, ax, attr, image, *, sign="all", **style):
+        def draw(
+            self, ax: object, attr: object, image: object, *, sign: str = "all", **style: object
+        ) -> None:
             return None
 
     assert isinstance(IMAGE_RENDERER_REGISTRY["unittest-lib"], _Dummy)
@@ -58,27 +62,33 @@ def test_decorator_registers_by_library():
     del IMAGE_RENDERER_REGISTRY["unittest-lib"]
 
 
-def test_shap_native_matches_manual_recipe():
+def test_shap_native_matches_manual_recipe() -> None:
     pytest.importorskip("shap")
     import matplotlib.pyplot as plt
+
     from raitap.transparency.visualisers.image_rendering import ShapNativeRenderer
     from raitap.transparency.visualisers.shap_visualisers import (
-        _image_heatmap, _symmetric_vmin_vmax,
+        _image_heatmap,
+        _symmetric_vmin_vmax,
     )
 
     shap_hwc = np.linspace(-2, 2, 4 * 4 * 3).reshape(4, 4, 3).astype(np.float32)
     fig, ax = plt.subplots()
     im = ShapNativeRenderer().draw(ax, shap_hwc, None)
+    assert im is not None
     expected = _image_heatmap(shap_hwc)
     vmin, vmax = _symmetric_vmin_vmax(expected, 99.9)
     assert im.get_clim() == (vmin, vmax)
-    np.testing.assert_allclose(im.get_array(), expected)
+    drawn = im.get_array()
+    assert drawn is not None
+    np.testing.assert_allclose(np.asarray(drawn), expected)
     plt.close(fig)
 
 
-def test_captum_native_draws_and_returns_mappable():
+def test_captum_native_draws_and_returns_mappable() -> None:
     pytest.importorskip("captum")
     import matplotlib.pyplot as plt
+
     from raitap.transparency.visualisers.image_rendering import CaptumNativeRenderer
 
     attr = np.linspace(-1, 1, 8 * 8 * 3).reshape(8, 8, 3).astype(np.float32)
@@ -89,9 +99,10 @@ def test_captum_native_draws_and_returns_mappable():
     plt.close(fig)
 
 
-def test_captum_native_flat_for_degenerate():
+def test_captum_native_flat_for_degenerate() -> None:
     pytest.importorskip("captum")
     import matplotlib.pyplot as plt
+
     from raitap.transparency.visualisers.image_rendering import CaptumNativeRenderer
 
     attr = np.zeros((8, 8, 3), dtype=np.float32)
@@ -101,19 +112,24 @@ def test_captum_native_flat_for_degenerate():
     plt.close(fig)
 
 
-def test_builtin_libraries_registered():
+def test_builtin_libraries_registered() -> None:
     from raitap.transparency.visualisers.image_rendering import (
-        CaptumNativeRenderer, IMAGE_RENDERER_REGISTRY, ShapNativeRenderer,
+        IMAGE_RENDERER_REGISTRY,
+        CaptumNativeRenderer,
+        ShapNativeRenderer,
     )
+
     assert isinstance(IMAGE_RENDERER_REGISTRY["shap"], ShapNativeRenderer)
     assert isinstance(IMAGE_RENDERER_REGISTRY["captum"], CaptumNativeRenderer)
 
 
-def test_resolver_shap_vs_captum_shapley_trap():
+def test_resolver_shap_vs_captum_shapley_trap() -> None:
     from raitap.transparency.contracts import MethodFamily
     from raitap.transparency.visualisers.image_rendering import (
-        CaptumNativeRenderer, ShapNativeRenderer,
+        CaptumNativeRenderer,
+        ShapNativeRenderer,
     )
+
     r_shap, _ = resolve_image_renderer("shap", frozenset({MethodFamily.SHAPLEY}))
     r_cap, sign = resolve_image_renderer(
         "captum", frozenset({MethodFamily.SHAPLEY, MethodFamily.PERTURBATION})
@@ -126,18 +142,23 @@ def test_resolver_shap_vs_captum_shapley_trap():
     assert cam_sign == "positive"
 
 
-def test_image_renderer_on_public_adapters_facade():
+def test_image_renderer_on_public_adapters_facade() -> None:
     from raitap import adapters
+
     assert hasattr(adapters, "image_renderer")
 
     @adapters.image_renderer(for_library="superxai-test")
     class _SuperXAIRenderer:
-        def draw(self, ax, attr, image, *, sign="all", **style):
+        def draw(
+            self, ax: object, attr: object, image: object, *, sign: str = "all", **style: object
+        ) -> None:
             return None
 
     from raitap.transparency.visualisers.image_rendering import resolve_image_renderer
+
     renderer, _ = resolve_image_renderer("superxai-test", frozenset())
     assert isinstance(renderer, _SuperXAIRenderer)
     # cleanup global registry to avoid cross-test leakage
     from raitap.transparency.visualisers.image_rendering import IMAGE_RENDERER_REGISTRY
+
     del IMAGE_RENDERER_REGISTRY["superxai-test"]

--- a/src/raitap/transparency/visualisers/tests/test_image_rendering.py
+++ b/src/raitap/transparency/visualisers/tests/test_image_rendering.py
@@ -117,8 +117,11 @@ def test_builtin_libraries_registered() -> None:
     from raitap.transparency.visualisers.image_rendering import IMAGE_RENDERER_REGISTRY
     from raitap.transparency.visualisers.shap_visualisers import ShapNativeRenderer
 
-    assert isinstance(IMAGE_RENDERER_REGISTRY["shap"], ShapNativeRenderer)
-    assert isinstance(IMAGE_RENDERER_REGISTRY["captum"], CaptumNativeRenderer)
+    # Compare by class name, not isinstance: other tests in the suite re-import
+    # the library visualiser modules (sys.modules surgery), which can leave the
+    # registry holding an instance from a different module-load identity.
+    assert type(IMAGE_RENDERER_REGISTRY["shap"]).__name__ == ShapNativeRenderer.__name__
+    assert type(IMAGE_RENDERER_REGISTRY["captum"]).__name__ == CaptumNativeRenderer.__name__
 
 
 def test_resolver_shap_vs_captum_shapley_trap() -> None:
@@ -130,8 +133,10 @@ def test_resolver_shap_vs_captum_shapley_trap() -> None:
     r_cap, sign = resolve_image_renderer(
         "captum", frozenset({MethodFamily.SHAPLEY, MethodFamily.PERTURBATION})
     )
-    assert isinstance(r_shap, ShapNativeRenderer)
-    assert isinstance(r_cap, CaptumNativeRenderer) and sign == "all"
+    # Name comparison (not isinstance): robust to suite-wide module reloads — see
+    # test_builtin_libraries_registered.
+    assert type(r_shap).__name__ == ShapNativeRenderer.__name__
+    assert type(r_cap).__name__ == CaptumNativeRenderer.__name__ and sign == "all"
     _, cam_sign = resolve_image_renderer(
         "captum", frozenset({MethodFamily.GRADIENT, MethodFamily.CAM})
     )

--- a/src/raitap/transparency/visualisers/tests/test_image_rendering.py
+++ b/src/raitap/transparency/visualisers/tests/test_image_rendering.py
@@ -5,7 +5,13 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 
-from raitap.transparency.visualisers.image_rendering import RaitapHouseRenderer
+from raitap.transparency.contracts import MethodFamily
+from raitap.transparency.visualisers.image_rendering import (
+    IMAGE_RENDERER_REGISTRY,
+    RaitapHouseRenderer,
+    image_renderer,
+    resolve_image_renderer,
+)
 
 
 def test_house_renderer_signed_returns_mappable():
@@ -26,3 +32,26 @@ def test_house_renderer_positive_is_non_negative_floor():
     vmin, vmax = mappable.get_clim()
     assert vmin == 0.0 and vmax > 0.0
     plt.close(fig)
+
+
+def test_unknown_library_resolves_to_house():
+    renderer, sign = resolve_image_renderer("does-not-exist", frozenset())
+    assert isinstance(renderer, RaitapHouseRenderer)
+    assert sign == "all"
+
+
+def test_cam_family_resolves_to_positive_sign():
+    _, sign = resolve_image_renderer(None, frozenset({MethodFamily.CAM}))
+    assert sign == "positive"
+
+
+def test_decorator_registers_by_library():
+    @image_renderer(for_library="unittest-lib")
+    class _Dummy:
+        def draw(self, ax, attr, image, *, sign="all", **style):
+            return None
+
+    assert isinstance(IMAGE_RENDERER_REGISTRY["unittest-lib"], _Dummy)
+    renderer, _ = resolve_image_renderer("unittest-lib", frozenset())
+    assert isinstance(renderer, _Dummy)
+    del IMAGE_RENDERER_REGISTRY["unittest-lib"]

--- a/src/raitap/transparency/visualisers/tests/test_image_rendering.py
+++ b/src/raitap/transparency/visualisers/tests/test_image_rendering.py
@@ -124,3 +124,20 @@ def test_resolver_shap_vs_captum_shapley_trap():
         "captum", frozenset({MethodFamily.GRADIENT, MethodFamily.CAM})
     )
     assert cam_sign == "positive"
+
+
+def test_image_renderer_on_public_adapters_facade():
+    from raitap import adapters
+    assert hasattr(adapters, "image_renderer")
+
+    @adapters.image_renderer(for_library="superxai-test")
+    class _SuperXAIRenderer:
+        def draw(self, ax, attr, image, *, sign="all", **style):
+            return None
+
+    from raitap.transparency.visualisers.image_rendering import resolve_image_renderer
+    renderer, _ = resolve_image_renderer("superxai-test", frozenset())
+    assert isinstance(renderer, _SuperXAIRenderer)
+    # cleanup global registry to avoid cross-test leakage
+    from raitap.transparency.visualisers.image_rendering import IMAGE_RENDERER_REGISTRY
+    del IMAGE_RENDERER_REGISTRY["superxai-test"]

--- a/src/raitap/transparency/visualisers/tests/test_image_rendering.py
+++ b/src/raitap/transparency/visualisers/tests/test_image_rendering.py
@@ -4,6 +4,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 
 from raitap.transparency.contracts import MethodFamily
 from raitap.transparency.visualisers.image_rendering import (
@@ -55,3 +56,21 @@ def test_decorator_registers_by_library():
     renderer, _ = resolve_image_renderer("unittest-lib", frozenset())
     assert isinstance(renderer, _Dummy)
     del IMAGE_RENDERER_REGISTRY["unittest-lib"]
+
+
+def test_shap_native_matches_manual_recipe():
+    pytest.importorskip("shap")
+    import matplotlib.pyplot as plt
+    from raitap.transparency.visualisers.image_rendering import ShapNativeRenderer
+    from raitap.transparency.visualisers.shap_visualisers import (
+        _image_heatmap, _symmetric_vmin_vmax,
+    )
+
+    shap_hwc = np.linspace(-2, 2, 4 * 4 * 3).reshape(4, 4, 3).astype(np.float32)
+    fig, ax = plt.subplots()
+    im = ShapNativeRenderer().draw(ax, shap_hwc, None)
+    expected = _image_heatmap(shap_hwc)
+    vmin, vmax = _symmetric_vmin_vmax(expected, 99.9)
+    assert im.get_clim() == (vmin, vmax)
+    np.testing.assert_allclose(im.get_array(), expected)
+    plt.close(fig)

--- a/src/raitap/transparency/visualisers/tests/test_image_rendering.py
+++ b/src/raitap/transparency/visualisers/tests/test_image_rendering.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from raitap.transparency.visualisers.image_rendering import RaitapHouseRenderer
+
+
+def test_house_renderer_signed_returns_mappable():
+    fig, ax = plt.subplots()
+    attr = np.linspace(-1.0, 1.0, 3 * 4 * 4).reshape(3, 4, 4).astype(np.float32)
+    image = np.zeros((4, 4, 3), dtype=np.float32)
+    mappable = RaitapHouseRenderer().draw(ax, attr, image, sign="all")
+    assert mappable is not None
+    vmin, vmax = mappable.get_clim()
+    assert vmin == -vmax
+    plt.close(fig)
+
+
+def test_house_renderer_positive_is_non_negative_floor():
+    fig, ax = plt.subplots()
+    attr = np.abs(np.linspace(0.0, 1.0, 16)).reshape(1, 4, 4).astype(np.float32)
+    mappable = RaitapHouseRenderer().draw(ax, attr, None, sign="positive")
+    vmin, vmax = mappable.get_clim()
+    assert vmin == 0.0 and vmax > 0.0
+    plt.close(fig)

--- a/src/raitap/transparency/visualisers/tests/test_image_rendering.py
+++ b/src/raitap/transparency/visualisers/tests/test_image_rendering.py
@@ -99,3 +99,28 @@ def test_captum_native_flat_for_degenerate():
     im = CaptumNativeRenderer().draw(ax, attr, np.zeros_like(attr), sign="all")
     assert im is None  # flat-rendered, no mappable; must not raise
     plt.close(fig)
+
+
+def test_builtin_libraries_registered():
+    from raitap.transparency.visualisers.image_rendering import (
+        CaptumNativeRenderer, IMAGE_RENDERER_REGISTRY, ShapNativeRenderer,
+    )
+    assert isinstance(IMAGE_RENDERER_REGISTRY["shap"], ShapNativeRenderer)
+    assert isinstance(IMAGE_RENDERER_REGISTRY["captum"], CaptumNativeRenderer)
+
+
+def test_resolver_shap_vs_captum_shapley_trap():
+    from raitap.transparency.contracts import MethodFamily
+    from raitap.transparency.visualisers.image_rendering import (
+        CaptumNativeRenderer, ShapNativeRenderer,
+    )
+    r_shap, _ = resolve_image_renderer("shap", frozenset({MethodFamily.SHAPLEY}))
+    r_cap, sign = resolve_image_renderer(
+        "captum", frozenset({MethodFamily.SHAPLEY, MethodFamily.PERTURBATION})
+    )
+    assert isinstance(r_shap, ShapNativeRenderer)
+    assert isinstance(r_cap, CaptumNativeRenderer) and sign == "all"
+    _, cam_sign = resolve_image_renderer(
+        "captum", frozenset({MethodFamily.GRADIENT, MethodFamily.CAM})
+    )
+    assert cam_sign == "positive"

--- a/src/raitap/transparency/visualisers/tests/test_image_rendering.py
+++ b/src/raitap/transparency/visualisers/tests/test_image_rendering.py
@@ -66,8 +66,8 @@ def test_shap_native_matches_manual_recipe() -> None:
     pytest.importorskip("shap")
     import matplotlib.pyplot as plt
 
-    from raitap.transparency.visualisers.image_rendering import ShapNativeRenderer
     from raitap.transparency.visualisers.shap_visualisers import (
+        ShapNativeRenderer,
         _image_heatmap,
         _symmetric_vmin_vmax,
     )
@@ -116,8 +116,8 @@ def test_builtin_libraries_registered() -> None:
     from raitap.transparency.visualisers.image_rendering import (
         IMAGE_RENDERER_REGISTRY,
         CaptumNativeRenderer,
-        ShapNativeRenderer,
     )
+    from raitap.transparency.visualisers.shap_visualisers import ShapNativeRenderer
 
     assert isinstance(IMAGE_RENDERER_REGISTRY["shap"], ShapNativeRenderer)
     assert isinstance(IMAGE_RENDERER_REGISTRY["captum"], CaptumNativeRenderer)
@@ -125,10 +125,8 @@ def test_builtin_libraries_registered() -> None:
 
 def test_resolver_shap_vs_captum_shapley_trap() -> None:
     from raitap.transparency.contracts import MethodFamily
-    from raitap.transparency.visualisers.image_rendering import (
-        CaptumNativeRenderer,
-        ShapNativeRenderer,
-    )
+    from raitap.transparency.visualisers.image_rendering import CaptumNativeRenderer
+    from raitap.transparency.visualisers.shap_visualisers import ShapNativeRenderer
 
     r_shap, _ = resolve_image_renderer("shap", frozenset({MethodFamily.SHAPLEY}))
     r_cap, sign = resolve_image_renderer(

--- a/src/raitap/transparency/visualisers/tests/test_image_rendering.py
+++ b/src/raitap/transparency/visualisers/tests/test_image_rendering.py
@@ -89,7 +89,7 @@ def test_captum_native_draws_and_returns_mappable() -> None:
     pytest.importorskip("captum")
     import matplotlib.pyplot as plt
 
-    from raitap.transparency.visualisers.image_rendering import CaptumNativeRenderer
+    from raitap.transparency.visualisers.captum_visualisers import CaptumNativeRenderer
 
     attr = np.linspace(-1, 1, 8 * 8 * 3).reshape(8, 8, 3).astype(np.float32)
     image = np.abs(attr)
@@ -103,7 +103,7 @@ def test_captum_native_flat_for_degenerate() -> None:
     pytest.importorskip("captum")
     import matplotlib.pyplot as plt
 
-    from raitap.transparency.visualisers.image_rendering import CaptumNativeRenderer
+    from raitap.transparency.visualisers.captum_visualisers import CaptumNativeRenderer
 
     attr = np.zeros((8, 8, 3), dtype=np.float32)
     fig, ax = plt.subplots()
@@ -113,10 +113,8 @@ def test_captum_native_flat_for_degenerate() -> None:
 
 
 def test_builtin_libraries_registered() -> None:
-    from raitap.transparency.visualisers.image_rendering import (
-        IMAGE_RENDERER_REGISTRY,
-        CaptumNativeRenderer,
-    )
+    from raitap.transparency.visualisers.captum_visualisers import CaptumNativeRenderer
+    from raitap.transparency.visualisers.image_rendering import IMAGE_RENDERER_REGISTRY
     from raitap.transparency.visualisers.shap_visualisers import ShapNativeRenderer
 
     assert isinstance(IMAGE_RENDERER_REGISTRY["shap"], ShapNativeRenderer)
@@ -125,7 +123,7 @@ def test_builtin_libraries_registered() -> None:
 
 def test_resolver_shap_vs_captum_shapley_trap() -> None:
     from raitap.transparency.contracts import MethodFamily
-    from raitap.transparency.visualisers.image_rendering import CaptumNativeRenderer
+    from raitap.transparency.visualisers.captum_visualisers import CaptumNativeRenderer
     from raitap.transparency.visualisers.shap_visualisers import ShapNativeRenderer
 
     r_shap, _ = resolve_image_renderer("shap", frozenset({MethodFamily.SHAPLEY}))

--- a/src/raitap/transparency/visualisers/tests/test_visualisers.py
+++ b/src/raitap/transparency/visualisers/tests/test_visualisers.py
@@ -1479,3 +1479,41 @@ class TestInputThumbnailVisualiser:
         output_path = tmp_path / "shap_image.png"
         visualiser.save(attributions, output_path, inputs=sample_images)
         assert output_path.exists()
+
+
+def test_detection_uses_shap_renderer_for_shap_library(monkeypatch: pytest.MonkeyPatch) -> None:
+    import raitap.transparency.visualisers.image_rendering as ir
+    from raitap.transparency.contracts import DetectionBox, MethodFamily, VisualisationContext
+    from raitap.transparency.visualisers.detection_image_visualiser import DetectionImageVisualiser
+
+    calls: dict[str, bool] = {}
+
+    class _Spy:
+        def draw(
+            self,
+            ax: Any,
+            attr: Any,
+            image: Any,
+            *,
+            sign: str = "all",
+            **style: Any,
+        ) -> None:
+            calls["used"] = True
+            return ax.imshow(np.zeros((4, 4)))
+
+    monkeypatch.setitem(ir.IMAGE_RENDERER_REGISTRY, "shap", _Spy())
+
+    attr = torch.zeros(3, 4, 4)
+    img = torch.zeros(3, 4, 4)
+    ctx = VisualisationContext(
+        algorithm="GradientExplainer",
+        sample_names=None,
+        show_sample_names=False,
+        detection_box=DetectionBox(0, 0, (0.0, 0.0, 2.0, 2.0), 0.9, 1, "cat"),
+        source_library="shap",
+        method_families=frozenset({MethodFamily.SHAPLEY}),
+    )
+    fig = DetectionImageVisualiser().visualise(attr, inputs=img, context=ctx)
+    assert calls.get("used") is True
+    assert all(im.get_cmap().name != "seismic" for ax in fig.axes for im in ax.images)
+    plt.close(fig)


### PR DESCRIPTION
## Summary

- Extract image-attribution heatmap rendering into a shared **renderer** layer (`ImageAttributionRenderer` + library-keyed registry). `ShapImageVisualiser`/`CaptumImageVisualiser` now delegate their per-panel paint to it (pixel-identical, guarded by existing MPL baselines); detection reuses the same renderers.
- **Fix #221**: `DetectionImageVisualiser` previously rendered every library/method with one recipe (`abs`-sum + `seismic` + max-norm) — discarding attribution sign and drawing a diverging colormap over non-negative data. It now resolves a renderer from the explainer's library + method family, so detection is **sign-aware and library-faithful**, while keeping the per-box layout (bbox, title, low-res CAM upsample from #203).
- **Automatic dispatch from provenance**: `source_library` (explainer `registry_name`) and `method_families` are threaded to the visualisation context; unknown libraries fall back to a dependency-free house renderer. Plugins may register a custom look via `@adapters.image_renderer(for_library="<registry_name>")` — no shap/captum knowledge required, no RAITAP edits.

Behaviour change: detection attribution overlays change appearance (sign-aware, per-library) versus the previous single magnitude style. Classification output is unchanged.

Follow-up: the new detection visual-regression test is skip-guarded until its baseline exists; run the `regen-baselines` workflow (now wired to include it) to generate and commit `detection_house_heat_map.png`, which activates the test.

Closes #221.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — Not breaking: changes are additive and backward-compatible (new optional fields, new opt-in decorator); no `!` needed.
- [x] **Contributor guide** — Read.

## Optional

- [x] **Issue** _(optional)_ — Closes #221.
- [x] **Docs** _(optional)_ — Contributor `architecture` + `writing-a-plugin` updated (visualiser vs renderer; opt-in custom renderer).
- [x] **Tests** _(optional)_ — Renderer unit tests, resolver SHAPLEY-trap, detection behaviour test, skip-guarded MPL regression.
