### PR TITLE
refactor(infra): raw-string error_patterns + fix marabou demo runner

### DIFF
--- a/contributor-configs/marabou-mnist/README.md
+++ b/contributor-configs/marabou-mnist/README.md
@@ -30,5 +30,8 @@ Marabou wheels are Python 3.11 + Linux/WSL only. On Windows, run via WSL.
    contributor-configs/marabou-mnist/run.sh hardware=cpu
    ```
 
+   The script syncs the required extras itself and passes `--custom-deps`
+   to raitap, so the auto-deps gate is skipped — no `-y`/consent needed.
+
 2. **Inspect outputs.** Marabou verification results land under the Hydra
    run directory (`outputs/<date>/<time>/robustness/`).

--- a/contributor-configs/marabou-mnist/run.ps1
+++ b/contributor-configs/marabou-mnist/run.ps1
@@ -6,7 +6,9 @@ $ErrorActionPreference = 'Stop'
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 # Translate the Windows script path into the WSL view (D:\... -> /mnt/d/...).
-$WslDir = (& wsl wslpath -a -u $ScriptDir).Trim()
+# wsl.exe strips backslashes from forwarded args, so feed wslpath a
+# forward-slash path (D:/... which wslpath -a also accepts).
+$WslDir = (& wsl wslpath -a -u ($ScriptDir -replace '\\', '/')).Trim()
 
 # Quote each forwarded arg for the bash side.
 $ForwardedArgs = ($args | ForEach-Object {

--- a/contributor-configs/marabou-mnist/run.sh
+++ b/contributor-configs/marabou-mnist/run.sh
@@ -27,4 +27,5 @@ uv run -p 3.11 \
   raitap \
     --config-dir "$SCRIPT_DIR" \
     --config-name assessment \
+    --custom-deps \
     "$@"

--- a/docs/contributor/adding-an-adapter.md
+++ b/docs/contributor/adding-an-adapter.md
@@ -23,7 +23,6 @@ Name the file after the library (e.g. `superxai_explainer.py`). Then:
 ```python
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
 from raitap import adapters
@@ -41,7 +40,7 @@ if TYPE_CHECKING:
     # extra="superxai",            # uv extra name; defaults to `registry_name` (omit unless they differ — see metrics for an exception)
     library="superxai-lib",        # real PyPI package name; drives `self._lazy_import()`
     error_patterns={               # rewrite cryptic upstream errors at call sites
-        re.compile(r"some library footgun"): "Do X instead.",
+        r"some library footgun": "Do X instead.",   # raw regex strings, compiled at registration
     },
     suppress_warnings=[            # optional library-noise filters installed at decoration time
         (r"some noisy.*pattern", UserWarning, r"superxai.*"),

--- a/docs/contributor/adding-an-adapter.md
+++ b/docs/contributor/adding-an-adapter.md
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     # extra="superxai",            # uv extra name; defaults to `registry_name` (omit unless they differ — see metrics for an exception)
     library="superxai-lib",        # real PyPI package name; drives `self._lazy_import()`
     error_patterns={               # rewrite cryptic upstream errors at call sites
-        r"some library footgun": "Do X instead.",   # raw regex strings, compiled at registration
+        r"some library footgun": "Do X instead.",
     },
     suppress_warnings=[            # optional library-noise filters installed at decoration time
         (r"some noisy.*pattern", UserWarning, r"superxai.*"),

--- a/docs/contributor/logging.md
+++ b/docs/contributor/logging.md
@@ -66,7 +66,7 @@ from raitap import adapters
     registry_name="shap",
     library="shap",
     error_patterns={
-        re.compile(r"BackwardHookFunctionBackward is a view"): (
+        r"BackwardHookFunctionBackward is a view": (
             "DeepExplainer can fail on PyTorch models that use SiLU "
             "activations (for example EfficientNet variants). Use "
             "alternatives like GradientExplainer."

--- a/docs/contributor/writing-a-plugin.md
+++ b/docs/contributor/writing-a-plugin.md
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
     registry_name="superxai",      # CLI `+transparency=superxai` / Python `from raitap.transparency import superxai`
     library="superxai-lib",        # real name of your PyPI package; drives `self._lazy_import()` (defaults to registry_name)
     error_patterns={               # rewrite cryptic upstream errors at call sites
-        r"some library footgun": "Do X instead.", # raw regex strings (compiled at registration); avoid deep stack traces in RAITAP
+        r"some library footgun": "Do X instead.", # nicer error messages to avoid deep stack traces in RAITAP
     },
     algorithm_registry={
         # the algos your library offers; ExplainerSemanticsHints carries the

--- a/docs/contributor/writing-a-plugin.md
+++ b/docs/contributor/writing-a-plugin.md
@@ -50,7 +50,6 @@ instead of the in-tree relative import. Decorate it with the public
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
 from raitap import adapters
@@ -66,7 +65,7 @@ if TYPE_CHECKING:
     registry_name="superxai",      # CLI `+transparency=superxai` / Python `from raitap.transparency import superxai`
     library="superxai-lib",        # real name of your PyPI package; drives `self._lazy_import()` (defaults to registry_name)
     error_patterns={               # rewrite cryptic upstream errors at call sites
-        re.compile(r"some library footgun"): "Do X instead.", # nicer error messages to avoid deep stack traces in RAITAP
+        r"some library footgun": "Do X instead.", # raw regex strings (compiled at registration); avoid deep stack traces in RAITAP
     },
     algorithm_registry={
         # the algos your library offers; ExplainerSemanticsHints carries the

--- a/src/raitap/_adapters.py
+++ b/src/raitap/_adapters.py
@@ -25,6 +25,7 @@ import importlib
 import inspect
 import os
 import pkgutil
+import re
 from contextlib import contextmanager
 from dataclasses import dataclass
 from importlib import metadata as importlib_metadata
@@ -35,7 +36,6 @@ from hydra_zen import ZenStore, builds
 from raitap.types import TaskKind
 
 if TYPE_CHECKING:
-    import re
     from collections.abc import Iterator, Mapping, Sequence
     from types import ModuleType
 
@@ -95,7 +95,10 @@ class AdapterDecoratorOptions(TypedDict, total=False):
     registry_name: Required[str]
     extra: str
     library: str
-    error_patterns: Mapping[re.Pattern[str], str]
+    # Raw regex strings → friendly messages. Compiled at registration by
+    # ``_register_core`` (mirrors ``suppress_warnings``, which also takes raw
+    # strings). Pass ``r"..."``; add inline flags like ``(?i)`` if needed.
+    error_patterns: Mapping[str, str]
     suppress_warnings: Sequence[tuple[str, type[Warning], str | None]]
     schema: type
 
@@ -118,7 +121,9 @@ class AdapterMixin:
     # Hydra config group ("transparency" / "robustness" / ...). Set by
     # ``_register_core`` and read by :meth:`_rethrow` to scope error chips.
     _adapter_group: str | None = None
-    # Regex → friendly-message map applied automatically by :meth:`_rethrow`.
+    # Compiled regex → friendly-message map applied automatically by
+    # :meth:`_rethrow`. Stored pre-compiled (``_register_core`` compiles the
+    # raw-string ``error_patterns`` decorator kwarg).
     error_patterns: Mapping[re.Pattern[str], str] = {}
     # Task families this adapter accepts. Default classification so legacy
     # adapters stay correct without explicit declaration. Issue #146.
@@ -239,7 +244,9 @@ def _register_core(
     if library is not None:
         cls.library = library
     if error_patterns is not None:
-        cls.error_patterns = error_patterns
+        cls.error_patterns = {
+            re.compile(pattern): message for pattern, message in error_patterns.items()
+        }
     if suppress_warnings:
         for pattern, category, module in suppress_warnings:
             raitap_log.suppress(message=pattern, category=category, module=module or "")

--- a/src/raitap/_adapters.py
+++ b/src/raitap/_adapters.py
@@ -244,9 +244,16 @@ def _register_core(
     if library is not None:
         cls.library = library
     if error_patterns is not None:
-        cls.error_patterns = {
-            re.compile(pattern): message for pattern, message in error_patterns.items()
-        }
+        compiled: dict[re.Pattern[str], str] = {}
+        for pattern, message in error_patterns.items():
+            try:
+                compiled[re.compile(pattern)] = message
+            except re.error as exc:
+                raise ValueError(
+                    f"{cls.__name__} (registry_name={registry_name!r}) declares an invalid "
+                    f"error_patterns regex {pattern!r}: {exc}"
+                ) from exc
+        cls.error_patterns = compiled
     if suppress_warnings:
         for pattern, category, module in suppress_warnings:
             raitap_log.suppress(message=pattern, category=category, module=module or "")

--- a/src/raitap/robustness/assessors/auto_lirpa_assessor.py
+++ b/src/raitap/robustness/assessors/auto_lirpa_assessor.py
@@ -21,7 +21,6 @@ Contract mapping onto :class:`FormalVerificationAssessor`:
 from __future__ import annotations
 
 import contextlib
-import re
 import time
 from collections.abc import Mapping  # noqa: TC003 — runtime use in module-level annotation
 from typing import TYPE_CHECKING, Any
@@ -69,8 +68,8 @@ _NORM_TO_LIRPA: dict[PerturbationNorm, float] = {
 
 # Curated rewrites for opaque auto-LiRPA errors. Matched against ``str(exc)``;
 # first hit wins. See :func:`raitap.utils.errors.rethrow`.
-_AUTO_LIRPA_ERROR_MESSAGES: Mapping[re.Pattern[str], str] = {
-    re.compile(r"self\.stride .* != self\.kernel_size"): (
+_AUTO_LIRPA_ERROR_MESSAGES: Mapping[str, str] = {
+    r"self\.stride .* != self\.kernel_size": (
         "auto-LiRPA's MaxPool bound propagator only supports non-overlapping "
         "pooling (stride == kernel_size). This model has an overlapping MaxPool "
         "(e.g. ResNet's k=3, s=2 stem), which bound propagation cannot handle. "

--- a/src/raitap/robustness/assessors/marabou_assessor.py
+++ b/src/raitap/robustness/assessors/marabou_assessor.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import logging
 import math
-import re
 import shutil
 import tempfile
 import time
@@ -49,8 +48,8 @@ from .base_assessor import FormalVerificationAssessor
 
 # Curated error patterns for confusing maraboupy errors. Matched against
 # ``str(exc)``; first hit wins. See :func:`raitap.utils.errors.rethrow`.
-_MARABOUPY_ERROR_MESSAGES: Mapping[re.Pattern[str], str] = {
-    re.compile(r"Invoked with: <class 'maraboupy\.MarabouCore\.Equation\.EquationType'>"): (
+_MARABOUPY_ERROR_MESSAGES: Mapping[str, str] = {
+    r"Invoked with: <class 'maraboupy\.MarabouCore\.Equation\.EquationType'>": (
         "Equation construction trap: `MarabouCore.Equation` (the C++ class) "
         "stores its type on the class, not the instance, so "
         "`InputQueryBuilder.getInputQuery` accessing `e.EquationType` returns "
@@ -60,7 +59,7 @@ _MARABOUPY_ERROR_MESSAGES: Mapping[re.Pattern[str], str] = {
         "https://github.com/NeuralNetworkVerification/Marabou/blob/master/"
         "maraboupy/MarabouUtils.py."
     ),
-    re.compile(r"Operation \S+ not implemented"): (
+    r"Operation \S+ not implemented": (
         "Marabou's ONNX parser does not implement an op used by the model. "
         "Re-export with the Marabou-supported subset only — see "
         "https://github.com/NeuralNetworkVerification/Marabou/blob/master/"

--- a/src/raitap/transparency/explainers/shap_explainer.py
+++ b/src/raitap/transparency/explainers/shap_explainer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING, Any, cast
 
 from raitap import raitap_log
@@ -77,9 +76,9 @@ def _select_target_attributions(
     registry_name="shap",
     library="shap",
     error_patterns={
-        re.compile(
+        (
             r"Output \d+ of BackwardHookFunctionBackward is a view "
-            r"and is being modified inplace",
+            r"and is being modified inplace"
         ): (
             "DeepExplainer can fail on PyTorch models that use SiLU activations "
             "(for example EfficientNet variants) due to autograd/in-place "


### PR DESCRIPTION
## Summary

Two unrelated changes bundled per request.

### marabou-mnist runner fixes
- `run.ps1`: `wsl wslpath` strips backslashes from forwarded args, yielding a null path. Convert `\`→`/` before passing (wslpath `-a` accepts forward-slash Windows paths).
- `run.sh`: pass `--custom-deps` to raitap. The script already `uv sync`s the explicit extra set; the auto-deps gate was redundant and failed (`uv add raitap[...]` is a self-dependency when cwd resolves to the raitap repo). Skipping it keeps run.sh's superset of extras authoritative.
- README: document the deps-gate skip; drop the now-wrong `-y` note.

### error_patterns: accept raw regex strings
`@adapters.*(error_patterns=...)` now takes plain `r"..."` strings (compiled at registration in `_register_core`), matching `suppress_warnings`. `rethrow` keeps its low-level `re.Pattern` contract; the stored class attr stays pre-compiled, so consumers and tests are unchanged.

Not breaking: `re.compile()` returns an already-compiled `Pattern` unchanged, so existing plugins passing `re.compile(...)` keys still work at runtime.

Producers updated: shap / marabou / auto_lirpa adapters + contributor docs (adding-an-adapter, logging, writing-a-plugin). Verified with `ruff format` / `ruff check` (clean).

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — If this PR breaks compatibility (API, configs, file formats, etc.), the title uses `!` after the type or scope. This change is runtime-compatible (see above), so no `!`.
- [x] **Contributor guide** — I've read [**Pull requests and commit messages**](https://caiivs.github.io/raitap/contributor/pull-requests.html) before requesting review.

## Optional

- [ ] **Issue** _(optional)_ — A GitHub issues is linked to this PR ("Development" section in the right sidebar).
- [x] **Docs** _(optional)_ — User or contributor docs updated where needed.
- [ ] **Tests** _(optional)_ — New or updated tests cover the change.
