### PR TITLE
feat(transparency): class names and true labels for detection boxes (#233)

### DIFF
--- a/docs/modules/transparency/detection.md
+++ b/docs/modules/transparency/detection.md
@@ -84,9 +84,11 @@ transparency = {
 
 ## Box labels and ground truth
 
-Each explained box is labelled in the report headings, figure titles, and
+Each explained box is labelled in the report headings and on the original-image
 thumbnail overlay with its **predicted class name** and, when ground truth is
-available, the **true label** of the closest real object.
+available, the **true label** of the closest real object. The per-box
+attribution figures carry no title — the label, score, and ground-truth match
+would only duplicate what the overlay and heading already show.
 
 **Predicted class names.** A box reads `kite` instead of `class 38` whenever a
 class-name source is available:

--- a/docs/modules/transparency/detection.md
+++ b/docs/modules/transparency/detection.md
@@ -84,28 +84,17 @@ transparency = {
 
 ## Box labels and ground truth
 
-Each explained box is labelled in the report headings and on the original-image
-thumbnail overlay with its **predicted class name** and, when ground truth is
-available, the **true label** of the closest real object. The per-box
-attribution figures carry no title — the label, score, and ground-truth match
-would only duplicate what the overlay and heading already show.
+Boxes are labelled in the report headings and on the thumbnail overlay; the
+per-box attribution figures stay title-less (a title would only duplicate them).
 
-**Predicted class names.** A box reads `kite` instead of `class 38` whenever a
-class-name source is available:
+**Predicted name.** A box reads `kite`, not `class 38`, when a name source is
+available: torchvision detectors use their bundled categories automatically;
+otherwise set `model.class_names` (id-ordered, index 0 first), which takes
+precedence. With neither, boxes fall back to `class <id>`.
 
-- For pretrained torchvision detectors, the model's bundled category names are
-  used automatically — no configuration needed.
-- For your own model, set `model.class_names` to the id-ordered list of names
-  (index 0 first). This takes precedence over any bundled names.
-- With neither, boxes fall back to the numeric form `class <id>`.
-
-**True labels.** When you configure detection ground truth
-(`data.labels.source` with `data.labels.kind: detection`), each box is matched
-to the ground-truth object it overlaps most and shows that object's label plus
-the overlap as `gt: <name> (IoU <value>)`. The match is by overlap alone, so a
-disagreement is visible directly — e.g. `pred: dog 0.92 | gt: cat (IoU 0.71)`.
-A box that overlaps no labelled object reads `gt: no match`. IoU (intersection
-over union) ranges 0–1; the match uses the same `raitap.detection.iou_threshold`
-as the explanation, and a higher value means a tighter overlap.
-
-With no ground truth configured, no `gt:` line is shown.
+**True label.** Set `data.labels.source` + `data.labels.kind: detection` to match
+each box to the ground-truth object it overlaps most, shown as
+`gt: <name> (IoU <value>)`. The match is by overlap alone, so disagreements
+surface (`pred: dog 0.92 | gt: cat (IoU 0.71)`); a box overlapping no labelled
+object reads `gt: no match`, and with no ground truth the `gt:` clause is
+omitted. Matching reuses `raitap.detection.iou_threshold`.

--- a/docs/modules/transparency/detection.md
+++ b/docs/modules/transparency/detection.md
@@ -101,7 +101,7 @@ class-name source is available:
 (`data.labels.source` with `data.labels.kind: detection`), each box is matched
 to the ground-truth object it overlaps most and shows that object's label plus
 the overlap as `gt: <name> (IoU <value>)`. The match is by overlap alone, so a
-disagreement is visible directly — e.g. `pred: dog 0.92 | gt: cat, IoU=0.71`.
+disagreement is visible directly — e.g. `pred: dog 0.92 | gt: cat (IoU 0.71)`.
 A box that overlaps no labelled object reads `gt: no match`. IoU (intersection
 over union) ranges 0–1; the match uses the same `raitap.detection.iou_threshold`
 as the explanation, and a higher value means a tighter overlap.

--- a/docs/modules/transparency/detection.md
+++ b/docs/modules/transparency/detection.md
@@ -81,3 +81,29 @@ transparency = {
     ),
 }
 ```
+
+## Box labels and ground truth
+
+Each explained box is labelled in the report headings, figure titles, and
+thumbnail overlay with its **predicted class name** and, when ground truth is
+available, the **true label** of the closest real object.
+
+**Predicted class names.** A box reads `kite` instead of `class 38` whenever a
+class-name source is available:
+
+- For pretrained torchvision detectors, the model's bundled category names are
+  used automatically — no configuration needed.
+- For your own model, set `model.class_names` to the id-ordered list of names
+  (index 0 first). This takes precedence over any bundled names.
+- With neither, boxes fall back to the numeric form `class <id>`.
+
+**True labels.** When you configure detection ground truth
+(`data.labels.source` with `data.labels.kind: detection`), each box is matched
+to the ground-truth object it overlaps most and shows that object's label plus
+the overlap as `gt: <name> (IoU <value>)`. The match is by overlap alone, so a
+disagreement is visible directly — e.g. `pred: dog 0.92 | gt: cat, IoU=0.71`.
+A box that overlaps no labelled object reads `gt: no match`. IoU (intersection
+over union) ranges 0–1; the match uses the same `raitap.detection.iou_threshold`
+as the explanation, and a higher value means a tighter overlap.
+
+With no ground truth configured, no `gt:` line is shown.

--- a/src/raitap/configs/schema.py
+++ b/src/raitap/configs/schema.py
@@ -55,6 +55,12 @@ class ModelConfig:
     # before loading the state-dict. Usually ``False`` since weights come from
     # the state-dict itself.
     pretrained: bool = False
+    # Optional explicit id->name table for detection class labels. Index-aligned
+    # with the model's label ids (id 0 first). When set, overrides any names
+    # captured from torchvision ``weights.meta["categories"]``. Leave unset to
+    # use the model's bundled category names (pretrained torchvision detectors)
+    # or fall back to numeric ids.
+    class_names: list[str] | None = None
 
 
 @dataclass

--- a/src/raitap/models/backend.py
+++ b/src/raitap/models/backend.py
@@ -135,6 +135,9 @@ class ModelBackend(ABC):
     # Declared per-sample input shape with ``None`` marking dynamic dims
     # (typically the batch dim). ``None`` overall = no rank adaptation.
     expected_input_shape: tuple[int | None, ...] | None = None
+    # Optional id->name table for the model's output classes (e.g. torchvision
+    # detection ``weights.meta["categories"]``). ``None`` when unavailable.
+    category_names: list[str] | None = None
 
     @property
     @abstractmethod
@@ -173,10 +176,12 @@ class TorchBackend(ModelBackend):
         *,
         device: torch.device | None = None,
         task_kind: TaskKind | None = None,
+        category_names: list[str] | None = None,
     ) -> None:
         self.model = model
         self.device = torch.device("cpu") if device is None else device
         self._task_kind = task_kind if task_kind is not None else self._infer_task_kind(model)
+        self.category_names = category_names
 
     @staticmethod
     def _infer_task_kind(model: nn.Module) -> TaskKind:

--- a/src/raitap/models/model.py
+++ b/src/raitap/models/model.py
@@ -345,6 +345,26 @@ def _load_torch_module_from_path(
     raise ValueError(f"Expected an nn.Module or state-dict in {path}, got {type(obj).__name__}.")
 
 
+def _default_category_names(model_name: str) -> list[str] | None:
+    """Return the torchvision default weights' ``categories`` for *model_name*.
+
+    Detection weights carry an index-aligned ``categories`` list (id 0 first,
+    ``"N/A"`` placeholders for unused ids). ``None`` for models whose default
+    weights expose no categories (e.g. plain classifiers carry ImageNet labels
+    we don't use here) or when resolution fails.
+    """
+    try:
+        from torchvision.models import get_model_weights
+
+        default = get_model_weights(model_name).DEFAULT  # type: ignore[attr-defined]
+        categories = default.meta.get("categories")
+    except Exception:  # best-effort metadata; never block model load
+        return None
+    if categories is None:
+        return None
+    return list(categories)
+
+
 def _load_pretrained(model_name: str, *, hardware: str) -> ModelBackend:
     """
     Load a torchvision model with its default pre-trained weights.
@@ -370,7 +390,7 @@ def _load_pretrained(model_name: str, *, hardware: str) -> ModelBackend:
     model = factory(weights="DEFAULT")
     model.to(device)
     model.eval()
-    return TorchBackend(model, device=device)
+    return TorchBackend(model, device=device, category_names=_default_category_names(model_name))
 
 
 def _supported_model_formats() -> list[str]:

--- a/src/raitap/models/model.py
+++ b/src/raitap/models/model.py
@@ -349,9 +349,11 @@ def _default_category_names(model_name: str) -> list[str] | None:
     """Return the torchvision default weights' ``categories`` for *model_name*.
 
     Detection weights carry an index-aligned ``categories`` list (id 0 first,
-    ``"N/A"`` placeholders for unused ids). ``None`` for models whose default
-    weights expose no categories (e.g. plain classifiers carry ImageNet labels
-    we don't use here) or when resolution fails.
+    ``"N/A"`` placeholders for unused ids). Classification weights also expose
+    their ImageNet labels here, so a classifier backend gets ``category_names``
+    populated too — harmless, since only the detection box-labelling path reads
+    it. ``None`` only when the default weights expose no ``categories`` key or
+    when resolution fails.
     """
     try:
         from torchvision.models import get_model_weights

--- a/src/raitap/models/tests/test_model_categories.py
+++ b/src/raitap/models/tests/test_model_categories.py
@@ -1,0 +1,39 @@
+"""Tests for category-name capture on TorchBackend and _load_pretrained."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_torchbackend_category_names_defaults_none() -> None:
+    import torch.nn as nn
+
+    from raitap.models.backend import TorchBackend
+
+    backend = TorchBackend(nn.Linear(2, 2))
+    assert backend.category_names is None
+
+
+def test_torchbackend_category_names_stored() -> None:
+    import torch.nn as nn
+
+    from raitap.models.backend import TorchBackend
+
+    backend = TorchBackend(nn.Linear(2, 2), category_names=["__background__", "kite"])
+    assert backend.category_names == ["__background__", "kite"]
+
+
+@pytest.mark.slow
+def test_load_pretrained_detection_captures_categories() -> None:
+    pytest.importorskip("torchvision")
+    from raitap.models.model import _load_pretrained
+
+    backend = _load_pretrained("fasterrcnn_resnet50_fpn_v2", hardware="cpu")
+    cats = backend.category_names
+    assert cats is not None
+    assert cats[0] == "__background__"
+    from torchvision.models import get_model_weights
+
+    expected = get_model_weights("fasterrcnn_resnet50_fpn_v2").DEFAULT.meta["categories"]  # type: ignore[attr-defined]
+    assert cats == list(expected)
+    assert len(cats) > 38

--- a/src/raitap/pipeline/phases/assess_transparency.py
+++ b/src/raitap/pipeline/phases/assess_transparency.py
@@ -137,6 +137,10 @@ def _assess_transparency_detection(
     from raitap.configs.adapter_factory import resolve_per_image_transform
     from raitap.pipeline.phases.explain_detection import explain_detection
     from raitap.transparency.baselines import apply_config_baseline
+    from raitap.transparency.detection_labels import (
+        enrich_detection_box,
+        resolve_category_names,
+    )
     from raitap.transparency.factory import (
         _PARSED_EXPLAINER_CONFIG_CACHE,
         _parse_explainer_config,
@@ -152,6 +156,10 @@ def _assess_transparency_detection(
     explanations: list[ExplanationResult] = []
     visualisations: list[VisualisationResult] = []
     backend = _require_model_backend(model)
+    category_names = resolve_category_names(
+        getattr(config.model, "class_names", None),
+        getattr(backend, "category_names", None),
+    )
 
     for name in explainer_names:
         explainer_config = config.transparency[name]
@@ -213,6 +221,11 @@ def _assess_transparency_detection(
                 call_kwargs=merged_kwargs,
                 call_provenance=call_provenance,
             ):
+                if result.detection_box is not None:
+                    result.detection_box = enrich_detection_box(
+                        result.detection_box,
+                        category_names=category_names,
+                    )
                 explanations.append(result)
                 visualisations.extend(result.visualise())
         finally:

--- a/src/raitap/pipeline/phases/assess_transparency.py
+++ b/src/raitap/pipeline/phases/assess_transparency.py
@@ -164,7 +164,7 @@ def _assess_transparency_detection(
         backend.category_names,
     )
     data_labels = getattr(data, "labels", None)
-    detection_gt = data_labels if isinstance(data_labels, list) else None
+    detection_ground_truth = data_labels if isinstance(data_labels, list) else None
 
     for name in explainer_names:
         explainer_config = config.transparency[name]
@@ -187,7 +187,7 @@ def _assess_transparency_detection(
 
             call_from_config = dict(parsed.call)
             raitap_cfg = dict(parsed.raitap)
-            gt_iou_threshold = float(
+            ground_truth_iou_threshold = float(
                 raitap_cfg.get("detection", {}).get("iou_threshold", _DEFAULT_IOU_THRESHOLD)
             )
             if data.sample_ids is not None:
@@ -231,26 +231,26 @@ def _assess_transparency_detection(
             ):
                 if result.detection_box is not None:
                     sample_index = result.original_sample_index
-                    gt_for_sample = None
-                    if detection_gt is not None and sample_index is not None:
-                        if sample_index < len(detection_gt):
-                            gt_for_sample = detection_gt[sample_index]
+                    ground_truth_for_sample = None
+                    if detection_ground_truth is not None and sample_index is not None:
+                        if sample_index < len(detection_ground_truth):
+                            ground_truth_for_sample = detection_ground_truth[sample_index]
                         else:
-                            # Loader guarantees len(detection_gt) == n_samples, so this
+                            # Loader guarantees len(detection_ground_truth) == n_samples, so this
                             # only fires on a genuine prediction/label misalignment;
                             # surface it instead of silently skipping the GT match.
                             raitap_log.warn(
                                 "Detection ground truth has %d entries but an explanation "
                                 "references sample_index=%d; rendering this box without a "
                                 "true label (prediction/label misalignment).",
-                                len(detection_gt),
+                                len(detection_ground_truth),
                                 sample_index,
                             )
                     result.detection_box = enrich_detection_box(
                         result.detection_box,
                         category_names=category_names,
-                        gt_for_sample=gt_for_sample,
-                        iou_threshold=gt_iou_threshold,
+                        ground_truth_for_sample=ground_truth_for_sample,
+                        iou_threshold=ground_truth_iou_threshold,
                     )
                 explanations.append(result)
                 visualisations.extend(result.visualise())

--- a/src/raitap/pipeline/phases/assess_transparency.py
+++ b/src/raitap/pipeline/phases/assess_transparency.py
@@ -160,8 +160,8 @@ def _assess_transparency_detection(
     visualisations: list[VisualisationResult] = []
     backend = _require_model_backend(model)
     category_names = resolve_category_names(
-        getattr(config.model, "class_names", None),
-        getattr(backend, "category_names", None),
+        config.model.class_names,
+        backend.category_names,
     )
     data_labels = getattr(data, "labels", None)
     detection_gt = data_labels if isinstance(data_labels, list) else None
@@ -188,9 +188,7 @@ def _assess_transparency_detection(
             call_from_config = dict(parsed.call)
             raitap_cfg = dict(parsed.raitap)
             gt_iou_threshold = float(
-                dict(parsed.raitap)
-                .get("detection", {})
-                .get("iou_threshold", _DEFAULT_IOU_THRESHOLD)
+                raitap_cfg.get("detection", {}).get("iou_threshold", _DEFAULT_IOU_THRESHOLD)
             )
             if data.sample_ids is not None:
                 raitap_cfg["sample_ids"] = data.sample_ids
@@ -233,13 +231,21 @@ def _assess_transparency_detection(
             ):
                 if result.detection_box is not None:
                     sample_index = result.original_sample_index
-                    gt_for_sample = (
-                        detection_gt[sample_index]
-                        if detection_gt is not None
-                        and sample_index is not None
-                        and sample_index < len(detection_gt)
-                        else None
-                    )
+                    gt_for_sample = None
+                    if detection_gt is not None and sample_index is not None:
+                        if sample_index < len(detection_gt):
+                            gt_for_sample = detection_gt[sample_index]
+                        else:
+                            # Loader guarantees len(detection_gt) == n_samples, so this
+                            # only fires on a genuine prediction/label misalignment;
+                            # surface it instead of silently skipping the GT match.
+                            raitap_log.warn(
+                                "Detection ground truth has %d entries but an explanation "
+                                "references sample_index=%d; rendering this box without a "
+                                "true label (prediction/label misalignment).",
+                                len(detection_gt),
+                                sample_index,
+                            )
                     result.detection_box = enrich_detection_box(
                         result.detection_box,
                         category_names=category_names,

--- a/src/raitap/pipeline/phases/assess_transparency.py
+++ b/src/raitap/pipeline/phases/assess_transparency.py
@@ -135,7 +135,10 @@ def _assess_transparency_detection(
     """
     from raitap.configs import resolve_run_dir
     from raitap.configs.adapter_factory import resolve_per_image_transform
-    from raitap.pipeline.phases.explain_detection import explain_detection
+    from raitap.pipeline.phases.explain_detection import (
+        _DEFAULT_IOU_THRESHOLD,
+        explain_detection,
+    )
     from raitap.transparency.baselines import apply_config_baseline
     from raitap.transparency.detection_labels import (
         enrich_detection_box,
@@ -160,6 +163,8 @@ def _assess_transparency_detection(
         getattr(config.model, "class_names", None),
         getattr(backend, "category_names", None),
     )
+    data_labels = getattr(data, "labels", None)
+    detection_gt = data_labels if isinstance(data_labels, list) else None
 
     for name in explainer_names:
         explainer_config = config.transparency[name]
@@ -182,6 +187,11 @@ def _assess_transparency_detection(
 
             call_from_config = dict(parsed.call)
             raitap_cfg = dict(parsed.raitap)
+            gt_iou_threshold = float(
+                dict(parsed.raitap)
+                .get("detection", {})
+                .get("iou_threshold", _DEFAULT_IOU_THRESHOLD)
+            )
             if data.sample_ids is not None:
                 raitap_cfg["sample_ids"] = data.sample_ids
                 raitap_cfg["sample_names"] = data.sample_ids
@@ -222,9 +232,19 @@ def _assess_transparency_detection(
                 call_provenance=call_provenance,
             ):
                 if result.detection_box is not None:
+                    sample_index = result.original_sample_index
+                    gt_for_sample = (
+                        detection_gt[sample_index]
+                        if detection_gt is not None
+                        and sample_index is not None
+                        and sample_index < len(detection_gt)
+                        else None
+                    )
                     result.detection_box = enrich_detection_box(
                         result.detection_box,
                         category_names=category_names,
+                        gt_for_sample=gt_for_sample,
+                        iou_threshold=gt_iou_threshold,
                     )
                 explanations.append(result)
                 visualisations.extend(result.visualise())

--- a/src/raitap/pipeline/phases/tests/test_assess_transparency_detection.py
+++ b/src/raitap/pipeline/phases/tests/test_assess_transparency_detection.py
@@ -173,6 +173,152 @@ def test_assess_transparency_routes_detection_kind_to_explain_detection(
     assert len(explanations) == 2
 
 
+def test_detection_transparency_renders_class_name_end_to_end(tmp_path: Path) -> None:
+    """Caller-side enrichment must fill ``DetectionBox.label_name`` from the
+    resolved category-names table BEFORE ``result.visualise()`` renders the
+    figure, so a configured class name reaches both the in-memory box and the
+    rendered per-box title.
+
+    ``explain_detection`` is mocked to yield a *real* ``ExplanationResult`` that
+    carries a raw box (``label_name=None``) plus a real
+    ``DetectionImageVisualiser``; the only thing under test is that the
+    transparency caller enriches the box ahead of the render path."""
+    from raitap.transparency.contracts import (
+        DetectionBox,
+        ExplanationOutputSpace,
+        ExplanationPayloadKind,
+        ExplanationScope,
+        InputSpec,
+        MethodFamily,
+        OutputSpaceSpec,
+        ScopeDefinitionStep,
+    )
+    from raitap.transparency.results import (
+        ConfiguredVisualiser,
+        ExplanationResult,
+        ExplanationSemantics,
+    )
+    from raitap.transparency.visualisers.detection_image_visualiser import (
+        DetectionImageVisualiser,
+    )
+
+    predicted_label_id = 7
+    config = AppConfig(experiment_name="render-test")
+    set_output_root(config, tmp_path)
+    config.model.class_names = (
+        ["__background__"]
+        + [f"c{i}" for i in range(1, predicted_label_id)]
+        + ["kite"]
+        + [f"c{i}" for i in range(predicted_label_id + 1, 91)]
+    )
+    config.transparency = {
+        "ig_det": TransparencyConfig(
+            _target_="CaptumExplainer",
+            algorithm="IntegratedGradients",
+            call={"target": 0},
+            raitap={"detection": {"score_threshold": 0.5, "max_boxes": 5}},
+            visualisers=[{"_target_": "DetectionImageVisualiser"}],
+        )
+    }
+
+    model = _FakeModel()
+    data = _FakeData(num_samples=1)
+    forward = _make_detection_forward_output(num_samples=1)
+
+    semantics = ExplanationSemantics(
+        scope=ExplanationScope.LOCAL,
+        scope_definition_step=ScopeDefinitionStep.EXPLAINER_OUTPUT,
+        payload_kind=ExplanationPayloadKind.ATTRIBUTIONS,
+        method_families=frozenset({MethodFamily.GRADIENT}),
+        target=None,
+        sample_selection=None,
+        input_spec=InputSpec(kind="image", shape=(1, 3, 64, 64), layout="NCHW"),
+        output_space=OutputSpaceSpec(
+            space=ExplanationOutputSpace.DETECTION_BOXES,
+            shape=(1, 3, 64, 64),
+            layout="NCHW",
+        ),
+    )
+
+    def fake_explain_detection(**kwargs: Any) -> Iterator[ExplanationResult]:
+        run_dir = kwargs["base_run_dir"] / "sample_0" / "box_0"
+        result = ExplanationResult(
+            attributions=torch.zeros(1, 3, 64, 64),
+            inputs=torch.rand(1, 3, 64, 64),
+            run_dir=run_dir,
+            experiment_name="render-test",
+            explainer_target=kwargs["explainer_target"],
+            algorithm="IntegratedGradients",
+            explainer_name=kwargs["explainer_name"],
+            visualisers=[ConfiguredVisualiser(DetectionImageVisualiser())],
+            semantics=semantics,
+        )
+        # Raw box as explain_detection emits it: label_name is unresolved (None).
+        result.detection_box = DetectionBox(
+            display_index=0,
+            raw_index=0,
+            xyxy=(10.0, 10.0, 50.0, 50.0),
+            score=0.9,
+            label_index=predicted_label_id,
+            label_name=None,
+        )
+        result.original_sample_index = 0
+        yield result
+
+    class _FakeExplainer:
+        algorithm = "IntegratedGradients"
+
+        def check_backend_compat(self, backend: object) -> None:
+            return None
+
+    with (
+        patch(
+            "raitap.pipeline.phases.assess_transparency.Explanation",
+            side_effect=AssertionError("classification path should not run"),
+        ),
+        patch(
+            "raitap.transparency.factory.create_explainer",
+            return_value=(_FakeExplainer(), "raitap.transparency.CaptumExplainer"),
+        ),
+        patch(
+            "raitap.transparency.factory.create_visualisers",
+            return_value=[ConfiguredVisualiser(DetectionImageVisualiser())],
+        ),
+        patch(
+            "raitap.transparency.factory.check_explainer_visualiser_compat",
+            return_value=None,
+        ),
+        patch(
+            "raitap.transparency.factory.check_explainer_visualiser_payload_compat",
+            return_value=None,
+        ),
+        patch(
+            "raitap.transparency.factory.check_explainer_visualiser_semantic_compat",
+            return_value=None,
+        ),
+        patch(
+            "raitap.pipeline.phases.explain_detection.explain_detection",
+            side_effect=fake_explain_detection,
+        ),
+    ):
+        explanations, visualisations = assess_transparency(
+            config,
+            model,  # type: ignore[arg-type]
+            data,  # type: ignore[arg-type]
+            forward,
+            input_metadata=None,
+            resolved_preprocessing=None,
+        )
+
+    # In-memory box was enriched before visualise().
+    assert any(
+        e.detection_box is not None and e.detection_box.label_name == "kite" for e in explanations
+    )
+    # And the enriched name reached a RENDERED per-box title (downstream of visualise()).
+    titles = [v.figure.axes[0].get_title() for v in visualisations if hasattr(v, "figure")]
+    assert any("kite" in t for t in titles)
+
+
 def test_assess_transparency_detection_skips_when_no_explainers(tmp_path: Path) -> None:
     config = AppConfig(experiment_name="empty")
     set_output_root(config, tmp_path)

--- a/src/raitap/pipeline/phases/tests/test_assess_transparency_detection.py
+++ b/src/raitap/pipeline/phases/tests/test_assess_transparency_detection.py
@@ -467,7 +467,7 @@ def test_detection_transparency_matches_ground_truth_end_to_end(tmp_path: Path) 
     # no title (asserted below), so the GT detail is carried by the box itself.
     box = explanations[0].detection_box
     assert box is not None
-    assert box.gt_evaluated is True
+    assert box.ground_truth_evaluated is True
     assert box.true_label_index == gt_label_id
     assert box.true_label_name == f"c{gt_label_id}"
     assert box.true_match_iou == pytest.approx(1.0)

--- a/src/raitap/pipeline/phases/tests/test_assess_transparency_detection.py
+++ b/src/raitap/pipeline/phases/tests/test_assess_transparency_detection.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
+import pytest
 import torch
 
 if TYPE_CHECKING:
@@ -317,6 +318,156 @@ def test_detection_transparency_renders_class_name_end_to_end(tmp_path: Path) ->
     # And the enriched name reached a RENDERED per-box title (downstream of visualise()).
     titles = [v.figure.axes[0].get_title() for v in visualisations if hasattr(v, "figure")]
     assert any("kite" in t for t in titles)
+
+
+def test_detection_transparency_matches_ground_truth_end_to_end(tmp_path: Path) -> None:
+    """When ``data.labels`` carries detection GT, the caller matches each box to
+    GT by IoU and the true label + match IoU reach the in-memory box AND the
+    rendered title — exercising the caller GT-wiring branch (positional lookup,
+    bounds guard, threshold pass-through), not just ``enrich_detection_box`` in
+    isolation. The GT class (20) differs from the predicted class (7) so the
+    class-agnostic match surfaces a disagreement, which is the point of the
+    feature."""
+    from raitap.transparency.contracts import (
+        DetectionBox,
+        ExplanationOutputSpace,
+        ExplanationPayloadKind,
+        ExplanationScope,
+        InputSpec,
+        MethodFamily,
+        OutputSpaceSpec,
+        ScopeDefinitionStep,
+    )
+    from raitap.transparency.results import (
+        ConfiguredVisualiser,
+        ExplanationResult,
+        ExplanationSemantics,
+    )
+    from raitap.transparency.visualisers.detection_image_visualiser import (
+        DetectionImageVisualiser,
+    )
+
+    predicted_label_id = 7
+    gt_label_id = 20
+    config = AppConfig(experiment_name="gt-match-test")
+    set_output_root(config, tmp_path)
+    config.model.class_names = ["__background__"] + [f"c{i}" for i in range(1, 91)]
+    config.transparency = {
+        "ig_det": TransparencyConfig(
+            _target_="CaptumExplainer",
+            algorithm="IntegratedGradients",
+            call={"target": 0},
+            raitap={"detection": {"score_threshold": 0.5, "max_boxes": 5, "iou_threshold": 0.5}},
+            visualisers=[{"_target_": "DetectionImageVisualiser"}],
+        )
+    }
+
+    model = _FakeModel()
+    data = _FakeData(num_samples=1)
+    # GT for sample 0: one box at the SAME coords as the predicted box (IoU 1.0)
+    # but a different class id, so the match is spatial (class-agnostic).
+    data.labels = [  # type: ignore[attr-defined]
+        {
+            "boxes": torch.tensor([[10.0, 10.0, 50.0, 50.0]]),
+            "labels": torch.tensor([gt_label_id], dtype=torch.int64),
+        }
+    ]
+    forward = _make_detection_forward_output(num_samples=1)
+
+    semantics = ExplanationSemantics(
+        scope=ExplanationScope.LOCAL,
+        scope_definition_step=ScopeDefinitionStep.EXPLAINER_OUTPUT,
+        payload_kind=ExplanationPayloadKind.ATTRIBUTIONS,
+        method_families=frozenset({MethodFamily.GRADIENT}),
+        target=None,
+        sample_selection=None,
+        input_spec=InputSpec(kind="image", shape=(1, 3, 64, 64), layout="NCHW"),
+        output_space=OutputSpaceSpec(
+            space=ExplanationOutputSpace.DETECTION_BOXES,
+            shape=(1, 3, 64, 64),
+            layout="NCHW",
+        ),
+    )
+
+    def fake_explain_detection(**kwargs: Any) -> Iterator[ExplanationResult]:
+        run_dir = kwargs["base_run_dir"] / "sample_0" / "box_0"
+        result = ExplanationResult(
+            attributions=torch.zeros(1, 3, 64, 64),
+            inputs=torch.rand(1, 3, 64, 64),
+            run_dir=run_dir,
+            experiment_name="gt-match-test",
+            explainer_target=kwargs["explainer_target"],
+            algorithm="IntegratedGradients",
+            explainer_name=kwargs["explainer_name"],
+            visualisers=[ConfiguredVisualiser(DetectionImageVisualiser())],
+            semantics=semantics,
+        )
+        result.detection_box = DetectionBox(
+            display_index=0,
+            raw_index=0,
+            xyxy=(10.0, 10.0, 50.0, 50.0),
+            score=0.9,
+            label_index=predicted_label_id,
+            label_name=None,
+        )
+        result.original_sample_index = 0
+        yield result
+
+    class _FakeExplainer:
+        algorithm = "IntegratedGradients"
+
+        def check_backend_compat(self, backend: object) -> None:
+            return None
+
+    with (
+        patch(
+            "raitap.pipeline.phases.assess_transparency.Explanation",
+            side_effect=AssertionError("classification path should not run"),
+        ),
+        patch(
+            "raitap.transparency.factory.create_explainer",
+            return_value=(_FakeExplainer(), "raitap.transparency.CaptumExplainer"),
+        ),
+        patch(
+            "raitap.transparency.factory.create_visualisers",
+            return_value=[ConfiguredVisualiser(DetectionImageVisualiser())],
+        ),
+        patch(
+            "raitap.transparency.factory.check_explainer_visualiser_compat",
+            return_value=None,
+        ),
+        patch(
+            "raitap.transparency.factory.check_explainer_visualiser_payload_compat",
+            return_value=None,
+        ),
+        patch(
+            "raitap.transparency.factory.check_explainer_visualiser_semantic_compat",
+            return_value=None,
+        ),
+        patch(
+            "raitap.pipeline.phases.explain_detection.explain_detection",
+            side_effect=fake_explain_detection,
+        ),
+    ):
+        explanations, visualisations = assess_transparency(
+            config,
+            model,  # type: ignore[arg-type]
+            data,  # type: ignore[arg-type]
+            forward,
+            input_metadata=None,
+            resolved_preprocessing=None,
+        )
+
+    # GT match reached the in-memory box: evaluated, matched, true class = GT (20).
+    box = explanations[0].detection_box
+    assert box is not None
+    assert box.gt_evaluated is True
+    assert box.true_label_index == gt_label_id
+    assert box.true_label_name == f"c{gt_label_id}"
+    assert box.true_match_iou == pytest.approx(1.0)
+    # And the GT clause reached a RENDERED per-box title.
+    titles = [v.figure.axes[0].get_title() for v in visualisations if hasattr(v, "figure")]
+    assert any(f"gt: c{gt_label_id} (IoU 1.00)" in t for t in titles)
 
 
 def test_assess_transparency_detection_skips_when_no_explainers(tmp_path: Path) -> None:

--- a/src/raitap/pipeline/phases/tests/test_assess_transparency_detection.py
+++ b/src/raitap/pipeline/phases/tests/test_assess_transparency_detection.py
@@ -311,13 +311,16 @@ def test_detection_transparency_renders_class_name_end_to_end(tmp_path: Path) ->
             resolved_preprocessing=None,
         )
 
-    # In-memory box was enriched before visualise().
+    # Caller enrichment populated the in-memory box that the report builder
+    # later reads for the heading + overlay.
     assert any(
         e.detection_box is not None and e.detection_box.label_name == "kite" for e in explanations
     )
-    # And the enriched name reached a RENDERED per-box title (downstream of visualise()).
+    # The render path ran end-to-end through the real visualiser and produced a
+    # figure with NO title (label/score/GT live on the overlay + heading only).
     titles = [v.figure.axes[0].get_title() for v in visualisations if hasattr(v, "figure")]
-    assert any("kite" in t for t in titles)
+    assert titles  # at least one per-box figure rendered
+    assert all(t == "" for t in titles)
 
 
 def test_detection_transparency_matches_ground_truth_end_to_end(tmp_path: Path) -> None:
@@ -459,15 +462,18 @@ def test_detection_transparency_matches_ground_truth_end_to_end(tmp_path: Path) 
         )
 
     # GT match reached the in-memory box: evaluated, matched, true class = GT (20).
+    # The builder renders this on the heading + overlay; the per-box figure has
+    # no title (asserted below), so the GT detail is carried by the box itself.
     box = explanations[0].detection_box
     assert box is not None
     assert box.gt_evaluated is True
     assert box.true_label_index == gt_label_id
     assert box.true_label_name == f"c{gt_label_id}"
     assert box.true_match_iou == pytest.approx(1.0)
-    # And the GT clause reached a RENDERED per-box title.
+    # The render path ran and produced a title-less figure.
     titles = [v.figure.axes[0].get_title() for v in visualisations if hasattr(v, "figure")]
-    assert any(f"gt: c{gt_label_id} (IoU 1.00)" in t for t in titles)
+    assert titles
+    assert all(t == "" for t in titles)
 
 
 def test_assess_transparency_detection_skips_when_no_explainers(tmp_path: Path) -> None:

--- a/src/raitap/pipeline/phases/tests/test_assess_transparency_detection.py
+++ b/src/raitap/pipeline/phases/tests/test_assess_transparency_detection.py
@@ -176,9 +176,10 @@ def test_assess_transparency_routes_detection_kind_to_explain_detection(
 
 def test_detection_transparency_renders_class_name_end_to_end(tmp_path: Path) -> None:
     """Caller-side enrichment must fill ``DetectionBox.label_name`` from the
-    resolved category-names table BEFORE ``result.visualise()`` renders the
-    figure, so a configured class name reaches both the in-memory box and the
-    rendered per-box title.
+    resolved category-names table BEFORE ``result.visualise()`` runs, so the
+    configured class name lands on the in-memory box that the report builder
+    later reads for the heading + overlay. The per-box figure itself stays
+    title-less (asserted below).
 
     ``explain_detection`` is mocked to yield a *real* ``ExplanationResult`` that
     carries a raw box (``label_name=None``) plus a real
@@ -326,12 +327,13 @@ def test_detection_transparency_renders_class_name_end_to_end(tmp_path: Path) ->
 
 def test_detection_transparency_matches_ground_truth_end_to_end(tmp_path: Path) -> None:
     """When ``data.labels`` carries detection GT, the caller matches each box to
-    GT by IoU and the true label + match IoU reach the in-memory box AND the
-    rendered title — exercising the caller GT-wiring branch (positional lookup,
-    bounds guard, threshold pass-through), not just ``enrich_detection_box`` in
-    isolation. The GT class (20) differs from the predicted class (7) so the
-    class-agnostic match surfaces a disagreement, which is the point of the
-    feature."""
+    GT by IoU and the true label + match IoU land on the in-memory box (which the
+    report builder renders on the heading + overlay) — exercising the caller
+    GT-wiring branch (positional lookup, bounds guard, threshold pass-through),
+    not just ``enrich_detection_box`` in isolation. The per-box figure stays
+    title-less (asserted below). The GT class (20) differs from the predicted
+    class (7) so the class-agnostic match surfaces a disagreement, which is the
+    point of the feature."""
     from raitap.transparency.contracts import (
         DetectionBox,
         ExplanationOutputSpace,

--- a/src/raitap/pipeline/phases/tests/test_assess_transparency_detection.py
+++ b/src/raitap/pipeline/phases/tests/test_assess_transparency_detection.py
@@ -321,6 +321,7 @@ def test_detection_transparency_renders_class_name_end_to_end(tmp_path: Path) ->
     titles = [v.figure.axes[0].get_title() for v in visualisations if hasattr(v, "figure")]
     assert titles  # at least one per-box figure rendered
     assert all(t == "" for t in titles)
+    assert all(not v.figure.texts for v in visualisations if hasattr(v, "figure"))  # no suptitle
 
 
 def test_detection_transparency_matches_ground_truth_end_to_end(tmp_path: Path) -> None:
@@ -474,6 +475,72 @@ def test_detection_transparency_matches_ground_truth_end_to_end(tmp_path: Path) 
     titles = [v.figure.axes[0].get_title() for v in visualisations if hasattr(v, "figure")]
     assert titles
     assert all(t == "" for t in titles)
+    assert all(not v.figure.texts for v in visualisations if hasattr(v, "figure"))  # no suptitle
+
+
+def test_detection_per_box_figure_has_no_suptitle_with_sample_names(tmp_path: Path) -> None:
+    # Regression guard (#233): with the axis title removed, the sample-name
+    # suptitle fallback in ExplanationResult.visualise must stay suppressed for
+    # detection per-box figures even when show_sample_names is on — they are
+    # title-less by design (info lives on the overlay + heading).
+    from raitap.transparency.contracts import (
+        DetectionBox,
+        ExplanationOutputSpace,
+        ExplanationPayloadKind,
+        ExplanationScope,
+        InputSpec,
+        MethodFamily,
+        OutputSpaceSpec,
+        ScopeDefinitionStep,
+    )
+    from raitap.transparency.results import (
+        ConfiguredVisualiser,
+        ExplanationResult,
+        ExplanationSemantics,
+    )
+    from raitap.transparency.visualisers.detection_image_visualiser import (
+        DetectionImageVisualiser,
+    )
+
+    sem = ExplanationSemantics(
+        scope=ExplanationScope.LOCAL,
+        scope_definition_step=ScopeDefinitionStep.EXPLAINER_OUTPUT,
+        payload_kind=ExplanationPayloadKind.ATTRIBUTIONS,
+        method_families=frozenset({MethodFamily.GRADIENT}),
+        target=None,
+        sample_selection=None,
+        input_spec=InputSpec(kind="image", shape=(1, 3, 32, 32), layout="NCHW"),
+        output_space=OutputSpaceSpec(
+            space=ExplanationOutputSpace.DETECTION_BOXES, shape=(1, 3, 32, 32), layout="NCHW"
+        ),
+    )
+    result = ExplanationResult(
+        attributions=torch.zeros(1, 3, 32, 32),
+        inputs=torch.rand(1, 3, 32, 32),
+        run_dir=tmp_path / "box_0",
+        experiment_name="x",
+        explainer_target="t",
+        algorithm="IntegratedGradients",
+        explainer_name="ig",
+        semantics=sem,
+        visualisers=[ConfiguredVisualiser(DetectionImageVisualiser())],
+        kwargs={"show_sample_names": True, "sample_names": ["street.jpg"]},
+    )
+    result.detection_box = DetectionBox(
+        display_index=0,
+        raw_index=0,
+        xyxy=(2, 3, 22, 23),
+        score=0.9,
+        label_index=1,
+        label_name="kite",
+    )
+    result.original_sample_index = 0
+
+    vis_results = result.visualise()
+    assert vis_results
+    for vr in vis_results:
+        assert vr.figure.axes[0].get_title() == ""
+        assert vr.figure.texts == []  # no sample-name suptitle leaked in
 
 
 def test_assess_transparency_detection_skips_when_no_explainers(tmp_path: Path) -> None:

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -715,7 +715,13 @@ def _detection_box_heading(box: DetectionBox) -> str:
         ground_truth_clause = "no match"
     else:
         ground_truth_name = box.true_label_name or f"class {box.true_label_index}"
-        ground_truth_clause = f"{ground_truth_name} (IoU {box.true_match_iou:.2f})"
+        # ``true_match_iou`` is normally set alongside the index by the matcher;
+        # guard the format in case a caller populates only the label.
+        ground_truth_clause = (
+            f"{ground_truth_name} (IoU {box.true_match_iou:.2f})"
+            if box.true_match_iou is not None
+            else ground_truth_name
+        )
     return f"pred: {label} {box.score:.2f} | gt: {ground_truth_clause}"
 
 
@@ -1175,6 +1181,8 @@ def _overlay_legend_line(box: DetectionBox) -> str:
     if box.true_label_index is None:
         return f"{base} | gt: no match"
     ground_truth_name = box.true_label_name or f"class {box.true_label_index}"
+    if box.true_match_iou is None:  # label without a match IoU — show name alone
+        return f"{base} | gt: {ground_truth_name}"
     return f"{base} | gt: {ground_truth_name} (IoU {box.true_match_iou:.2f})"
 
 

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -1121,6 +1121,9 @@ def _overlay_detection_boxes(figure: Any, *, outputs: RunOutputs, sample_index: 
     if not axes:
         return
     ax = axes[0]
+    # On the image: only a compact ``#index`` tag per box (anchored inside its
+    # top-left corner) so labels never collide when boxes are close. The full
+    # per-box detail goes in a legend below the image, keyed by the same index.
     for box in boxes:
         x1, y1, x2, y2 = box.xyxy
         ax.add_patch(
@@ -1133,25 +1136,46 @@ def _overlay_detection_boxes(figure: Any, *, outputs: RunOutputs, sample_index: 
                 facecolor="none",
             )
         )
-        label = box.label_name or f"class {box.label_index}"
-        if box.gt_evaluated and box.true_label_index is not None:
-            gt_name = box.true_label_name or f"class {box.true_label_index}"
-            overlay_text = (
-                f"#{box.display_index} {label} ({box.score:.2f}) "
-                f"| gt: {gt_name} (IoU {box.true_match_iou:.2f})"
-            )
-        elif box.gt_evaluated:
-            overlay_text = f"#{box.display_index} {label} ({box.score:.2f}) | gt: no match"
-        else:
-            overlay_text = f"#{box.display_index} {label} ({box.score:.2f})"
         ax.text(
-            x1,
-            max(y1 - 4, 4),
-            overlay_text,
-            color="lime",
-            fontsize=7,
-            bbox={"facecolor": "black", "alpha": 0.55, "pad": 1, "edgecolor": "none"},
+            x1 + 2,
+            y1 + 2,
+            f"#{box.display_index}",
+            color="black",
+            fontsize=8,
+            fontweight="bold",
+            va="top",
+            ha="left",
+            bbox={"facecolor": "lime", "alpha": 0.9, "pad": 1, "edgecolor": "none"},
         )
+    # Legend below the image (``bbox_inches="tight"`` at save time keeps it in
+    # frame). One line per box; close boxes stay legible because their detail
+    # lives here, not stacked on the image.
+    legend = "\n".join(_overlay_legend_line(box) for box in boxes)
+    ax.text(
+        0.0,
+        -0.02,
+        legend,
+        transform=ax.transAxes,
+        va="top",
+        ha="left",
+        fontsize=7,
+        family="monospace",
+        color="#222222",
+        bbox={"facecolor": "white", "edgecolor": "#bbbbbb", "boxstyle": "round,pad=0.4"},
+        clip_on=False,
+    )
+
+
+def _overlay_legend_line(box: DetectionBox) -> str:
+    """One legend row for a detection box: ``#i name (score) [| gt: ...]``."""
+    label = box.label_name or f"class {box.label_index}"
+    base = f"#{box.display_index} {label} ({box.score:.2f})"
+    if not box.gt_evaluated:
+        return base
+    if box.true_label_index is None:
+        return f"{base} | gt: no match"
+    gt_name = box.true_label_name or f"class {box.true_label_index}"
+    return f"{base} | gt: {gt_name} (IoU {box.true_match_iou:.2f})"
 
 
 # Human-facing labels for the baseline ``mode`` token. The raw token is kept in

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -709,14 +709,14 @@ def _detection_box_heading(box: DetectionBox) -> str:
     with no GT, the legacy ``label, score=..`` form is unchanged.
     """
     label = box.label_name or f"class {box.label_index}"
-    if not box.gt_evaluated:
+    if not box.ground_truth_evaluated:
         return f"{label}, score={box.score:.2f}"
     if box.true_label_index is None:
-        gt_clause = "no match"
+        ground_truth_clause = "no match"
     else:
-        gt_name = box.true_label_name or f"class {box.true_label_index}"
-        gt_clause = f"{gt_name} (IoU {box.true_match_iou:.2f})"
-    return f"pred: {label} {box.score:.2f} | gt: {gt_clause}"
+        ground_truth_name = box.true_label_name or f"class {box.true_label_index}"
+        ground_truth_clause = f"{ground_truth_name} (IoU {box.true_match_iou:.2f})"
+    return f"pred: {label} {box.score:.2f} | gt: {ground_truth_clause}"
 
 
 def _build_local_section(
@@ -842,7 +842,7 @@ def _build_local_section(
                         "label_index": detection_box.label_index,
                         "label_name": detection_box.label_name,
                         "xyxy": list(detection_box.xyxy),
-                        "gt_evaluated": detection_box.gt_evaluated,
+                        "ground_truth_evaluated": detection_box.ground_truth_evaluated,
                         "true_label_index": detection_box.true_label_index,
                         "true_label_name": detection_box.true_label_name,
                         "true_match_iou": detection_box.true_match_iou,
@@ -1170,12 +1170,12 @@ def _overlay_legend_line(box: DetectionBox) -> str:
     """One legend row for a detection box: ``#i name (score) [| gt: ...]``."""
     label = box.label_name or f"class {box.label_index}"
     base = f"#{box.display_index} {label} ({box.score:.2f})"
-    if not box.gt_evaluated:
+    if not box.ground_truth_evaluated:
         return base
     if box.true_label_index is None:
         return f"{base} | gt: no match"
-    gt_name = box.true_label_name or f"class {box.true_label_index}"
-    return f"{base} | gt: {gt_name} (IoU {box.true_match_iou:.2f})"
+    ground_truth_name = box.true_label_name or f"class {box.true_label_index}"
+    return f"{base} | gt: {ground_truth_name} (IoU {box.true_match_iou:.2f})"
 
 
 # Human-facing labels for the baseline ``mode`` token. The raw token is kept in

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -704,7 +704,7 @@ def _detection_box_heading(box: DetectionBox) -> str:
     """One-line ``Box`` heading clause: predicted label + optional ground-truth match.
 
     Shows the ``gt:`` clause only when GT was evaluated for the box's sample —
-    a matched box reads ``pred: X 0.99 | gt: Y, IoU=..``; a no-match box reads
+    a matched box reads ``pred: X 0.99 | gt: Y (IoU ..)``; a no-match box reads
     ``| gt: no match`` (neutral, not "false positive" — GT may be incomplete);
     with no GT, the legacy ``label, score=..`` form is unchanged.
     """
@@ -715,7 +715,7 @@ def _detection_box_heading(box: DetectionBox) -> str:
         gt_clause = "no match"
     else:
         gt_name = box.true_label_name or f"class {box.true_label_index}"
-        gt_clause = f"{gt_name}, IoU={box.true_match_iou:.2f}"
+        gt_clause = f"{gt_name} (IoU {box.true_match_iou:.2f})"
     return f"pred: {label} {box.score:.2f} | gt: {gt_clause}"
 
 

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -25,7 +25,7 @@ from raitap.robustness.contracts import (
     PerturbationDistribution,
     ReportFigureScope,
 )
-from raitap.transparency.contracts import ExplanationScope, VisualisationContext
+from raitap.transparency.contracts import DetectionBox, ExplanationScope, VisualisationContext
 from raitap.transparency.visualisers import BaseVisualiser, InputThumbnailVisualiser
 
 from .filenames import report_output_filename
@@ -700,6 +700,25 @@ def _native_scope_groups(
     ]
 
 
+def _detection_box_heading(box: DetectionBox) -> str:
+    """One-line ``Box`` heading clause: predicted label + optional ground-truth match.
+
+    Shows the ``gt:`` clause only when GT was evaluated for the box's sample —
+    a matched box reads ``pred: X 0.99 | gt: Y, IoU=..``; a no-match box reads
+    ``| gt: no match`` (neutral, not "false positive" — GT may be incomplete);
+    with no GT, the legacy ``label, score=..`` form is unchanged.
+    """
+    label = box.label_name or f"class {box.label_index}"
+    if not box.gt_evaluated:
+        return f"{label}, score={box.score:.2f}"
+    if box.true_label_index is None:
+        gt_clause = "no match"
+    else:
+        gt_name = box.true_label_name or f"class {box.true_label_index}"
+        gt_clause = f"{gt_name}, IoU={box.true_match_iou:.2f}"
+    return f"pred: {label} {box.score:.2f} | gt: {gt_clause}"
+
+
 def _build_local_section(
     outputs: RunOutputs,
     *,
@@ -812,10 +831,9 @@ def _build_local_section(
                 }
                 heading_box_part = ""
                 if detection_box is not None:
-                    label = detection_box.label_name or f"class {detection_box.label_index}"
                     heading_box_part = (
                         f" - Box {detection_box.display_index}"
-                        f" ({label}, score={detection_box.score:.2f})"
+                        f" ({_detection_box_heading(detection_box)})"
                     )
                     metadata["detection_box"] = {
                         "display_index": detection_box.display_index,
@@ -824,6 +842,10 @@ def _build_local_section(
                         "label_index": detection_box.label_index,
                         "label_name": detection_box.label_name,
                         "xyxy": list(detection_box.xyxy),
+                        "gt_evaluated": detection_box.gt_evaluated,
+                        "true_label_index": detection_box.true_label_index,
+                        "true_label_name": detection_box.true_label_name,
+                        "true_match_iou": detection_box.true_match_iou,
                     }
                 visualiser_title = getattr(configured.visualiser, "title", None)
                 if visualiser_title:
@@ -1112,10 +1134,20 @@ def _overlay_detection_boxes(figure: Any, *, outputs: RunOutputs, sample_index: 
             )
         )
         label = box.label_name or f"class {box.label_index}"
+        if box.gt_evaluated and box.true_label_index is not None:
+            gt_name = box.true_label_name or f"class {box.true_label_index}"
+            overlay_text = (
+                f"#{box.display_index} {label} ({box.score:.2f}) "
+                f"| gt: {gt_name} (IoU {box.true_match_iou:.2f})"
+            )
+        elif box.gt_evaluated:
+            overlay_text = f"#{box.display_index} {label} ({box.score:.2f}) | gt: no match"
+        else:
+            overlay_text = f"#{box.display_index} {label} ({box.score:.2f})"
         ax.text(
             x1,
             max(y1 - 4, 4),
-            f"#{box.display_index} {label} ({box.score:.2f})",
+            overlay_text,
             color="lime",
             fontsize=7,
             bbox={"facecolor": "black", "alpha": 0.55, "pad": 1, "edgecolor": "none"},

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -20,6 +20,8 @@ from raitap.reporting.builder import (
     _canonical_facet_owners,
     _copy_asset,
     _detection_box_heading,
+    _overlay_detection_boxes,
+    _overlay_legend_line,
     _render_kwargs_for_robustness_visualiser,
     build_merged_report,
     build_report,
@@ -2475,3 +2477,90 @@ def test_detection_heading_no_gt_unchanged() -> None:
     h = _detection_box_heading(box)
     assert "gt:" not in h
     assert "kite, score=0.99" in h
+
+
+def _det_box(
+    *,
+    display_index: int,
+    label_name: str,
+    score: float,
+    gt_evaluated: bool = False,
+    true_label_name: str | None = None,
+    true_label_index: int | None = None,
+    true_match_iou: float | None = None,
+) -> DetectionBox:
+    return DetectionBox(
+        display_index=display_index,
+        raw_index=display_index,
+        xyxy=(10.0, 10.0, 40.0, 40.0),
+        score=score,
+        label_index=1,
+        label_name=label_name,
+        gt_evaluated=gt_evaluated,
+        true_label_name=true_label_name,
+        true_label_index=true_label_index,
+        true_match_iou=true_match_iou,
+    )
+
+
+def test_overlay_legend_line_covers_all_branches() -> None:
+    matched = _det_box(
+        display_index=0,
+        label_name="kite",
+        score=0.99,
+        gt_evaluated=True,
+        true_label_name="sheep",
+        true_label_index=3,
+        true_match_iou=0.71,
+    )
+    assert _overlay_legend_line(matched) == "#0 kite (0.99) | gt: sheep (IoU 0.71)"
+    no_match = _det_box(display_index=1, label_name="dog", score=0.92, gt_evaluated=True)
+    assert _overlay_legend_line(no_match) == "#1 dog (0.92) | gt: no match"
+    no_gt = _det_box(display_index=2, label_name="boat", score=0.81)
+    assert _overlay_legend_line(no_gt) == "#2 boat (0.81)"
+
+
+class _DetExpl:
+    def __init__(self, box: DetectionBox, sample_index: int) -> None:
+        self.detection_box = box
+        self.original_sample_index = sample_index
+
+
+class _DetOutputs:
+    def __init__(self, explanations: list[_DetExpl]) -> None:
+        self.explanations = explanations
+
+
+def test_overlay_draws_index_tags_and_legend_below_image() -> None:
+    # Two clustered boxes on one sample: the image carries only compact #i tags
+    # (no long labels that would collide), and one legend text holds both full
+    # lines keyed by index.
+    box0 = _det_box(
+        display_index=0,
+        label_name="kite",
+        score=0.99,
+        gt_evaluated=True,
+        true_label_name="kite",
+        true_label_index=1,
+        true_match_iou=0.83,
+    )
+    box1 = _det_box(display_index=1, label_name="dog", score=0.92, gt_evaluated=True)
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    ax.imshow(torch.zeros(50, 50, 3).numpy())
+    _overlay_detection_boxes(
+        fig,
+        outputs=_DetOutputs([_DetExpl(box0, 0), _DetExpl(box1, 0)]),  # type: ignore[arg-type]
+        sample_index=0,
+    )
+    texts = [t.get_text() for t in ax.texts]
+    # compact tags on the image
+    assert "#0" in texts
+    assert "#1" in texts
+    # full detail in a single legend text, both lines, keyed by index
+    legend = next(t for t in texts if "\n" in t)
+    assert "#0 kite (0.99) | gt: kite (IoU 0.83)" in legend
+    assert "#1 dog (0.92) | gt: no match" in legend
+    # no long per-box label is stamped beside the boxes (only tags + legend)
+    assert not any(t.startswith("#0 kite") for t in texts if "\n" not in t)
+    plt.close(fig)

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -2443,7 +2443,7 @@ def test_detection_heading_matched_gt() -> None:
         score=0.99,
         label_index=38,
         label_name="kite",
-        gt_evaluated=True,
+        ground_truth_evaluated=True,
         true_label_index=20,
         true_label_name="sheep",
         true_match_iou=0.71,
@@ -2460,7 +2460,7 @@ def test_detection_heading_no_match() -> None:
         score=0.99,
         label_index=38,
         label_name="kite",
-        gt_evaluated=True,
+        ground_truth_evaluated=True,
     )
     assert "gt: no match" in _detection_box_heading(box)
 
@@ -2484,7 +2484,7 @@ def _det_box(
     display_index: int,
     label_name: str,
     score: float,
-    gt_evaluated: bool = False,
+    ground_truth_evaluated: bool = False,
     true_label_name: str | None = None,
     true_label_index: int | None = None,
     true_match_iou: float | None = None,
@@ -2496,7 +2496,7 @@ def _det_box(
         score=score,
         label_index=1,
         label_name=label_name,
-        gt_evaluated=gt_evaluated,
+        ground_truth_evaluated=ground_truth_evaluated,
         true_label_name=true_label_name,
         true_label_index=true_label_index,
         true_match_iou=true_match_iou,
@@ -2508,13 +2508,13 @@ def test_overlay_legend_line_covers_all_branches() -> None:
         display_index=0,
         label_name="kite",
         score=0.99,
-        gt_evaluated=True,
+        ground_truth_evaluated=True,
         true_label_name="sheep",
         true_label_index=3,
         true_match_iou=0.71,
     )
     assert _overlay_legend_line(matched) == "#0 kite (0.99) | gt: sheep (IoU 0.71)"
-    no_match = _det_box(display_index=1, label_name="dog", score=0.92, gt_evaluated=True)
+    no_match = _det_box(display_index=1, label_name="dog", score=0.92, ground_truth_evaluated=True)
     assert _overlay_legend_line(no_match) == "#1 dog (0.92) | gt: no match"
     no_gt = _det_box(display_index=2, label_name="boat", score=0.81)
     assert _overlay_legend_line(no_gt) == "#2 boat (0.81)"
@@ -2539,12 +2539,12 @@ def test_overlay_draws_index_tags_and_legend_below_image() -> None:
         display_index=0,
         label_name="kite",
         score=0.99,
-        gt_evaluated=True,
+        ground_truth_evaluated=True,
         true_label_name="kite",
         true_label_index=1,
         true_match_iou=0.83,
     )
-    box1 = _det_box(display_index=1, label_name="dog", score=0.92, gt_evaluated=True)
+    box1 = _det_box(display_index=1, label_name="dog", score=0.92, ground_truth_evaluated=True)
     fig = plt.figure()
     ax = fig.add_subplot(111)
     ax.imshow(torch.zeros(50, 50, 3).numpy())

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -2452,6 +2452,22 @@ def test_detection_heading_matched_gt() -> None:
     assert "gt: sheep (IoU 0.71)" in _detection_box_heading(box)
 
 
+def test_detection_heading_matched_gt_without_iou() -> None:
+    # Defensive: true label set but no match IoU -> name shown, no "(IoU ...)".
+    box = DetectionBox(
+        display_index=0,
+        raw_index=2,
+        xyxy=(0, 0, 1, 1),
+        score=0.99,
+        label_index=38,
+        label_name="kite",
+        ground_truth_evaluated=True,
+        true_label_index=20,
+        true_label_name="sheep",
+    )
+    assert _detection_box_heading(box) == "pred: kite 0.99 | gt: sheep"
+
+
 def test_detection_heading_no_match() -> None:
     box = DetectionBox(
         display_index=0,
@@ -2518,6 +2534,16 @@ def test_overlay_legend_line_covers_all_branches() -> None:
     assert _overlay_legend_line(no_match) == "#1 dog (0.92) | gt: no match"
     no_gt = _det_box(display_index=2, label_name="boat", score=0.81)
     assert _overlay_legend_line(no_gt) == "#2 boat (0.81)"
+    # Defensive: a true label without a match IoU shows the name, no "(IoU ...)".
+    label_only = _det_box(
+        display_index=3,
+        label_name="cat",
+        score=0.7,
+        ground_truth_evaluated=True,
+        true_label_name="cat",
+        true_label_index=5,
+    )
+    assert _overlay_legend_line(label_only) == "#3 cat (0.70) | gt: cat"
 
 
 class _DetExpl:

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -2447,7 +2447,7 @@ def test_detection_heading_matched_gt() -> None:
         true_match_iou=0.71,
     )
     assert "pred: kite 0.99" in _detection_box_heading(box)
-    assert "gt: sheep, IoU=0.71" in _detection_box_heading(box)
+    assert "gt: sheep (IoU 0.71)" in _detection_box_heading(box)
 
 
 def test_detection_heading_no_match() -> None:

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -19,6 +19,7 @@ from raitap.reporting.builder import (
     BuiltReport,
     _canonical_facet_owners,
     _copy_asset,
+    _detection_box_heading,
     _render_kwargs_for_robustness_visualiser,
     build_merged_report,
     build_report,
@@ -49,6 +50,7 @@ from raitap.robustness.results import (
 from raitap.robustness.visualisers import ImagePairVisualiser, PerturbationHeatmapVisualiser
 from raitap.robustness.visualisers.base_visualiser import BaseRobustnessVisualiser
 from raitap.transparency.contracts import (
+    DetectionBox,
     ExplanationOutputSpace,
     ExplanationPayloadKind,
     ExplanationScope,
@@ -2424,3 +2426,52 @@ def test_build_report_attaches_baseline_image_once_per_explanation(tmp_path: Pat
     # Two visualisers -> two local_visualiser groups, but the baseline renders once.
     assert len(local_vis_groups) == 2
     assert len(baseline_imgs) == 1
+
+
+# ---------------------------------------------------------------------------
+# _detection_box_heading unit tests (issue #233)
+# ---------------------------------------------------------------------------
+
+
+def test_detection_heading_matched_gt() -> None:
+    box = DetectionBox(
+        display_index=0,
+        raw_index=2,
+        xyxy=(0, 0, 1, 1),
+        score=0.99,
+        label_index=38,
+        label_name="kite",
+        gt_evaluated=True,
+        true_label_index=20,
+        true_label_name="sheep",
+        true_match_iou=0.71,
+    )
+    assert "pred: kite 0.99" in _detection_box_heading(box)
+    assert "gt: sheep, IoU=0.71" in _detection_box_heading(box)
+
+
+def test_detection_heading_no_match() -> None:
+    box = DetectionBox(
+        display_index=0,
+        raw_index=2,
+        xyxy=(0, 0, 1, 1),
+        score=0.99,
+        label_index=38,
+        label_name="kite",
+        gt_evaluated=True,
+    )
+    assert "gt: no match" in _detection_box_heading(box)
+
+
+def test_detection_heading_no_gt_unchanged() -> None:
+    box = DetectionBox(
+        display_index=0,
+        raw_index=2,
+        xyxy=(0, 0, 1, 1),
+        score=0.99,
+        label_index=38,
+        label_name="kite",
+    )
+    h = _detection_box_heading(box)
+    assert "gt:" not in h
+    assert "kite, score=0.99" in h

--- a/src/raitap/transparency/contracts.py
+++ b/src/raitap/transparency/contracts.py
@@ -234,13 +234,13 @@ class DetectionBox:
     score: float
     label_index: int
     label_name: str | None = None
-    # Ground-truth match (issue #233 Part 2). ``gt_evaluated`` is True whenever
+    # Ground-truth match (issue #233 Part 2). ``ground_truth_evaluated`` is True whenever
     # GT was available for this box's sample (so an unmatched box is a genuine
     # false positive, distinct from "no GT configured"). When matched,
     # ``true_label_index`` / ``true_label_name`` / ``true_match_iou`` describe the
     # highest-IoU GT box (class-agnostic match). All three stay None on a false
-    # positive (gt_evaluated True, no match) and when GT is absent.
-    gt_evaluated: bool = False
+    # positive (ground_truth_evaluated True, no match) and when GT is absent.
+    ground_truth_evaluated: bool = False
     true_label_index: int | None = None
     true_label_name: str | None = None
     true_match_iou: float | None = None

--- a/src/raitap/transparency/contracts.py
+++ b/src/raitap/transparency/contracts.py
@@ -234,6 +234,16 @@ class DetectionBox:
     score: float
     label_index: int
     label_name: str | None = None
+    # Ground-truth match (issue #233 Part 2). ``gt_evaluated`` is True whenever
+    # GT was available for this box's sample (so an unmatched box is a genuine
+    # false positive, distinct from "no GT configured"). When matched,
+    # ``true_label_index`` / ``true_label_name`` / ``true_match_iou`` describe the
+    # highest-IoU GT box (class-agnostic match). All three stay None on a false
+    # positive (gt_evaluated True, no match) and when GT is absent.
+    gt_evaluated: bool = False
+    true_label_index: int | None = None
+    true_label_name: str | None = None
+    true_match_iou: float | None = None
 
 
 @dataclass(frozen=True)

--- a/src/raitap/transparency/detection_labels.py
+++ b/src/raitap/transparency/detection_labels.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    import torch
+
     from raitap.transparency.contracts import DetectionBox
 
 
@@ -53,3 +55,36 @@ def enrich_detection_box(
         box,
         label_name=label_name_for(box.label_index, category_names),
     )
+
+
+def match_box_to_gt(
+    pred_xyxy: tuple[float, float, float, float],
+    gt_boxes: torch.Tensor,
+    gt_labels: torch.Tensor,
+    iou_threshold: float,
+) -> tuple[int, float] | None:
+    """Class-agnostic best-IoU match of a predicted box to ground truth.
+
+    Returns ``(gt_label_index, iou)`` for the highest-IoU GT box at or above
+    ``iou_threshold``, else ``None`` (no match -> the prediction is a false
+    positive). Matching ignores class so "predicted X, truth Y" disagreements
+    surface; the GT class is reported, not required to equal the prediction.
+
+    ``gt_boxes`` is ``(M, 4)`` xyxy and ``gt_labels`` is ``(M,)`` int, both in
+    the same pixel space as ``pred_xyxy`` (the detection forward-pass space).
+
+    ``torch`` / ``torchvision`` are imported lazily here so the module's pure
+    name-resolution helpers stay importable without the optional torch extra.
+    """
+    import torch
+    from torchvision.ops import box_iou
+
+    if gt_boxes.numel() == 0:
+        return None
+    pred = torch.tensor([pred_xyxy], dtype=gt_boxes.dtype, device=gt_boxes.device)
+    ious = box_iou(pred, gt_boxes)[0]  # (M,)
+    best = int(ious.argmax().item())
+    best_iou = float(ious[best].item())
+    if best_iou < iou_threshold:
+        return None
+    return int(gt_labels[best].item()), best_iou

--- a/src/raitap/transparency/detection_labels.py
+++ b/src/raitap/transparency/detection_labels.py
@@ -43,7 +43,7 @@ def enrich_detection_box(
     box: DetectionBox,
     *,
     category_names: Sequence[str] | None = None,
-    gt_for_sample: dict[str, torch.Tensor] | None = None,
+    ground_truth_for_sample: dict[str, torch.Tensor] | None = None,
     iou_threshold: float = 0.5,
 ) -> DetectionBox:
     """Return *box* with display metadata resolved (predicted name + GT match).
@@ -53,19 +53,22 @@ def enrich_detection_box(
 
     - ``label_name`` is resolved from ``category_names`` (``None`` -> numeric id
       fallback downstream).
-    - When ``gt_for_sample`` is given (the sample's GT dict with ``boxes``/
+    - When ``ground_truth_for_sample`` is given (the sample's GT dict with ``boxes``/
       ``labels``), the box is matched to GT by class-agnostic IoU and
-      ``gt_evaluated`` is set ``True`` regardless of whether a match was found.
+      ``ground_truth_evaluated`` is set ``True`` regardless of whether a match was found.
       A match fills ``true_label_index`` / ``true_label_name`` / ``true_match_iou``;
-      no match leaves them ``None`` (a false positive). ``gt_for_sample=None``
-      means GT was not configured and leaves ``gt_evaluated`` ``False``.
+      no match leaves them ``None`` (a false positive). ``ground_truth_for_sample=None``
+      means GT was not configured and leaves ``ground_truth_evaluated`` ``False``.
     """
     true_label_index: int | None = None
     true_label_name: str | None = None
     true_match_iou: float | None = None
-    if gt_for_sample is not None:
-        match = match_box_to_gt(
-            box.xyxy, gt_for_sample["boxes"], gt_for_sample["labels"], iou_threshold
+    if ground_truth_for_sample is not None:
+        match = match_box_to_ground_truth(
+            box.xyxy,
+            ground_truth_for_sample["boxes"],
+            ground_truth_for_sample["labels"],
+            iou_threshold,
         )
         if match is not None:
             true_label_index, true_match_iou = match
@@ -73,27 +76,27 @@ def enrich_detection_box(
     return dataclasses.replace(
         box,
         label_name=label_name_for(box.label_index, category_names),
-        gt_evaluated=gt_for_sample is not None,
+        ground_truth_evaluated=ground_truth_for_sample is not None,
         true_label_index=true_label_index,
         true_label_name=true_label_name,
         true_match_iou=true_match_iou,
     )
 
 
-def match_box_to_gt(
+def match_box_to_ground_truth(
     pred_xyxy: tuple[float, float, float, float],
-    gt_boxes: torch.Tensor,
-    gt_labels: torch.Tensor,
+    ground_truth_boxes: torch.Tensor,
+    ground_truth_labels: torch.Tensor,
     iou_threshold: float,
 ) -> tuple[int, float] | None:
     """Class-agnostic best-IoU match of a predicted box to ground truth.
 
-    Returns ``(gt_label_index, iou)`` for the highest-IoU GT box at or above
+    Returns ``(ground_truth_label_index, iou)`` for the highest-IoU GT box at or above
     ``iou_threshold``, else ``None`` (no match -> the prediction is a false
     positive). Matching ignores class so "predicted X, truth Y" disagreements
     surface; the GT class is reported, not required to equal the prediction.
 
-    ``gt_boxes`` is ``(M, 4)`` xyxy and ``gt_labels`` is ``(M,)`` int, both in
+    ``ground_truth_boxes`` is ``(M, 4)`` xyxy and ``ground_truth_labels`` is ``(M,)`` int, both in
     the same pixel space as ``pred_xyxy`` (the detection forward-pass space).
 
     ``torch`` / ``torchvision`` are imported lazily here so the module's pure
@@ -102,12 +105,14 @@ def match_box_to_gt(
     import torch
     from torchvision.ops import box_iou
 
-    if gt_boxes.numel() == 0:
+    if ground_truth_boxes.numel() == 0:
         return None
-    pred = torch.tensor([pred_xyxy], dtype=gt_boxes.dtype, device=gt_boxes.device)
-    ious = box_iou(pred, gt_boxes)[0]  # (M,)
+    pred = torch.tensor(
+        [pred_xyxy], dtype=ground_truth_boxes.dtype, device=ground_truth_boxes.device
+    )
+    ious = box_iou(pred, ground_truth_boxes)[0]  # (M,)
     best = int(ious.argmax().item())
     best_iou = float(ious[best].item())
     if best_iou < iou_threshold:
         return None
-    return int(gt_labels[best].item()), best_iou
+    return int(ground_truth_labels[best].item()), best_iou

--- a/src/raitap/transparency/detection_labels.py
+++ b/src/raitap/transparency/detection_labels.py
@@ -43,17 +43,40 @@ def enrich_detection_box(
     box: DetectionBox,
     *,
     category_names: Sequence[str] | None = None,
+    gt_for_sample: dict[str, torch.Tensor] | None = None,
+    iou_threshold: float = 0.5,
 ) -> DetectionBox:
-    """Return *box* with display metadata resolved from the category-names table.
+    """Return *box* with display metadata resolved (predicted name + GT match).
 
-    Pure: no model, no I/O. ``explain_detection`` builds the raw box (prediction
-    geometry + ``label_index``); the transparency caller calls this to fill the
-    human-readable ``label_name`` before rendering. A later task extends this
-    helper with the ground-truth match (``gt_*`` params + fields).
+    Pure: no model, no I/O. ``explain_detection`` builds the raw box (geometry +
+    ``label_index``); the transparency caller calls this before rendering.
+
+    - ``label_name`` is resolved from ``category_names`` (``None`` -> numeric id
+      fallback downstream).
+    - When ``gt_for_sample`` is given (the sample's GT dict with ``boxes``/
+      ``labels``), the box is matched to GT by class-agnostic IoU and
+      ``gt_evaluated`` is set ``True`` regardless of whether a match was found.
+      A match fills ``true_label_index`` / ``true_label_name`` / ``true_match_iou``;
+      no match leaves them ``None`` (a false positive). ``gt_for_sample=None``
+      means GT was not configured and leaves ``gt_evaluated`` ``False``.
     """
+    true_label_index: int | None = None
+    true_label_name: str | None = None
+    true_match_iou: float | None = None
+    if gt_for_sample is not None:
+        match = match_box_to_gt(
+            box.xyxy, gt_for_sample["boxes"], gt_for_sample["labels"], iou_threshold
+        )
+        if match is not None:
+            true_label_index, true_match_iou = match
+            true_label_name = label_name_for(true_label_index, category_names)
     return dataclasses.replace(
         box,
         label_name=label_name_for(box.label_index, category_names),
+        gt_evaluated=gt_for_sample is not None,
+        true_label_index=true_label_index,
+        true_label_name=true_label_name,
+        true_match_iou=true_match_iou,
     )
 
 

--- a/src/raitap/transparency/detection_labels.py
+++ b/src/raitap/transparency/detection_labels.py
@@ -1,0 +1,34 @@
+"""Pure helpers for detection box labelling (issue #233).
+
+No I/O, no model, no GPU — keeps id->name resolution and box->GT matching
+unit-testable on synthetic tensors. ``resolve_category_names`` fixes source
+precedence (explicit config > backend weights.meta > None) in one place.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def resolve_category_names(
+    explicit: Sequence[str] | None,
+    backend_categories: Sequence[str] | None,
+) -> list[str] | None:
+    """Resolve the id->name table. Precedence: explicit config > backend > None."""
+    if explicit is not None:
+        return list(explicit)
+    if backend_categories is not None:
+        return list(backend_categories)
+    return None
+
+
+def label_name_for(index: int, names: Sequence[str] | None) -> str | None:
+    """Bounds-safe id->name lookup; ``None`` when no map or index out of range."""
+    if names is None:
+        return None
+    if 0 <= index < len(names):
+        return names[index]
+    return None

--- a/src/raitap/transparency/detection_labels.py
+++ b/src/raitap/transparency/detection_labels.py
@@ -7,10 +7,13 @@ precedence (explicit config > backend weights.meta > None) in one place.
 
 from __future__ import annotations
 
+import dataclasses
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from raitap.transparency.contracts import DetectionBox
 
 
 def resolve_category_names(
@@ -32,3 +35,21 @@ def label_name_for(index: int, names: Sequence[str] | None) -> str | None:
     if 0 <= index < len(names):
         return names[index]
     return None
+
+
+def enrich_detection_box(
+    box: DetectionBox,
+    *,
+    category_names: Sequence[str] | None = None,
+) -> DetectionBox:
+    """Return *box* with display metadata resolved from the category-names table.
+
+    Pure: no model, no I/O. ``explain_detection`` builds the raw box (prediction
+    geometry + ``label_index``); the transparency caller calls this to fill the
+    human-readable ``label_name`` before rendering. A later task extends this
+    helper with the ground-truth match (``gt_*`` params + fields).
+    """
+    return dataclasses.replace(
+        box,
+        label_name=label_name_for(box.label_index, category_names),
+    )

--- a/src/raitap/transparency/results.py
+++ b/src/raitap/transparency/results.py
@@ -197,6 +197,10 @@ class ExplanationResult(Trackable):
                 "score": self.detection_box.score,
                 "label_index": self.detection_box.label_index,
                 "label_name": self.detection_box.label_name,
+                "gt_evaluated": self.detection_box.gt_evaluated,
+                "true_label_index": self.detection_box.true_label_index,
+                "true_label_name": self.detection_box.true_label_name,
+                "true_match_iou": self.detection_box.true_match_iou,
             }
         if self.original_sample_index is not None:
             metadata["original_sample_index"] = self.original_sample_index

--- a/src/raitap/transparency/results.py
+++ b/src/raitap/transparency/results.py
@@ -266,10 +266,15 @@ class ExplanationResult(Trackable):
             # Standard visualise() call with context and library-specific kwargs
             figure = vis.visualise(attributions, inputs=inputs, context=context, **merged_call)
 
-            # Legacy fallback for visualisers that don't handle titles themselves via context
+            # Legacy fallback for visualisers that don't handle titles themselves via
+            # context. Detection per-box figures are title-less by design (label / score
+            # / GT live on the overlay + report heading), so they opt out — otherwise a
+            # sample-name suptitle would silently reappear now that the axis title was
+            # removed (issue #233).
             if (
                 show_sample_names
                 and sample_names
+                and self.detection_box is None
                 and not figure.texts
                 and not any(ax.get_title() for ax in figure.axes)
             ):
@@ -422,9 +427,12 @@ class ExplanationResult(Trackable):
             if visualiser_with_sample_index is not None:
                 visualiser_with_sample_index.sample_index = original_visualiser_sample_index
 
+        # Detection per-box figures opt out of the sample-name suptitle fallback —
+        # they are title-less by design (see the matching guard above, issue #233).
         if (
             show_sample_names
             and sample_names
+            and self.detection_box is None
             and not figure.texts
             and not any(ax.get_title() for ax in figure.axes)
         ):

--- a/src/raitap/transparency/results.py
+++ b/src/raitap/transparency/results.py
@@ -197,7 +197,7 @@ class ExplanationResult(Trackable):
                 "score": self.detection_box.score,
                 "label_index": self.detection_box.label_index,
                 "label_name": self.detection_box.label_name,
-                "gt_evaluated": self.detection_box.gt_evaluated,
+                "ground_truth_evaluated": self.detection_box.ground_truth_evaluated,
                 "true_label_index": self.detection_box.true_label_index,
                 "true_label_name": self.detection_box.true_label_name,
                 "true_match_iou": self.detection_box.true_match_iou,

--- a/src/raitap/transparency/tests/test_contracts.py
+++ b/src/raitap/transparency/tests/test_contracts.py
@@ -299,7 +299,7 @@ def test_detection_box_gt_fields_default_unset() -> None:
     assert box.true_label_index is None
     assert box.true_label_name is None
     assert box.true_match_iou is None
-    assert box.gt_evaluated is False
+    assert box.ground_truth_evaluated is False
 
 
 def test_detection_box_gt_fields_set() -> None:
@@ -315,8 +315,8 @@ def test_detection_box_gt_fields_set() -> None:
         true_label_index=20,
         true_label_name="sheep",
         true_match_iou=0.71,
-        gt_evaluated=True,
+        ground_truth_evaluated=True,
     )
     assert box.true_label_name == "sheep"
     assert box.true_match_iou == 0.71
-    assert box.gt_evaluated is True
+    assert box.ground_truth_evaluated is True

--- a/src/raitap/transparency/tests/test_contracts.py
+++ b/src/raitap/transparency/tests/test_contracts.py
@@ -290,3 +290,33 @@ def test_baseline_record_is_frozen_and_carries_descriptor() -> None:
     assert record.shape == (50, 3, 224, 224)
     with pytest.raises(dataclasses.FrozenInstanceError):
         record.mode = "zero"  # type: ignore[misc]  # frozen
+
+
+def test_detection_box_gt_fields_default_unset() -> None:
+    from raitap.transparency.contracts import DetectionBox
+
+    box = DetectionBox(display_index=0, raw_index=0, xyxy=(0, 0, 1, 1), score=0.9, label_index=38)
+    assert box.true_label_index is None
+    assert box.true_label_name is None
+    assert box.true_match_iou is None
+    assert box.gt_evaluated is False
+
+
+def test_detection_box_gt_fields_set() -> None:
+    from raitap.transparency.contracts import DetectionBox
+
+    box = DetectionBox(
+        display_index=0,
+        raw_index=0,
+        xyxy=(0, 0, 1, 1),
+        score=0.9,
+        label_index=38,
+        label_name="kite",
+        true_label_index=20,
+        true_label_name="sheep",
+        true_match_iou=0.71,
+        gt_evaluated=True,
+    )
+    assert box.true_label_name == "sheep"
+    assert box.true_match_iou == 0.71
+    assert box.gt_evaluated is True

--- a/src/raitap/transparency/tests/test_detection_image_visualiser.py
+++ b/src/raitap/transparency/tests/test_detection_image_visualiser.py
@@ -392,3 +392,93 @@ def test_untitled_visualiser_falls_back_to_class_index_group_name() -> None:
 
     untitled = DetectionImageVisualiser()
     assert _visualiser_group_name(untitled, 2) == "DetectionImageVisualiser_2"
+
+
+# ---------------------------------------------------------------------------
+# GT-label title tests
+# ---------------------------------------------------------------------------
+
+
+def _box_gt(
+    *,
+    label_name: str | None = "kite",
+    score: float = 0.99,
+    gt_evaluated: bool = False,
+    true_label_name: str | None = None,
+    true_label_index: int | None = None,
+    true_match_iou: float | None = None,
+) -> DetectionBox:
+    return DetectionBox(
+        display_index=0,
+        raw_index=0,
+        xyxy=(2.0, 3.0, 22.0, 23.0),
+        score=score,
+        label_index=1,
+        label_name=label_name,
+        gt_evaluated=gt_evaluated,
+        true_label_name=true_label_name,
+        true_label_index=true_label_index,
+        true_match_iou=true_match_iou,
+    )
+
+
+def test_title_includes_gt_when_matched() -> None:
+    vis = DetectionImageVisualiser()
+    inputs = torch.rand(1, 3, 32, 32)
+    attributions = torch.zeros_like(inputs)
+    ctx = VisualisationContext(
+        algorithm="x",
+        sample_names=None,
+        show_sample_names=False,
+        detection_box=_box_gt(
+            label_name="kite",
+            score=0.99,
+            gt_evaluated=True,
+            true_label_name="sheep",
+            true_label_index=3,
+            true_match_iou=0.71,
+        ),
+    )
+    fig = vis.visualise(attributions, inputs, context=ctx)
+    title = fig.axes[0].get_title()
+    assert "kite: 0.99" in title
+    assert "gt: sheep (IoU 0.71)" in title
+
+
+def test_title_no_match() -> None:
+    vis = DetectionImageVisualiser()
+    inputs = torch.rand(1, 3, 32, 32)
+    attributions = torch.zeros_like(inputs)
+    ctx = VisualisationContext(
+        algorithm="x",
+        sample_names=None,
+        show_sample_names=False,
+        detection_box=_box_gt(
+            label_name="kite",
+            score=0.99,
+            gt_evaluated=True,
+            true_label_index=None,
+        ),
+    )
+    fig = vis.visualise(attributions, inputs, context=ctx)
+    title = fig.axes[0].get_title()
+    assert "gt: no match" in title
+
+
+def test_title_unchanged_without_gt() -> None:
+    vis = DetectionImageVisualiser()
+    inputs = torch.rand(1, 3, 32, 32)
+    attributions = torch.zeros_like(inputs)
+    ctx = VisualisationContext(
+        algorithm="x",
+        sample_names=None,
+        show_sample_names=False,
+        detection_box=_box_gt(
+            label_name="kite",
+            score=0.99,
+            gt_evaluated=False,
+        ),
+    )
+    fig = vis.visualise(attributions, inputs, context=ctx)
+    title = fig.axes[0].get_title()
+    assert "gt:" not in title

--- a/src/raitap/transparency/tests/test_detection_image_visualiser.py
+++ b/src/raitap/transparency/tests/test_detection_image_visualiser.py
@@ -401,7 +401,7 @@ def test_visualiser_sets_no_title_even_with_ground_truth() -> None:
             score=0.99,
             label_index=1,
             label_name="kite",
-            gt_evaluated=True,
+            ground_truth_evaluated=True,
             true_label_name="sheep",
             true_label_index=3,
             true_match_iou=0.71,

--- a/src/raitap/transparency/tests/test_detection_image_visualiser.py
+++ b/src/raitap/transparency/tests/test_detection_image_visualiser.py
@@ -65,7 +65,9 @@ def test_visualiser_returns_figure_with_axis_limits_matching_image() -> None:
     assert abs(ylim[1] - ylim[0]) == pytest.approx(64.0, abs=2.0)
 
 
-def test_visualiser_title_carries_label_name_and_score() -> None:
+def test_visualiser_sets_no_title() -> None:
+    # The per-box figure carries no title: label / score / GT live only on the
+    # thumbnail overlay and the report heading, never duplicated on the figure.
     vis = DetectionImageVisualiser()
     inputs = torch.rand(1, 3, 32, 32)
     attributions = torch.zeros_like(inputs)
@@ -76,24 +78,7 @@ def test_visualiser_title_carries_label_name_and_score() -> None:
         detection_box=_box(label_name="car"),
     )
     fig = vis.visualise(attributions, inputs, context=ctx)
-    title = fig.get_axes()[0].get_title()
-    assert "car" in title
-    assert "0.87" in title
-
-
-def test_visualiser_falls_back_to_class_id_when_label_name_missing() -> None:
-    vis = DetectionImageVisualiser()
-    inputs = torch.rand(1, 3, 32, 32)
-    attributions = torch.zeros_like(inputs)
-    ctx = VisualisationContext(
-        algorithm="x",
-        sample_names=None,
-        show_sample_names=False,
-        detection_box=_box(label_name=None),
-    )
-    fig = vis.visualise(attributions, inputs, context=ctx)
-    title = fig.get_axes()[0].get_title()
-    assert "class 4" in title
+    assert fig.get_axes()[0].get_title() == ""
 
 
 def test_visualiser_raises_when_detection_box_missing() -> None:
@@ -395,34 +380,13 @@ def test_untitled_visualiser_falls_back_to_class_index_group_name() -> None:
 
 
 # ---------------------------------------------------------------------------
-# GT-label title tests
+# No-title invariant (GT info lives on the overlay + report heading, not here)
 # ---------------------------------------------------------------------------
 
 
-def _box_gt(
-    *,
-    label_name: str | None = "kite",
-    score: float = 0.99,
-    gt_evaluated: bool = False,
-    true_label_name: str | None = None,
-    true_label_index: int | None = None,
-    true_match_iou: float | None = None,
-) -> DetectionBox:
-    return DetectionBox(
-        display_index=0,
-        raw_index=0,
-        xyxy=(2.0, 3.0, 22.0, 23.0),
-        score=score,
-        label_index=1,
-        label_name=label_name,
-        gt_evaluated=gt_evaluated,
-        true_label_name=true_label_name,
-        true_label_index=true_label_index,
-        true_match_iou=true_match_iou,
-    )
-
-
-def test_title_includes_gt_when_matched() -> None:
+def test_visualiser_sets_no_title_even_with_ground_truth() -> None:
+    # GT match details must NOT leak onto the per-box figure title — they are
+    # rendered only on the thumbnail overlay and report heading.
     vis = DetectionImageVisualiser()
     inputs = torch.rand(1, 3, 32, 32)
     attributions = torch.zeros_like(inputs)
@@ -430,9 +394,13 @@ def test_title_includes_gt_when_matched() -> None:
         algorithm="x",
         sample_names=None,
         show_sample_names=False,
-        detection_box=_box_gt(
-            label_name="kite",
+        detection_box=DetectionBox(
+            display_index=0,
+            raw_index=0,
+            xyxy=(2.0, 3.0, 22.0, 23.0),
             score=0.99,
+            label_index=1,
+            label_name="kite",
             gt_evaluated=True,
             true_label_name="sheep",
             true_label_index=3,
@@ -440,45 +408,4 @@ def test_title_includes_gt_when_matched() -> None:
         ),
     )
     fig = vis.visualise(attributions, inputs, context=ctx)
-    title = fig.axes[0].get_title()
-    assert "kite: 0.99" in title
-    assert "gt: sheep (IoU 0.71)" in title
-
-
-def test_title_no_match() -> None:
-    vis = DetectionImageVisualiser()
-    inputs = torch.rand(1, 3, 32, 32)
-    attributions = torch.zeros_like(inputs)
-    ctx = VisualisationContext(
-        algorithm="x",
-        sample_names=None,
-        show_sample_names=False,
-        detection_box=_box_gt(
-            label_name="kite",
-            score=0.99,
-            gt_evaluated=True,
-            true_label_index=None,
-        ),
-    )
-    fig = vis.visualise(attributions, inputs, context=ctx)
-    title = fig.axes[0].get_title()
-    assert "gt: no match" in title
-
-
-def test_title_unchanged_without_gt() -> None:
-    vis = DetectionImageVisualiser()
-    inputs = torch.rand(1, 3, 32, 32)
-    attributions = torch.zeros_like(inputs)
-    ctx = VisualisationContext(
-        algorithm="x",
-        sample_names=None,
-        show_sample_names=False,
-        detection_box=_box_gt(
-            label_name="kite",
-            score=0.99,
-            gt_evaluated=False,
-        ),
-    )
-    fig = vis.visualise(attributions, inputs, context=ctx)
-    title = fig.axes[0].get_title()
-    assert "gt:" not in title
+    assert fig.axes[0].get_title() == ""

--- a/src/raitap/transparency/tests/test_detection_labels.py
+++ b/src/raitap/transparency/tests/test_detection_labels.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from raitap.transparency.detection_labels import label_name_for, resolve_category_names
+from raitap.transparency.contracts import DetectionBox
+from raitap.transparency.detection_labels import (
+    enrich_detection_box,
+    label_name_for,
+    resolve_category_names,
+)
 
 
 def test_resolve_prefers_explicit_over_backend() -> None:
@@ -33,3 +38,32 @@ def test_label_name_for_none_map_returns_none() -> None:
 def test_label_name_for_out_of_range_returns_none() -> None:
     assert label_name_for(99, ["a", "b"]) is None
     assert label_name_for(-1, ["a", "b"]) is None
+
+
+def _raw_box(label_index: int = 38) -> DetectionBox:
+    return DetectionBox(
+        display_index=0,
+        raw_index=2,
+        xyxy=(0.0, 0.0, 1.0, 1.0),
+        score=0.99,
+        label_index=label_index,
+        label_name=None,
+    )
+
+
+def test_enrich_sets_label_name_from_names() -> None:
+    names = ["__background__"] + [f"c{i}" for i in range(1, 91)]
+    out = enrich_detection_box(_raw_box(38), category_names=names)
+    assert out.label_name == "c38"
+
+
+def test_enrich_label_name_none_without_names() -> None:
+    out = enrich_detection_box(_raw_box(38), category_names=None)
+    assert out.label_name is None
+
+
+def test_enrich_returns_new_frozen_instance() -> None:
+    raw = _raw_box(38)
+    out = enrich_detection_box(raw, category_names=["__background__", "kite"])
+    assert out is not raw
+    assert out.label_index == raw.label_index  # untouched fields preserved

--- a/src/raitap/transparency/tests/test_detection_labels.py
+++ b/src/raitap/transparency/tests/test_detection_labels.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import pytest
+import torch
+
 from raitap.transparency.contracts import DetectionBox
 from raitap.transparency.detection_labels import (
     enrich_detection_box,
     label_name_for,
+    match_box_to_gt,
     resolve_category_names,
 )
 
@@ -67,3 +71,38 @@ def test_enrich_returns_new_frozen_instance() -> None:
     out = enrich_detection_box(raw, category_names=["__background__", "kite"])
     assert out is not raw
     assert out.label_index == raw.label_index  # untouched fields preserved
+
+
+def test_match_returns_best_iou_gt_class_agnostic() -> None:
+    gt_boxes = torch.tensor([[0.0, 0.0, 10.0, 10.0], [50.0, 50.0, 60.0, 60.0]])
+    gt_labels = torch.tensor([7, 3])
+    out = match_box_to_gt((0.0, 0.0, 10.0, 10.0), gt_boxes, gt_labels, iou_threshold=0.5)
+    assert out is not None
+    idx, iou = out
+    assert idx == 7
+    assert iou == pytest.approx(1.0)
+
+
+def test_match_below_threshold_returns_none() -> None:
+    gt_boxes = torch.tensor([[0.0, 0.0, 10.0, 10.0]])
+    gt_labels = torch.tensor([7])
+    out = match_box_to_gt((100.0, 100.0, 110.0, 110.0), gt_boxes, gt_labels, iou_threshold=0.5)
+    assert out is None
+
+
+def test_match_empty_gt_returns_none() -> None:
+    out = match_box_to_gt(
+        (0.0, 0.0, 10.0, 10.0),
+        torch.zeros((0, 4)),
+        torch.zeros(0, dtype=torch.int64),
+        iou_threshold=0.5,
+    )
+    assert out is None
+
+
+def test_match_picks_highest_iou_among_several() -> None:
+    gt_boxes = torch.tensor([[0.0, 0.0, 10.0, 10.0], [0.0, 0.0, 9.0, 9.0]])
+    gt_labels = torch.tensor([1, 2])
+    out = match_box_to_gt((0.0, 0.0, 9.0, 9.0), gt_boxes, gt_labels, iou_threshold=0.1)
+    assert out is not None
+    assert out[0] == 2  # exact overlap with the second box

--- a/src/raitap/transparency/tests/test_detection_labels.py
+++ b/src/raitap/transparency/tests/test_detection_labels.py
@@ -106,3 +106,34 @@ def test_match_picks_highest_iou_among_several() -> None:
     out = match_box_to_gt((0.0, 0.0, 9.0, 9.0), gt_boxes, gt_labels, iou_threshold=0.1)
     assert out is not None
     assert out[0] == 2  # exact overlap with the second box
+
+
+NAMES = ["__background__"] + [f"c{i}" for i in range(1, 91)]
+
+
+def test_enrich_matches_gt_class_agnostic() -> None:
+    gt = {"boxes": torch.tensor([[0.0, 0.0, 1.0, 1.0]]), "labels": torch.tensor([20])}
+    out = enrich_detection_box(
+        _raw_box(38), category_names=NAMES, gt_for_sample=gt, iou_threshold=0.5
+    )
+    assert out.gt_evaluated is True
+    assert out.true_label_index == 20
+    assert out.true_label_name == "c20"  # GT class differs from pred -> disagreement shown
+    assert out.true_match_iou == pytest.approx(1.0)
+
+
+def test_enrich_no_match_is_false_positive() -> None:
+    gt = {"boxes": torch.tensor([[100.0, 100.0, 101.0, 101.0]]), "labels": torch.tensor([5])}
+    out = enrich_detection_box(
+        _raw_box(38), category_names=NAMES, gt_for_sample=gt, iou_threshold=0.5
+    )
+    assert out.gt_evaluated is True  # GT present for the sample
+    assert out.true_label_index is None  # nothing overlapped -> no match
+    assert out.true_label_name is None
+    assert out.true_match_iou is None
+
+
+def test_enrich_no_gt_leaves_evaluated_false() -> None:
+    out = enrich_detection_box(_raw_box(38), category_names=NAMES, gt_for_sample=None)
+    assert out.gt_evaluated is False
+    assert out.true_label_index is None

--- a/src/raitap/transparency/tests/test_detection_labels.py
+++ b/src/raitap/transparency/tests/test_detection_labels.py
@@ -7,7 +7,7 @@ from raitap.transparency.contracts import DetectionBox
 from raitap.transparency.detection_labels import (
     enrich_detection_box,
     label_name_for,
-    match_box_to_gt,
+    match_box_to_ground_truth,
     resolve_category_names,
 )
 
@@ -74,9 +74,11 @@ def test_enrich_returns_new_frozen_instance() -> None:
 
 
 def test_match_returns_best_iou_gt_class_agnostic() -> None:
-    gt_boxes = torch.tensor([[0.0, 0.0, 10.0, 10.0], [50.0, 50.0, 60.0, 60.0]])
-    gt_labels = torch.tensor([7, 3])
-    out = match_box_to_gt((0.0, 0.0, 10.0, 10.0), gt_boxes, gt_labels, iou_threshold=0.5)
+    ground_truth_boxes = torch.tensor([[0.0, 0.0, 10.0, 10.0], [50.0, 50.0, 60.0, 60.0]])
+    ground_truth_labels = torch.tensor([7, 3])
+    out = match_box_to_ground_truth(
+        (0.0, 0.0, 10.0, 10.0), ground_truth_boxes, ground_truth_labels, iou_threshold=0.5
+    )
     assert out is not None
     idx, iou = out
     assert idx == 7
@@ -84,14 +86,16 @@ def test_match_returns_best_iou_gt_class_agnostic() -> None:
 
 
 def test_match_below_threshold_returns_none() -> None:
-    gt_boxes = torch.tensor([[0.0, 0.0, 10.0, 10.0]])
-    gt_labels = torch.tensor([7])
-    out = match_box_to_gt((100.0, 100.0, 110.0, 110.0), gt_boxes, gt_labels, iou_threshold=0.5)
+    ground_truth_boxes = torch.tensor([[0.0, 0.0, 10.0, 10.0]])
+    ground_truth_labels = torch.tensor([7])
+    out = match_box_to_ground_truth(
+        (100.0, 100.0, 110.0, 110.0), ground_truth_boxes, ground_truth_labels, iou_threshold=0.5
+    )
     assert out is None
 
 
 def test_match_empty_gt_returns_none() -> None:
-    out = match_box_to_gt(
+    out = match_box_to_ground_truth(
         (0.0, 0.0, 10.0, 10.0),
         torch.zeros((0, 4)),
         torch.zeros(0, dtype=torch.int64),
@@ -101,9 +105,11 @@ def test_match_empty_gt_returns_none() -> None:
 
 
 def test_match_picks_highest_iou_among_several() -> None:
-    gt_boxes = torch.tensor([[0.0, 0.0, 10.0, 10.0], [0.0, 0.0, 9.0, 9.0]])
-    gt_labels = torch.tensor([1, 2])
-    out = match_box_to_gt((0.0, 0.0, 9.0, 9.0), gt_boxes, gt_labels, iou_threshold=0.1)
+    ground_truth_boxes = torch.tensor([[0.0, 0.0, 10.0, 10.0], [0.0, 0.0, 9.0, 9.0]])
+    ground_truth_labels = torch.tensor([1, 2])
+    out = match_box_to_ground_truth(
+        (0.0, 0.0, 9.0, 9.0), ground_truth_boxes, ground_truth_labels, iou_threshold=0.1
+    )
     assert out is not None
     assert out[0] == 2  # exact overlap with the second box
 
@@ -114,9 +120,9 @@ NAMES = ["__background__"] + [f"c{i}" for i in range(1, 91)]
 def test_enrich_matches_gt_class_agnostic() -> None:
     gt = {"boxes": torch.tensor([[0.0, 0.0, 1.0, 1.0]]), "labels": torch.tensor([20])}
     out = enrich_detection_box(
-        _raw_box(38), category_names=NAMES, gt_for_sample=gt, iou_threshold=0.5
+        _raw_box(38), category_names=NAMES, ground_truth_for_sample=gt, iou_threshold=0.5
     )
-    assert out.gt_evaluated is True
+    assert out.ground_truth_evaluated is True
     assert out.true_label_index == 20
     assert out.true_label_name == "c20"  # GT class differs from pred -> disagreement shown
     assert out.true_match_iou == pytest.approx(1.0)
@@ -125,15 +131,15 @@ def test_enrich_matches_gt_class_agnostic() -> None:
 def test_enrich_no_match_is_false_positive() -> None:
     gt = {"boxes": torch.tensor([[100.0, 100.0, 101.0, 101.0]]), "labels": torch.tensor([5])}
     out = enrich_detection_box(
-        _raw_box(38), category_names=NAMES, gt_for_sample=gt, iou_threshold=0.5
+        _raw_box(38), category_names=NAMES, ground_truth_for_sample=gt, iou_threshold=0.5
     )
-    assert out.gt_evaluated is True  # GT present for the sample
+    assert out.ground_truth_evaluated is True  # GT present for the sample
     assert out.true_label_index is None  # nothing overlapped -> no match
     assert out.true_label_name is None
     assert out.true_match_iou is None
 
 
 def test_enrich_no_gt_leaves_evaluated_false() -> None:
-    out = enrich_detection_box(_raw_box(38), category_names=NAMES, gt_for_sample=None)
-    assert out.gt_evaluated is False
+    out = enrich_detection_box(_raw_box(38), category_names=NAMES, ground_truth_for_sample=None)
+    assert out.ground_truth_evaluated is False
     assert out.true_label_index is None

--- a/src/raitap/transparency/tests/test_detection_labels.py
+++ b/src/raitap/transparency/tests/test_detection_labels.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from raitap.transparency.detection_labels import label_name_for, resolve_category_names
+
+
+def test_resolve_prefers_explicit_over_backend() -> None:
+    assert resolve_category_names(["a", "b"], ["x", "y"]) == ["a", "b"]
+
+
+def test_resolve_falls_back_to_backend_when_no_explicit() -> None:
+    assert resolve_category_names(None, ["x", "y"]) == ["x", "y"]
+
+
+def test_resolve_returns_none_when_neither_present() -> None:
+    assert resolve_category_names(None, None) is None
+
+
+def test_resolve_copies_to_list() -> None:
+    src = ("a", "b")
+    out = resolve_category_names(src, None)
+    assert out == ["a", "b"]
+    assert isinstance(out, list)
+
+
+def test_label_name_for_in_range() -> None:
+    assert label_name_for(38, ["__background__"] + [f"c{i}" for i in range(1, 91)]) == "c38"
+
+
+def test_label_name_for_none_map_returns_none() -> None:
+    assert label_name_for(3, None) is None
+
+
+def test_label_name_for_out_of_range_returns_none() -> None:
+    assert label_name_for(99, ["a", "b"]) is None
+    assert label_name_for(-1, ["a", "b"]) is None

--- a/src/raitap/transparency/visualisers/detection_image_visualiser.py
+++ b/src/raitap/transparency/visualisers/detection_image_visualiser.py
@@ -189,9 +189,14 @@ class DetectionImageVisualiser(BaseVisualiser):
         fig.legend(handles=[rect], loc="outside upper right", fontsize=8, framealpha=0.9)
 
         label_str = box.label_name if box.label_name else f"class {box.label_index}"
-        ax.set_title(
-            f"{label_str}: {box.score:.2f}    [box {box.display_index} (raw {box.raw_index})]"
-        )
+        title = f"{label_str}: {box.score:.2f}    [box {box.display_index} (raw {box.raw_index})]"
+        if box.gt_evaluated:
+            if box.true_label_index is not None:
+                gt_name = box.true_label_name or f"class {box.true_label_index}"
+                title += f"    gt: {gt_name} (IoU {box.true_match_iou:.2f})"
+            else:
+                title += "    gt: no match"
+        ax.set_title(title)
         ax.set_xticks([])
         ax.set_yticks([])
         ax.set_xlim(0, img_hwc.shape[1])

--- a/src/raitap/transparency/visualisers/detection_image_visualiser.py
+++ b/src/raitap/transparency/visualisers/detection_image_visualiser.py
@@ -188,15 +188,9 @@ class DetectionImageVisualiser(BaseVisualiser):
             fig.colorbar(heat, ax=ax).set_label("attribution")
         fig.legend(handles=[rect], loc="outside upper right", fontsize=8, framealpha=0.9)
 
-        label_str = box.label_name if box.label_name else f"class {box.label_index}"
-        title = f"{label_str}: {box.score:.2f}    [box {box.display_index} (raw {box.raw_index})]"
-        if box.gt_evaluated:
-            if box.true_label_index is not None:
-                gt_name = box.true_label_name or f"class {box.true_label_index}"
-                title += f"    gt: {gt_name} (IoU {box.true_match_iou:.2f})"
-            else:
-                title += "    gt: no match"
-        ax.set_title(title)
+        # No per-box title: the predicted label, score, and ground-truth match
+        # are shown on the thumbnail overlay (every box on the original image)
+        # and in the report heading, so a title here would only duplicate them.
         ax.set_xticks([])
         ax.set_yticks([])
         ax.set_xlim(0, img_hwc.shape[1])


### PR DESCRIPTION
## Summary

Detection attribution boxes now identify objects by **human-readable class name** and, when ground truth is configured, by **true label matched via IoU** — replacing the bare `class 38` numeric form.

- **Predicted class names.** Captures torchvision `weights.meta["categories"]` onto the backend at load (automatic for pretrained detectors); an explicit `model.class_names` config overrides it. Resolution precedence: explicit config > backend categories > numeric-id fallback.
- **Ground-truth true labels.** When `data.labels` (`kind: detection`) is configured, each predicted box is matched to GT by **class-agnostic IoU**, surfacing disagreements (`pred: dog 0.92 | gt: cat (IoU 0.71)`). No overlapping labelled object → `gt: no match`; no GT configured → no `gt:` clause.
- Rendered in report headings and on the thumbnail overlay (compact `#index` tags on the image + a legend below it); the per-box attribution figures are intentionally title-less, so the label/score/GT are not duplicated there. New `DetectionBox` fields are serialised to metadata.

**Architecture.** Names/GT are display metadata the explainer never reads, so `explain_detection.py` is **untouched** — enrichment happens in the caller (`_assess_transparency_detection`) via a pure `enrich_detection_box` seam applied before `result.visualise()`. Pure helpers (`resolve_category_names`, `label_name_for`, `match_box_to_gt`, `enrich_detection_box`) live in `transparency/detection_labels.py` with torch/torchvision imported lazily so the module stays importable without the optional extra.

**Backward compatible.** With neither a class-name source nor GT configured, output is unchanged (`class {id}`, no GT line).

**Follow-up (post-merge):** the detection MPL baseline PNG needs Linux-only regeneration because the detection figure changed (GT clause, title removal, overlay legend) — `test_detection_mpl_baseline.py` skips on non-Linux and is expected to flag until regenerated via `regen-baselines.yml`. Not broken.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — Non-breaking: purely additive (new optional config field + new `DetectionBox` fields with defaults). Title carries no `!`.
- [x] **Contributor guide** — I’ve read **Pull requests and commit messages** before requesting review.

## Optional

- [x] **Issue** _(optional)_ — Closes #233.
- [x] **Docs** _(optional)_ — `docs/modules/transparency/detection.md` documents class names + ground-truth labels.
- [x] **Tests** _(optional)_ — New unit tests for all helpers + caller wiring tests asserting enrichment reaches the in-memory box that the report renders (figures are title-less).
