### PR TITLE
fix(metrics): allow metrics-only pipeline runs (#237)

### DIFF
--- a/src/raitap/pipeline/orchestrator.py
+++ b/src/raitap/pipeline/orchestrator.py
@@ -26,12 +26,39 @@ from raitap.tracking import BaseTracker
 from raitap.utils.lazy import lazy_import
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import torch
 
     from raitap.configs.schema import AppConfig
     from raitap.data.preprocessing import ResolvedPreprocessing
 else:
     torch = lazy_import("torch")
+
+
+# Pipeline "deliverable" phases: each produces output a run can stand on, and a
+# run must configure at least one. This tuple is the single source of truth for
+# the metrics-only / transparency-only / …-only guard — adding a new assessment
+# module (e.g. fairness) means adding one entry here, and both the guard and its
+# error message pick it up automatically. (This makes the *guard* extensible; the
+# per-phase calls, RunOutputs fields, and report sections remain hardcoded.)
+_ASSESSMENT_PHASES: tuple[tuple[str, Callable[[AppConfig], bool]], ...] = (
+    ("metrics", metrics_run_enabled),
+    ("transparency", lambda config: bool(getattr(config, "transparency", None))),
+    ("robustness", lambda config: bool(getattr(config, "robustness", None))),
+)
+
+
+def _require_configured_assessment(config: AppConfig) -> None:
+    """Raise unless at least one assessment phase is configured.
+
+    Config-only check — call it before any expensive phase work (forward pass,
+    metrics) so a no-deliverable run fails fast instead of after the fact.
+    """
+    if any(is_configured(config) for _name, is_configured in _ASSESSMENT_PHASES):
+        return
+    available = ", ".join(name for name, _ in _ASSESSMENT_PHASES)
+    raise ValueError(f"No assessment phase configured; configure at least one of: {available}")
 
 
 def _run_pipeline(
@@ -138,18 +165,13 @@ def run_without_tracking(
     without instantiating a tracker. Composes the phase modules under
     :mod:`raitap.pipeline.phases` in order.
     """
+    _require_configured_assessment(config)
+
     raitap_log.info("Running model forward pass...")
     with torch.no_grad():
         forward_output = forward_pass(config, model.backend, data.tensor)
 
     metrics_eval = evaluate_metrics(config, forward_output, data.labels)
-
-    if not (
-        metrics_run_enabled(config)
-        or getattr(config, "transparency", None)
-        or getattr(config, "robustness", None)
-    ):
-        raise ValueError("No metrics, explainers, or robustness assessors configured")
 
     input_metadata = input_metadata_for_data(config, data)
     explanations, visualisations = assess_transparency(

--- a/src/raitap/pipeline/orchestrator.py
+++ b/src/raitap/pipeline/orchestrator.py
@@ -10,15 +10,12 @@ from typing import TYPE_CHECKING
 from raitap import raitap_log
 from raitap.data import Data
 from raitap.data.preprocessing import resolve_preprocessing
-from raitap.metrics import metrics_run_enabled
 from raitap.models import Model
 from raitap.pipeline.outputs import RunOutputs
-from raitap.pipeline.phases.assess_robustness import assess_robustness
-from raitap.pipeline.phases.assess_transparency import assess_transparency
-from raitap.pipeline.phases.evaluate_metrics import evaluate_metrics
 from raitap.pipeline.phases.forward_pass import forward_pass
 from raitap.pipeline.phases.input_metadata import input_metadata_for_data
 from raitap.pipeline.phases.prediction_summaries import prediction_summaries
+from raitap.pipeline.phases.registry import ASSESSMENT_PHASES, PhaseContext, PhaseContribution
 from raitap.pipeline.ui import print_summary
 from raitap.reporting import build_report, create_report, reporting_enabled
 from raitap.reporting.sample_selection import resolve_report_sample_selection
@@ -26,39 +23,12 @@ from raitap.tracking import BaseTracker
 from raitap.utils.lazy import lazy_import
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     import torch
 
     from raitap.configs.schema import AppConfig
     from raitap.data.preprocessing import ResolvedPreprocessing
 else:
     torch = lazy_import("torch")
-
-
-# Pipeline "deliverable" phases: each produces output a run can stand on, and a
-# run must configure at least one. This tuple is the single source of truth for
-# the metrics-only / transparency-only / …-only guard — adding a new assessment
-# module (e.g. fairness) means adding one entry here, and both the guard and its
-# error message pick it up automatically. (This makes the *guard* extensible; the
-# per-phase calls, RunOutputs fields, and report sections remain hardcoded.)
-_ASSESSMENT_PHASES: tuple[tuple[str, Callable[[AppConfig], bool]], ...] = (
-    ("metrics", metrics_run_enabled),
-    ("transparency", lambda config: bool(getattr(config, "transparency", None))),
-    ("robustness", lambda config: bool(getattr(config, "robustness", None))),
-)
-
-
-def _require_configured_assessment(config: AppConfig) -> None:
-    """Raise unless at least one assessment phase is configured.
-
-    Config-only check — call it before any expensive phase work (forward pass,
-    metrics) so a no-deliverable run fails fast instead of after the fact.
-    """
-    if any(is_configured(config) for _name, is_configured in _ASSESSMENT_PHASES):
-        return
-    available = ", ".join(name for name, _ in _ASSESSMENT_PHASES)
-    raise ValueError(f"No assessment phase configured; configure at least one of: {available}")
 
 
 def _run_pipeline(
@@ -159,43 +129,37 @@ def run_without_tracking(
     *,
     resolved_preprocessing: ResolvedPreprocessing | None = None,
 ) -> RunOutputs:
-    """Compose every phase except tracker setup.
+    """Compose every assessment phase except tracker setup.
 
     Public helper for tests and embedded callers that want the pipeline output
-    without instantiating a tracker. Composes the phase modules under
-    :mod:`raitap.pipeline.phases` in order.
+    without instantiating a tracker. Resolves which phases are configured from
+    :data:`~raitap.pipeline.phases.registry.ASSESSMENT_PHASES`, then runs each
+    over a shared :class:`~raitap.pipeline.phases.registry.PhaseContext`.
     """
-    _require_configured_assessment(config)
+    # Config-only guard, before the (potentially expensive) forward pass: a run
+    # with no configured deliverable phase fails fast instead of after the fact.
+    configured_phases = [phase for phase in ASSESSMENT_PHASES if phase.is_configured(config)]
+    if not configured_phases:
+        _raise_no_phase_configured()
 
     raitap_log.info("Running model forward pass...")
     with torch.no_grad():
         forward_output = forward_pass(config, model.backend, data.tensor)
 
-    metrics_eval = evaluate_metrics(config, forward_output, data.labels)
-
-    input_metadata = input_metadata_for_data(config, data)
-    explanations, visualisations = assess_transparency(
-        config,
-        model,
-        data,
-        forward_output,
-        input_metadata=input_metadata,
+    context = PhaseContext(
+        config=config,
+        model=model,
+        data=data,
+        forward_output=forward_output,
+        input_metadata=input_metadata_for_data(config, data),
         resolved_preprocessing=resolved_preprocessing,
     )
-    robustness_results, robustness_visualisations = assess_robustness(
-        config,
-        model,
-        data,
-        forward_output,
-        labels=data.labels,
-        input_metadata=input_metadata,
-        resolved_preprocessing=resolved_preprocessing,
-    )
+    contribution = PhaseContribution.merge(phase.run(context) for phase in configured_phases)
 
     return RunOutputs(
-        explanations=explanations,
-        visualisations=visualisations,
-        metrics=metrics_eval,
+        explanations=contribution.explanations,
+        visualisations=contribution.visualisations,
+        metrics=contribution.metrics,
         forward_output=forward_output,
         sample_ids=data.sample_ids,
         targets=data.labels,
@@ -204,9 +168,14 @@ def run_without_tracking(
             sample_ids=data.sample_ids,
             targets=data.labels,
         ),
-        robustness_results=robustness_results,
-        robustness_visualisations=robustness_visualisations,
+        robustness_results=contribution.robustness_results,
+        robustness_visualisations=contribution.robustness_visualisations,
     )
+
+
+def _raise_no_phase_configured() -> None:
+    available = ", ".join(phase.name for phase in ASSESSMENT_PHASES)
+    raise ValueError(f"No assessment phase configured; configure at least one of: {available}")
 
 
 def _validate_report_sample_selection(config: AppConfig, data: Data) -> None:

--- a/src/raitap/pipeline/orchestrator.py
+++ b/src/raitap/pipeline/orchestrator.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from raitap import raitap_log
 from raitap.data import Data
 from raitap.data.preprocessing import resolve_preprocessing
+from raitap.metrics import metrics_run_enabled
 from raitap.models import Model
 from raitap.pipeline.outputs import RunOutputs
 from raitap.pipeline.phases.assess_robustness import assess_robustness
@@ -143,8 +144,12 @@ def run_without_tracking(
 
     metrics_eval = evaluate_metrics(config, forward_output, data.labels)
 
-    if not (getattr(config, "transparency", None) or getattr(config, "robustness", None)):
-        raise ValueError("No explainers or robustness assessors configured")
+    if not (
+        metrics_run_enabled(config)
+        or getattr(config, "transparency", None)
+        or getattr(config, "robustness", None)
+    ):
+        raise ValueError("No metrics, explainers, or robustness assessors configured")
 
     input_metadata = input_metadata_for_data(config, data)
     explanations, visualisations = assess_transparency(

--- a/src/raitap/pipeline/phases/registry.py
+++ b/src/raitap/pipeline/phases/registry.py
@@ -1,0 +1,163 @@
+"""Assessment-phase chain — the single source of truth for which deliverable
+phases exist, how to tell whether each is configured, and how to run it.
+
+Both the "is any deliverable configured?" guard and the run loop in
+:func:`raitap.pipeline.orchestrator.run_without_tracking` iterate
+:data:`ASSESSMENT_PHASES`, so neither call site changes when the set of phases
+changes. Adding a new assessment module (e.g. fairness) means: add an
+:class:`AssessmentPhase` subclass, register it in :data:`ASSESSMENT_PHASES`, and
+thread its output onto :class:`PhaseContribution` + :class:`~raitap.pipeline.outputs.RunOutputs`
+(the latter is a flat frozen struct, so its fields stay explicit).
+
+Shaped after the Chain-of-Responsibility pattern: each phase independently
+decides — via :meth:`AssessmentPhase.is_configured` — whether to contribute.
+Unlike classic CoR there is no short-circuit: every configured phase runs and
+the pipeline accumulates all contributions, so the chain is a plain ordered list
+rather than a ``set_next`` linked list.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, ClassVar
+
+from raitap.metrics import metrics_run_enabled
+from raitap.pipeline.phases.assess_robustness import assess_robustness
+from raitap.pipeline.phases.assess_transparency import assess_transparency
+from raitap.pipeline.phases.evaluate_metrics import evaluate_metrics
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from raitap.configs.schema import AppConfig
+    from raitap.data import Data
+    from raitap.data.preprocessing import ResolvedPreprocessing
+    from raitap.metrics import MetricsEvaluation
+    from raitap.models import Model
+    from raitap.pipeline.outputs import ForwardOutput
+    from raitap.robustness.results import RobustnessResult, RobustnessVisualisationResult
+    from raitap.transparency.contracts import InputSpec
+    from raitap.transparency.results import ExplanationResult, VisualisationResult
+
+
+@dataclass(frozen=True)
+class PhaseContext:
+    """Everything an assessment phase may need, assembled once per run."""
+
+    config: AppConfig
+    model: Model
+    data: Data
+    forward_output: ForwardOutput
+    input_metadata: InputSpec | None
+    resolved_preprocessing: ResolvedPreprocessing | None
+
+
+@dataclass(frozen=True)
+class PhaseContribution:
+    """A phase's partial contribution to :class:`~raitap.pipeline.outputs.RunOutputs`.
+
+    Each phase fills only the fields it produces; :meth:`merge` folds the
+    per-phase contributions into one before the final ``RunOutputs`` is built.
+    """
+
+    explanations: list[ExplanationResult] = field(default_factory=list)
+    visualisations: list[VisualisationResult] = field(default_factory=list)
+    metrics: MetricsEvaluation | None = None
+    robustness_results: list[RobustnessResult] = field(default_factory=list)
+    robustness_visualisations: list[RobustnessVisualisationResult] = field(default_factory=list)
+
+    @classmethod
+    def merge(cls, contributions: Iterable[PhaseContribution]) -> PhaseContribution:
+        merged = cls()
+        for contribution in contributions:
+            metrics = contribution.metrics if contribution.metrics is not None else merged.metrics
+            merged = cls(
+                explanations=[*merged.explanations, *contribution.explanations],
+                visualisations=[*merged.visualisations, *contribution.visualisations],
+                metrics=metrics,
+                robustness_results=[
+                    *merged.robustness_results,
+                    *contribution.robustness_results,
+                ],
+                robustness_visualisations=[
+                    *merged.robustness_visualisations,
+                    *contribution.robustness_visualisations,
+                ],
+            )
+        return merged
+
+
+class AssessmentPhase(ABC):
+    """One deliverable-producing phase: a configured-check plus a run step."""
+
+    name: ClassVar[str]
+
+    @abstractmethod
+    def is_configured(self, config: AppConfig) -> bool:
+        """True when this phase has anything to do for ``config`` (config-only)."""
+
+    @abstractmethod
+    def run(self, ctx: PhaseContext) -> PhaseContribution:
+        """Execute the phase and return its contribution to the run outputs."""
+
+
+class MetricsPhase(AssessmentPhase):
+    name = "metrics"
+
+    def is_configured(self, config: AppConfig) -> bool:
+        return metrics_run_enabled(config)
+
+    def run(self, ctx: PhaseContext) -> PhaseContribution:
+        return PhaseContribution(
+            metrics=evaluate_metrics(ctx.config, ctx.forward_output, ctx.data.labels)
+        )
+
+
+class TransparencyPhase(AssessmentPhase):
+    name = "transparency"
+
+    def is_configured(self, config: AppConfig) -> bool:
+        return bool(getattr(config, "transparency", None))
+
+    def run(self, ctx: PhaseContext) -> PhaseContribution:
+        explanations, visualisations = assess_transparency(
+            ctx.config,
+            ctx.model,
+            ctx.data,
+            ctx.forward_output,
+            input_metadata=ctx.input_metadata,
+            resolved_preprocessing=ctx.resolved_preprocessing,
+        )
+        return PhaseContribution(explanations=explanations, visualisations=visualisations)
+
+
+class RobustnessPhase(AssessmentPhase):
+    name = "robustness"
+
+    def is_configured(self, config: AppConfig) -> bool:
+        return bool(getattr(config, "robustness", None))
+
+    def run(self, ctx: PhaseContext) -> PhaseContribution:
+        results, visualisations = assess_robustness(
+            ctx.config,
+            ctx.model,
+            ctx.data,
+            ctx.forward_output,
+            labels=ctx.data.labels,
+            input_metadata=ctx.input_metadata,
+            resolved_preprocessing=ctx.resolved_preprocessing,
+        )
+        return PhaseContribution(
+            robustness_results=results,
+            robustness_visualisations=visualisations,
+        )
+
+
+# Ordered chain. Order is preserved in execution (metrics -> transparency ->
+# robustness, matching the historical orchestrator order).
+ASSESSMENT_PHASES: tuple[AssessmentPhase, ...] = (
+    MetricsPhase(),
+    TransparencyPhase(),
+    RobustnessPhase(),
+)

--- a/src/raitap/tests/test_run_main.py
+++ b/src/raitap/tests/test_run_main.py
@@ -663,10 +663,7 @@ def test_run_without_tracking_infers_num_classes_and_runs_metrics(monkeypatch: M
 
     config = SimpleNamespace(
         transparency={"one": {}},
-        metrics=SimpleNamespace(num_classes=None),
-    )
-    monkeypatch.setattr(
-        "raitap.pipeline.phases.evaluate_metrics.metrics_run_enabled", lambda _cfg: True
+        metrics=SimpleNamespace(_target_="MulticlassClassificationMetrics", num_classes=None),
     )
     monkeypatch.setattr("raitap.pipeline.phases.assess_transparency.Explanation", _fake_explanation)
     monkeypatch.setattr("raitap.pipeline.phases.evaluate_metrics.Metrics", _fake_metrics)
@@ -696,10 +693,7 @@ def test_run_without_tracking_uses_provided_num_classes(monkeypatch: MonkeyPatch
 
     config = SimpleNamespace(
         transparency={"one": {}},
-        metrics=SimpleNamespace(num_classes=10),
-    )
-    monkeypatch.setattr(
-        "raitap.pipeline.phases.evaluate_metrics.metrics_run_enabled", lambda _cfg: True
+        metrics=SimpleNamespace(_target_="MulticlassClassificationMetrics", num_classes=10),
     )
     monkeypatch.setattr("raitap.pipeline.phases.assess_transparency.Explanation", _fake_explanation)
     monkeypatch.setattr(

--- a/src/raitap/tests/test_run_main.py
+++ b/src/raitap/tests/test_run_main.py
@@ -618,8 +618,38 @@ def test_run_without_tracking_raises_if_no_explainers_or_assessors(
         "raitap.pipeline.phases.evaluate_metrics.metrics_run_enabled", lambda _cfg: False
     )
 
-    with pytest.raises(ValueError, match="No explainers or robustness assessors configured"):
+    with pytest.raises(
+        ValueError, match="No metrics, explainers, or robustness assessors configured"
+    ):
         run_pipeline.run_without_tracking(config, model, data)  # type: ignore[arg-type]
+
+
+def test_run_without_tracking_allows_metrics_only(monkeypatch: MonkeyPatch) -> None:
+    class _Net(torch.nn.Module):
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            del x
+            return torch.tensor([[0.1, 0.9, 0.0], [0.8, 0.1, 0.1]])
+
+    model = SimpleNamespace(backend=_BackendStub(_Net()))
+    data = SimpleNamespace(tensor=torch.randn(2, 4), sample_ids=None, labels=None)
+    config = SimpleNamespace(
+        transparency={},
+        robustness={},
+        metrics=SimpleNamespace(num_classes=None),
+    )
+    monkeypatch.setattr(
+        "raitap.pipeline.phases.evaluate_metrics.metrics_run_enabled", lambda _cfg: True
+    )
+    monkeypatch.setattr("raitap.pipeline.orchestrator.metrics_run_enabled", lambda _cfg: True)
+    monkeypatch.setattr(
+        "raitap.pipeline.phases.evaluate_metrics.Metrics", lambda _c, _p, _t: SimpleNamespace()
+    )
+
+    outputs = run_pipeline.run_without_tracking(config, model, data)  # type: ignore[arg-type]
+
+    assert outputs.metrics is not None
+    assert outputs.explanations == []
+    assert outputs.robustness_results == []
 
 
 def test_run_without_tracking_infers_num_classes_and_runs_metrics(monkeypatch: MonkeyPatch) -> None:

--- a/src/raitap/tests/test_run_main.py
+++ b/src/raitap/tests/test_run_main.py
@@ -603,24 +603,17 @@ def test_run_with_tracking_config_but_no_target_skips_tracking(monkeypatch: Monk
     tracker_factory.assert_not_called()
 
 
-def test_run_without_tracking_raises_if_no_explainers_or_assessors(
-    monkeypatch: MonkeyPatch,
-) -> None:
+def test_run_without_tracking_raises_if_no_phase_configured() -> None:
     model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
     data = SimpleNamespace(tensor=torch.randn(2, 3), sample_ids=None, labels=None)
+    # No _target_ on metrics, empty transparency/robustness -> no phase configured.
     config = SimpleNamespace(
         transparency={},
         robustness={},
-        metrics=SimpleNamespace(num_classes=None),
+        metrics=SimpleNamespace(_target_=None, num_classes=None),
     )
 
-    monkeypatch.setattr(
-        "raitap.pipeline.phases.evaluate_metrics.metrics_run_enabled", lambda _cfg: False
-    )
-
-    with pytest.raises(
-        ValueError, match="No metrics, explainers, or robustness assessors configured"
-    ):
+    with pytest.raises(ValueError, match="No assessment phase configured"):
         run_pipeline.run_without_tracking(config, model, data)  # type: ignore[arg-type]
 
 
@@ -632,15 +625,13 @@ def test_run_without_tracking_allows_metrics_only(monkeypatch: MonkeyPatch) -> N
 
     model = SimpleNamespace(backend=_BackendStub(_Net()))
     data = SimpleNamespace(tensor=torch.randn(2, 4), sample_ids=None, labels=None)
+    # A real (non-empty) _target_ is exactly what metrics_run_enabled checks; no
+    # transparency/robustness configured -> genuine metrics-only run.
     config = SimpleNamespace(
         transparency={},
         robustness={},
-        metrics=SimpleNamespace(num_classes=None),
+        metrics=SimpleNamespace(_target_="MulticlassClassificationMetrics", num_classes=None),
     )
-    monkeypatch.setattr(
-        "raitap.pipeline.phases.evaluate_metrics.metrics_run_enabled", lambda _cfg: True
-    )
-    monkeypatch.setattr("raitap.pipeline.orchestrator.metrics_run_enabled", lambda _cfg: True)
     monkeypatch.setattr(
         "raitap.pipeline.phases.evaluate_metrics.Metrics", lambda _c, _p, _t: SimpleNamespace()
     )


### PR DESCRIPTION
## What

A config declaring `metrics` but no `transparency` and no `robustness` failed with `ValueError: No explainers or robustness assessors configured` — *after* the metrics phase had already written `metrics.json`, `metrics_overview.png`, and `artifacts.json`. The run exited `rc=1` despite producing valid deliverables.

Closes #237.

## Why

The guard predates metrics being a standalone deliverable. The schema already makes all three groups optional (`transparency`/`robustness` default `{}`, `metrics` defaults `None`), so a metrics-only config is well-formed.

## Change

Introduces an **assessment-phase chain** (`pipeline/phases/registry.py`) as the single source of truth for which deliverable phases exist, how to detect whether each is configured, and how to run it:

- `AssessmentPhase` — `name` + `is_configured(config)` + `run(ctx) -> PhaseContribution`. Concrete `MetricsPhase` / `TransparencyPhase` / `RobustnessPhase` wrap the existing phase functions (pure delegators — same functions, same args).
- `PhaseContext` — everything a phase may need, assembled once per run.
- `PhaseContribution` — a phase's partial slice of `RunOutputs`; `.merge()` folds them.
- `ASSESSMENT_PHASES` — the ordered chain. Both the "is anything configured?" guard **and** the run loop in `run_without_tracking` iterate it, so neither call site changes when phases change.

CoR-shaped: each phase independently decides via `is_configured` whether to contribute. There's no short-circuit (every configured phase runs and accumulates), so it's a plain ordered list, not a `set_next` linked chain.

The guard is now config-only and **fails fast** at the top of `run_without_tracking`, before the forward pass — an empty config previously paid a full forward pass (8 min on the COCO run) before raising.

**Extensibility (honest scope):** adding a future module (e.g. fairness) means adding one `AssessmentPhase` subclass, registering it in `ASSESSMENT_PHASES`, and threading its output fields onto `PhaseContribution` + `RunOutputs` (the latter is a flat frozen struct, so its fields stay explicit). It is *not* one line — but the guard and run loop pick it up for free.

## Downstream safety

`assess_transparency` / `assess_robustness` already return `([], [])` on empty config, and `build_report` appends only non-`None` sections (`_build_metrics_section` builds from `outputs.metrics`), so a metrics-only report renders the Metrics section alone. The detection path (the issue's scenario) was reasoned about, not run e2e (`Detection E2E` is skipped on this PR): the phase wrappers are pure delegators to the unchanged phase functions and produce the same `RunOutputs`, so behaviour is identical.

## Tests

- `test_run_without_tracking_allows_metrics_only` — metrics-only config proceeds to `RunOutputs` with `metrics is not None`, empty explanations/robustness.
- `test_run_without_tracking_raises_if_no_phase_configured` — empty config raises before the forward pass.
- The existing metrics+transparency test exercises multi-phase merge. Tests no longer monkeypatch `metrics_run_enabled` — they set a real `metrics._target_`.
- Full non-e2e suite green locally (1219 passed); the pipeline/phases/reporting modules (171 tests) pass. The phase chain rewires the shared `run_without_tracking` path, hence the broad run.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — Not breaking; loosens a guard and refactors internal composition (public `run_without_tracking` / `RunOutputs` signatures unchanged). Title uses no `!`.
- [x] **Contributor guide** — I've read **Pull requests and commit messages** before requesting review.

## Optional

- [x] **Issue** _(optional)_ — Closes #237.
- [ ] **Docs** _(optional)_ — No doc change needed; docs already describe metrics/transparency/robustness as independently optional.
- [x] **Tests** _(optional)_ — New + updated tests cover the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
