### PR TITLE
fix: guard optional config reads, dedup detection overlay, add SHAP parity test

### DIFF
--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -48,7 +48,13 @@ def build_report(config: AppConfig, outputs: RunOutputs) -> BuiltReport:
     assets_dir.mkdir(parents=True, exist_ok=True)
 
     reporting_cfg = config.reporting
-    configured_selection = None if reporting_cfg is None else reporting_cfg.sample_selection
+    # ``reporting`` may arrive as a struct-mode DictConfig that omits the
+    # optional ``sample_selection`` key; read defensively so the field's
+    # default applies instead of raising ``ConfigAttributeError`` (sibling of
+    # #240; matches the orchestrator's getattr guard for the same key).
+    configured_selection = (
+        None if reporting_cfg is None else getattr(reporting_cfg, "sample_selection", None)
+    )
     explicit_samples = resolve_report_sample_selection(
         configured_selection,
         sample_ids=outputs.sample_ids,

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -2660,3 +2660,41 @@ def test_overlay_draws_index_tags_and_legend_below_image() -> None:
     # no long per-box label is stamped beside the boxes (only tags + legend)
     assert not any(t.startswith("#0 kite") for t in texts if "\n" not in t)
     plt.close(fig)
+
+
+def test_build_report_handles_reporting_block_without_sample_selection(
+    tmp_path: Path,
+) -> None:
+    """Regression (sibling of #240): a struct-mode ``reporting:`` block that
+    omits the optional ``sample_selection`` key must not crash report building.
+
+    Like ``model.class_names`` in #240, ``build_report`` read
+    ``reporting_cfg.sample_selection`` unconditionally. When ``config.reporting``
+    arrives as a YAML-loaded struct-mode ``DictConfig`` (``object_type=dict``)
+    that never declares the key, the attribute access raised
+    ``ConfigAttributeError`` before ``resolve_report_sample_selection`` could
+    apply its default. The read must be defensive, matching the ``getattr``
+    guard the orchestrator already uses for the same key.
+    """
+    config = AppConfig(experiment_name="no-sample-selection")
+    set_output_root(config, tmp_path)
+    # Build a struct-mode reporting block carrying every ReportingConfig field
+    # EXCEPT ``sample_selection`` — isolates the failure to the line-51 read.
+    reporting_dict = OmegaConf.to_container(
+        OmegaConf.structured(ReportingConfig(_target_="PDFReporter", filename="report.pdf")),
+        resolve=True,
+    )
+    assert isinstance(reporting_dict, dict)
+    reporting_dict.pop("sample_selection", None)
+    reporting_block = OmegaConf.create(reporting_dict)
+    OmegaConf.set_struct(reporting_block, True)
+    config.reporting = reporting_block  # type: ignore[assignment]
+
+    outputs = _run_outputs(
+        forward_output=_fo(torch.tensor([[0.1, 0.9]])),
+        sample_ids=["a"],
+    )
+
+    # Must not raise ConfigAttributeError on the optional-key read.
+    report = build_report(config, outputs)
+    assert report is not None

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -2662,6 +2662,47 @@ def test_overlay_draws_index_tags_and_legend_below_image() -> None:
     plt.close(fig)
 
 
+def test_overlay_dedups_boxes_repeated_across_explainers() -> None:
+    """Regression for #241: each physical box is explained by every explainer, so
+    ``outputs.explanations`` holds one result per (box x explainer). The overlay
+    must draw each box ONCE — one rectangle, one ``#i`` tag, one legend line —
+    not once per explainer, and the drawn set must match the legend 1:1.
+    """
+    from matplotlib.patches import Rectangle
+
+    # Two physical boxes, each explained by three explainers => three distinct
+    # DetectionBox instances per box, all sharing one display_index. Distinct
+    # instances (not the same object) prove the dedup keys on display_index value,
+    # not object identity.
+    explanations: list[_DetExpl] = []
+    for _ in range(3):  # IntegratedGradients / LayerGradCam / SHAP
+        explanations.append(_DetExpl(_det_box(display_index=0, label_name="horse", score=0.85), 0))
+        explanations.append(
+            _DetExpl(_det_box(display_index=1, label_name="stop sign", score=0.73), 0)
+        )
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    ax.imshow(torch.zeros(50, 50, 3).numpy())
+    _overlay_detection_boxes(
+        fig,
+        outputs=_DetOutputs(explanations),  # type: ignore[arg-type]
+        sample_index=0,
+    )
+
+    texts = [t.get_text() for t in ax.texts]
+    legend = next(t for t in texts if "\n" in t)
+    legend_lines = legend.split("\n")
+    tags = [t for t in texts if "\n" not in t]  # compact #i image tags
+    rects = [p for p in ax.patches if isinstance(p, Rectangle)]
+
+    # Each physical box drawn once; legend reflects exactly the drawn set (1:1).
+    assert len(rects) == len(legend_lines) == len(tags) == 2
+    assert legend_lines == ["#0 horse (0.85)", "#1 stop sign (0.73)"]
+    assert sorted(tags) == ["#0", "#1"]
+    plt.close(fig)
+
+
 def test_build_report_handles_reporting_block_without_sample_selection(
     tmp_path: Path,
 ) -> None:

--- a/src/raitap/transparency/explainers/tests/test_shap_parity.py
+++ b/src/raitap/transparency/explainers/tests/test_shap_parity.py
@@ -79,3 +79,28 @@ def test_gradient_explainer_int_target_matches_direct_call(
     ref = _stack_select(sv, target=0)
 
     assert torch.allclose(out.detach().cpu(), ref.detach().cpu(), rtol=_RTOL, atol=_ATOL)
+
+
+def test_gradient_explainer_per_sample_target_matches_direct_call(
+    _shap: Any, seeded: Callable[..., None]
+) -> None:
+    """Per-sample list target → class-stack + advanced-index select must match a
+    direct shap call. Exercises the ``_select_target_attributions`` per-sample
+    branch — the wrapper logic with the most surface for wiring bugs."""
+    from raitap.transparency.explainers import ShapExplainer
+
+    seeded()
+    model = make_tiny_classifier(seed=0)
+    x = torch.randn(2, 3, 8, 8)
+    bg = torch.randn(2, 3, 8, 8)
+
+    seeded()
+    out = ShapExplainer("GradientExplainer").compute_attributions(
+        model, x, background_data=bg, target=[0, 1]
+    )
+
+    seeded()
+    sv = _shap.GradientExplainer(model, bg).shap_values(x)
+    ref = _stack_select(sv, target=[0, 1])
+
+    assert torch.allclose(out.detach().cpu(), ref.detach().cpu(), rtol=_RTOL, atol=_ATOL)

--- a/src/raitap/transparency/explainers/tests/test_shap_parity.py
+++ b/src/raitap/transparency/explainers/tests/test_shap_parity.py
@@ -1,0 +1,81 @@
+# src/raitap/transparency/explainers/tests/test_shap_parity.py
+"""Tier-1 parity: raitap's ShapExplainer returns the same numbers as a direct
+shap call for the same model/inputs/config/seed. Catches dropped kwargs, wrong
+target wiring, or stray mutation in the data path. SHAP needs this most: it does
+real post-processing (multi-class class-stacking + per-sample target selection)
+between the library call and the persisted artefact, unlike the near
+pass-through Captum wrapper."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import torch
+
+from raitap.testing import make_tiny_classifier
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+pytestmark = [pytest.mark.e2e, pytest.mark.parity]
+
+_RTOL = 1e-5
+_ATOL = 1e-6
+
+
+@pytest.fixture
+def _shap() -> Any:
+    return pytest.importorskip("shap")
+
+
+def _stack_select(shap_values: Any, *, target: int | list[int]) -> torch.Tensor:
+    """Replicate the wrapper's documented post-processing explicitly.
+
+    1. Normalise to a class-last tensor: a list of per-class arrays is stacked on
+       ``dim=-1``; an ndarray/tensor already carries the class axis last.
+    2. Select the target: an int indexes the class axis directly; a per-sample
+       list advanced-indexes one class per sample.
+
+    Mirrors ``shap_explainer._select_target_attributions`` but spelled out here
+    so the reference path stays independent of the code under test.
+    """
+    if isinstance(shap_values, list):
+        stacked = torch.stack(
+            [v if isinstance(v, torch.Tensor) else torch.from_numpy(v) for v in shap_values],
+            dim=-1,
+        )
+    elif isinstance(shap_values, torch.Tensor):
+        stacked = shap_values
+    else:
+        stacked = torch.from_numpy(shap_values)
+
+    if isinstance(target, int):
+        return stacked[..., target]
+
+    target_tensor = torch.tensor(target, dtype=torch.long)
+    batch_indices = torch.arange(stacked.shape[0], dtype=torch.long)
+    return stacked[batch_indices, ..., target_tensor]
+
+
+def test_gradient_explainer_int_target_matches_direct_call(
+    _shap: Any, seeded: Callable[..., None]
+) -> None:
+    """int target → class-stack + int-select must match a direct shap call."""
+    from raitap.transparency.explainers import ShapExplainer
+
+    seeded()
+    model = make_tiny_classifier(seed=0)
+    x = torch.randn(2, 3, 8, 8)
+    bg = torch.randn(2, 3, 8, 8)
+
+    seeded()  # GradientExplainer path-samples via numpy RNG; pin before each path.
+    out = ShapExplainer("GradientExplainer").compute_attributions(
+        model, x, background_data=bg, target=0
+    )
+
+    seeded()
+    sv = _shap.GradientExplainer(model, bg).shap_values(x)
+    ref = _stack_select(sv, target=0)
+
+    assert torch.allclose(out.detach().cpu(), ref.detach().cpu(), rtol=_RTOL, atol=_ATOL)

--- a/src/raitap/transparency/phase.py
+++ b/src/raitap/transparency/phase.py
@@ -188,8 +188,12 @@ def _assess_transparency_detection(
 
     explanations: list[ExplanationResult] = []
     backend = _require_model_backend(model)
+    # ``config.model`` is a struct-mode DictConfig; when the YAML omits the
+    # optional ``class_names`` key an unconditional read raises
+    # ``ConfigAttributeError``. Read defensively so the optional field +
+    # backend fallback in ``resolve_category_names`` work as designed (#240).
     category_names = resolve_category_names(
-        config.model.class_names,
+        getattr(config.model, "class_names", None),
         backend.category_names,
     )
     data_labels = getattr(data, "labels", None)

--- a/src/raitap/transparency/report.py
+++ b/src/raitap/transparency/report.py
@@ -594,12 +594,22 @@ def _overlay_detection_boxes(
     """Draw every detection box for a sample onto the thumbnail figure."""
     from matplotlib import patches as mpatches
 
-    boxes = [
-        explanation.detection_box
-        for explanation in outputs.explanations
-        if explanation.detection_box is not None
-        and explanation.original_sample_index == sample_index
-    ]
+    # Each physical box is explained by every explainer, so ``outputs.explanations``
+    # holds one result per (box x explainer). Dedup by ``display_index`` (the
+    # user-facing ordinal, unique per box in a sample) so each box is drawn once —
+    # one rectangle, one ``#i`` tag, one legend line — instead of once per
+    # explainer (#241). Order-preserving: first occurrence wins.
+    boxes: list[DetectionBox] = []
+    seen: set[int] = set()
+    for explanation in outputs.explanations:
+        box = explanation.detection_box
+        if (
+            box is not None
+            and explanation.original_sample_index == sample_index
+            and box.display_index not in seen
+        ):
+            seen.add(box.display_index)
+            boxes.append(box)
     if not boxes:
         return
     axes = figure.axes

--- a/src/raitap/transparency/tests/test_assess_transparency_detection.py
+++ b/src/raitap/transparency/tests/test_assess_transparency_detection.py
@@ -561,3 +561,93 @@ def test_assess_transparency_detection_skips_when_no_explainers(tmp_path: Path) 
         resolved_preprocessing=None,
     )
     assert explanations == []
+
+
+def test_assess_transparency_detection_handles_model_block_without_class_names(
+    tmp_path: Path,
+) -> None:
+    """Regression for #240: a struct-mode ``model:`` block that omits
+    ``class_names`` must not crash the transparency phase.
+
+    The real pipeline hands ``config.model`` as a YAML-loaded struct-mode
+    ``DictConfig`` (``object_type=dict``). When the block never declares the
+    optional ``class_names`` key, the unconditional attribute read raised
+    ``ConfigAttributeError`` before ``resolve_category_names`` could fall back
+    to ``backend.category_names``. The read must be defensive so the optional
+    field + backend fallback work as designed.
+    """
+    from omegaconf import OmegaConf
+
+    config = AppConfig(experiment_name="no-class-names")
+    set_output_root(config, tmp_path)
+    # Mirror a YAML-loaded model block: a plain struct-mode DictConfig that
+    # never declares ``class_names`` (object_type=dict, struct=True).
+    model_block = OmegaConf.create({"source": "fasterrcnn_resnet50_fpn_v2"})
+    OmegaConf.set_struct(model_block, True)
+    config.model = model_block  # type: ignore[assignment]
+    config.transparency = {
+        "ig_det": TransparencyConfig(
+            _target_="CaptumExplainer",
+            algorithm="IntegratedGradients",
+            call={"target": 0},
+            raitap={"detection": {"score_threshold": 0.5, "max_boxes": 5}},
+            visualisers=[{"_target_": "DetectionImageVisualiser"}],
+        )
+    }
+
+    model = _FakeModel()
+    data = _FakeData(num_samples=1)
+    forward = _make_detection_forward_output(num_samples=1)
+
+    def fake_explain_detection(**kwargs: Any) -> Iterator[ExplanationResult]:
+        from raitap.transparency.results import ExplanationResult as _Result
+
+        r = _Result.__new__(_Result)
+        r.attributions = torch.zeros(1, 3, 64, 64)
+        r.inputs = torch.zeros(1, 3, 64, 64)
+        r.visualisers = []
+        yield r
+
+    class _FakeExplainer:
+        algorithm = "IntegratedGradients"
+
+        def check_backend_compat(self, backend: object) -> None:
+            return None
+
+    with (
+        patch(
+            "raitap.transparency.phase.Explanation",
+            side_effect=AssertionError("classification path should not run"),
+        ),
+        patch(
+            "raitap.transparency.factory.create_explainer",
+            return_value=(_FakeExplainer(), "raitap.transparency.CaptumExplainer"),
+        ),
+        patch("raitap.transparency.factory.create_visualisers", return_value=[]),
+        patch(
+            "raitap.transparency.factory.check_explainer_visualiser_compat",
+            return_value=None,
+        ),
+        patch(
+            "raitap.transparency.factory.check_explainer_visualiser_payload_compat",
+            return_value=None,
+        ),
+        patch(
+            "raitap.transparency.factory.check_explainer_visualiser_semantic_compat",
+            return_value=None,
+        ),
+        patch(
+            "raitap.transparency.explain_detection.explain_detection",
+            side_effect=fake_explain_detection,
+        ),
+    ):
+        explanations = assess_transparency(
+            config,
+            model,  # type: ignore[arg-type]
+            data,  # type: ignore[arg-type]
+            forward,
+            input_metadata=None,
+            resolved_preprocessing=None,
+        )
+
+    assert len(explanations) == 1


### PR DESCRIPTION
## Summary

Minor fixes for the 0.13.x line, gathered on `final-minor-bugfixes`:

- **#240** — transparency/reporting crash on optional config keys omitted from a struct-mode block (+ swept sibling in the report builder).
- **#241** — detection "Original image" overlay repeated each box once per explainer.
- **#248** — `ShapExplainer` was the only attribution/attack backend without a parity test.

### Config struct-key read guards (#240)

Two transparency/reporting runs crashed at startup when an optional config key was omitted from a struct-mode `DictConfig` (`object_type=dict`, the shape a YAML-loaded block takes without schema merge):

- the detection transparency branch read `config.model.class_names` unconditionally. Absent key → `ConfigAttributeError` before `resolve_category_names` could fall back to the backend categories. Now read via `getattr(..., None)` so the optional field + backend fallback work as designed.
- **Sibling (swept, reachability proven)** — `build_report` read `reporting_cfg.sample_selection` the same way; a `reporting:` block omitting the key crashed report building. The orchestrator already guards the identical key with `getattr`; applied the same guard in the builder.

Both fixes are behavior-preserving when the key is present (existing `class_names`-set tests still pass).

### Detection overlay box dedup (#241)

The per-sample "Original image" overlay drew each detection box once **per explainer** — rectangles/`#i` tags overlapped (invisible) but the legend stacked N×K rows. Fixed by deduping collected boxes by `display_index` before drawing; the same deduplicated list feeds both the drawing and the legend, so the drawn set matches the legend 1:1. Cosmetic; attributions/metadata unaffected.

### SHAP parity test (#248)

Adds `test_shap_parity.py`. Two `GradientExplainer` tests (int target + per-sample list target) assert the wrapper returns the same numbers as a direct `shap.GradientExplainer` call, covering the wrapper's class-stacking and `_select_target_attributions` post-processing. Re-seeds before each path for the stochastic path-sampling; verified `max|Δ| = 0.0`. Characterization only — no production code change.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — If this PR breaks compatibility (API, configs, file formats, etc.), the title uses `!` after the type or scope (e.g. `feat!:` or `feat(transparency)!:`). I understand that this change will have a **direct, disruptive impact** on package users. I ensured that **this change is absolutely necessary and cannot be delayed**.
- [x] **Contributor guide** — I've read [**Pull requests and commit messages**](https://caiivs.github.io/raitap/contributor/pull-requests.html) before requesting review.

## Optional

- [x] **Issue** _(optional)_ — Closes #240. Closes #241. Closes #248.
- [ ] **Docs** _(optional)_ — User or contributor docs updated where needed.
- [x] **Tests** _(optional)_ — Regression tests for each: the `ConfigAttributeError` struct-key reads (#240), overlay box dedup with 1:1 drawn-vs-legend correspondence (#241), and SHAP `GradientExplainer` parity for both target modes (#248).
