### PR TITLE
refactor(transparency)!: unify visualiser-compat failures into one typed error

### DIFF
--- a/docs/contributor/logging.md
+++ b/docs/contributor/logging.md
@@ -81,7 +81,21 @@ class ShapExplainer(AttributionOnlyExplainer):
             return getattr(shap, self.algorithm)(model, ...).shap_values(inputs)
 ```
 
-The original exception is preserved on `__cause__`, so the raw traceback stays for debugging — only the user-facing top is rewritten. `RaitapError` subclasses render with the same `Module · via <lib> · View docs` chips as warnings.
+The original exception is preserved on `__cause__`, so the raw traceback stays for debugging; only the user-facing top is rewritten.
+
+### When to define a custom error type
+
+Default to raw `ValueError` / `TypeError`. The status frame renders any raitap-raised error via traceback classification (`print_failure_panel` / `RaitapRichHandler` walk the traceback to the owning module and draw the `Module · via <lib> · View docs` chips), so a custom type does **not** improve rendering.
+
+Define a `RaitapError` (or domain) subclass only on a **boundary**:
+
+- something `except`s it for control flow (e.g. `AssessorBackendIncompatibilityError` splits batch-fatal from per-sample isolation),
+- a test must assert that *specific* failure, not just "raised",
+- it crosses the public facade as a caller-visible contract.
+
+A subclass additionally carries an explicit `Diagnostic`, which beats the traceback heuristic when the raise site sits outside a classifiable module, or should point at a config knob instead of the raising line.
+
+Otherwise raw is correct. Type lazily, when the boundary appears.
 
 ## Module attribution
 

--- a/src/raitap/transparency/__init__.py
+++ b/src/raitap/transparency/__init__.py
@@ -57,7 +57,6 @@ from .contracts import (
     VisualSummarySpec,
 )
 from .exceptions import (
-    PayloadVisualiserIncompatibilityError,
     VisualiserIncompatibilityError,
 )
 from .semantics import (
@@ -243,7 +242,6 @@ __all__ = [  # noqa: RUF022
     "method_families_for_explainer",
     # Domain errors
     "BackendIncompatibilityError",
-    "PayloadVisualiserIncompatibilityError",
     "VisualiserIncompatibilityError",
     # Rest
     "create_explainer",

--- a/src/raitap/transparency/exceptions.py
+++ b/src/raitap/transparency/exceptions.py
@@ -2,44 +2,33 @@ from __future__ import annotations
 
 
 class VisualiserIncompatibilityError(Exception):
-    """Raised when a visualiser is not compatible with the chosen explainer algorithm."""
+    """A visualiser cannot render an explanation: one declared axis is unsupported.
 
-    def __init__(
-        self,
-        framework: str,
-        visualiser: str,
-        algorithm: str,
-        compatible_algorithms: list[str],
-    ) -> None:
-        self.framework = framework
+    Single typed failure for every transparency visualiser-compat gate — algorithm
+    allowlist, payload kind, and the typed §4.3 semantic axes (output space, scope,
+    method family). The predicate that decides incompatibility (subset / intersection
+    / membership) stays at the call site; this only carries the structured result.
+
+    Fields
+    ------
+    visualiser:
+        Class name of the rejecting visualiser.
+    axis:
+        Human label of the contract axis that failed (``"algorithm"``,
+        ``"payload kind"``, ``"output space"``, ``"scope"``, ``"method family"``,
+        ``"input metadata"``, …).
+    declared:
+        The explanation/explainer value(s) the visualiser rejects.
+    accepted:
+        What the visualiser supports on that axis (``"any"`` when wildcard).
+    """
+
+    def __init__(self, *, visualiser: str, axis: str, declared: str, accepted: str) -> None:
         self.visualiser = visualiser
-        self.algorithm = algorithm
-        self.compatible_algorithms = compatible_algorithms
+        self.axis = axis
+        self.declared = declared
+        self.accepted = accepted
         super().__init__(
-            f"Visualiser {visualiser!r} is not compatible with "
-            f"{framework}/{algorithm}.\n"
-            f"Compatible algorithms: {', '.join(compatible_algorithms) or 'none'}."
-        )
-
-
-class PayloadVisualiserIncompatibilityError(Exception):
-    """Raised when a visualiser does not accept the explainer's output payload kind."""
-
-    def __init__(
-        self,
-        *,
-        explainer_target: str,
-        visualiser: str,
-        output_payload_kind: str,
-        supported_payload_kinds: list[str],
-    ) -> None:
-        self.explainer_target = explainer_target
-        self.visualiser = visualiser
-        self.output_payload_kind = output_payload_kind
-        self.supported_payload_kinds = supported_payload_kinds
-        supported = ", ".join(supported_payload_kinds) if supported_payload_kinds else "none"
-        super().__init__(
-            f"Visualiser {visualiser!r} does not support explainer payload kind "
-            f"{output_payload_kind!r} (from {explainer_target}). "
-            f"That visualiser's supported_payload_kinds are: {supported}."
+            f"Visualiser {visualiser!r} is incompatible with this explanation: "
+            f"{axis} {declared!r} is not supported; expected {accepted}."
         )

--- a/src/raitap/transparency/factory.py
+++ b/src/raitap/transparency/factory.py
@@ -22,7 +22,7 @@ from .contracts import (
     MethodFamily,
     explainer_output_kind,
 )
-from .exceptions import PayloadVisualiserIncompatibilityError, VisualiserIncompatibilityError
+from .exceptions import VisualiserIncompatibilityError
 from .explainers.captum_explainer import CaptumExplainer
 from .explainers.shap_explainer import ShapExplainer
 from .results import ConfiguredVisualiser
@@ -99,11 +99,11 @@ def check_explainer_visualiser_payload_compat(
         if len(supported) == 0:
             continue
         if kind not in supported:
-            raise PayloadVisualiserIncompatibilityError(
-                explainer_target=explainer_target,
+            raise VisualiserIncompatibilityError(
                 visualiser=type(visualiser).__name__,
-                output_payload_kind=kind.value,
-                supported_payload_kinds=[k.value for k in sorted(supported, key=lambda x: x.value)],
+                axis="payload kind",
+                declared=kind.value,
+                accepted=", ".join(k.value for k in sorted(supported, key=lambda x: x.value)),
             )
 
 
@@ -128,11 +128,11 @@ def check_explainer_visualiser_semantic_compat(
         if supported_method_families and not (
             capability.method_families & supported_method_families
         ):
-            raise ValueError(
-                f"Visualiser {type(visualiser).__name__!r} does not support explainer "
-                f"method families {sorted(f.value for f in capability.method_families)}. "
-                "Its supported method families are "
-                f"{sorted(f.value for f in supported_method_families)}."
+            raise VisualiserIncompatibilityError(
+                visualiser=type(visualiser).__name__,
+                axis="method families",
+                declared=", ".join(sorted(f.value for f in capability.method_families)),
+                accepted=", ".join(sorted(f.value for f in supported_method_families)),
             )
 
         supported_output_spaces = _enum_frozenset(
@@ -143,12 +143,11 @@ def check_explainer_visualiser_semantic_compat(
             continue
         if capability.candidate_output_spaces & supported_output_spaces:
             continue
-        raise ValueError(
-            f"Visualiser {type(visualiser).__name__!r} does not support explainer "
-            "candidate output spaces "
-            f"{sorted(s.value for s in capability.candidate_output_spaces)}. "
-            "Its supported output spaces are "
-            f"{sorted(s.value for s in supported_output_spaces)}."
+        raise VisualiserIncompatibilityError(
+            visualiser=type(visualiser).__name__,
+            axis="candidate output spaces",
+            declared=", ".join(sorted(s.value for s in capability.candidate_output_spaces)),
+            accepted=", ".join(sorted(s.value for s in supported_output_spaces)),
         )
 
 
@@ -189,10 +188,10 @@ def check_explainer_visualiser_compat(
             algorithm,
             visualiser.compatible_algorithms,
             error_cls=VisualiserIncompatibilityError,
-            framework=explainer_target,
             visualiser=type(visualiser).__name__,
-            algorithm=algorithm,
-            compatible_algorithms=sorted(visualiser.compatible_algorithms),
+            axis="algorithm",
+            declared=algorithm,
+            accepted=", ".join(sorted(visualiser.compatible_algorithms)),
         )
 
 

--- a/src/raitap/transparency/report.py
+++ b/src/raitap/transparency/report.py
@@ -27,6 +27,7 @@ from raitap.reporting.staging import (
 )
 from raitap.tracking.base_tracker import Trackable
 from raitap.transparency.contracts import DetectionBox, ExplanationScope, VisualisationContext
+from raitap.transparency.exceptions import VisualiserIncompatibilityError
 from raitap.transparency.visualisers import BaseVisualiser, InputThumbnailVisualiser
 from raitap.utils.lazy import lazy_import
 
@@ -531,7 +532,7 @@ def _stage_sample_thumbnail(
             )
         try:
             visualiser.validate_explanation(explanation, attributions, inputs)
-        except ValueError as exc:
+        except (ValueError, VisualiserIncompatibilityError) as exc:
             last_error = exc
             continue
 

--- a/src/raitap/transparency/report.py
+++ b/src/raitap/transparency/report.py
@@ -532,7 +532,10 @@ def _stage_sample_thumbnail(
             )
         try:
             visualiser.validate_explanation(explanation, attributions, inputs)
-        except (ValueError, VisualiserIncompatibilityError) as exc:
+        except VisualiserIncompatibilityError as exc:
+            # Only an incompatibility means "this visualiser can't render this
+            # explanation, try the next". Any other error is a bug and must
+            # surface rather than be masked as a silently-skipped thumbnail.
             last_error = exc
             continue
 

--- a/src/raitap/transparency/tests/test_factory.py
+++ b/src/raitap/transparency/tests/test_factory.py
@@ -11,7 +11,6 @@ from omegaconf import OmegaConf
 
 from raitap.models.backend import ModelBackend
 from raitap.transparency import (
-    PayloadVisualiserIncompatibilityError,
     VisualiserIncompatibilityError,
 )
 from raitap.transparency.contracts import (
@@ -416,7 +415,7 @@ def test_payload_kind_mismatch_raises(
         lambda _cfg: [ConfiguredVisualiser(visualiser=_StructuredOnlyVisualiser(), call_kwargs={})],
     )
     model = SimpleNamespace(backend=_BackendStub(simple_cnn))
-    with pytest.raises(PayloadVisualiserIncompatibilityError):
+    with pytest.raises(VisualiserIncompatibilityError):
         _prepare_explanation(config, "test_explainer", cast("Model", model), sample_images)
 
 
@@ -543,7 +542,7 @@ def test_explanation_rejects_method_family_mismatch_before_compute(
     )
 
     model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
-    with pytest.raises(ValueError, match="method families"):
+    with pytest.raises(VisualiserIncompatibilityError, match="method families"):
         _prepare_explanation(
             config,
             "test_explainer",
@@ -610,7 +609,7 @@ def test_explanation_rejects_candidate_output_space_mismatch_before_compute(
     )
 
     model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
-    with pytest.raises(ValueError, match="candidate output spaces"):
+    with pytest.raises(VisualiserIncompatibilityError, match="candidate output spaces"):
         _prepare_explanation(
             config,
             "test_explainer",

--- a/src/raitap/transparency/tests/test_report.py
+++ b/src/raitap/transparency/tests/test_report.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
+import pytest
 import torch
 
 from raitap.transparency.exceptions import VisualiserIncompatibilityError
@@ -13,8 +14,6 @@ from raitap.transparency.visualisers import InputThumbnailVisualiser
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 
 def test_stage_sample_thumbnail_skips_visualiser_incompatibility(
@@ -56,3 +55,39 @@ def test_stage_sample_thumbnail_skips_visualiser_incompatibility(
     )
 
     assert result is None
+
+
+def test_stage_sample_thumbnail_propagates_unexpected_valueerror(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A bare ``ValueError`` from ``validate_explanation`` is a bug, not a rejection.
+
+    Only ``VisualiserIncompatibilityError`` means "this visualiser can't render this
+    explanation, skip it". An unexpected ``ValueError`` must surface, not be masked as
+    a silently-skipped thumbnail.
+    """
+
+    def _bug(self: object, *args: object, **kwargs: object) -> None:
+        raise ValueError("unexpected validate bug")
+
+    monkeypatch.setattr(InputThumbnailVisualiser, "validate_explanation", _bug)
+
+    explanation = SimpleNamespace(
+        original_sample_index=None,
+        attributions=torch.zeros(2, 10),
+        inputs=torch.zeros(2, 10),
+        kwargs={},
+        name="exp",
+        run_dir=tmp_path,
+    )
+    outputs = SimpleNamespace(explanations=[explanation])
+    selected = SimpleNamespace(summary=SimpleNamespace(sample_index=0))
+
+    with pytest.raises(ValueError, match="unexpected validate bug"):
+        _stage_sample_thumbnail(
+            outputs,  # type: ignore[arg-type]
+            selected=selected,  # type: ignore[arg-type]
+            assets_dir=tmp_path,
+            target_name="thumb.png",
+        )

--- a/src/raitap/transparency/tests/test_report.py
+++ b/src/raitap/transparency/tests/test_report.py
@@ -1,0 +1,58 @@
+"""Tests for transparency report staging helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import torch
+
+from raitap.transparency.exceptions import VisualiserIncompatibilityError
+from raitap.transparency.report import _stage_sample_thumbnail
+from raitap.transparency.visualisers import InputThumbnailVisualiser
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_stage_sample_thumbnail_skips_visualiser_incompatibility(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A visualiser that rejects an explanation must be skipped, not propagated.
+
+    Regression: ``validate_explanation`` raises ``VisualiserIncompatibilityError``
+    (not ``ValueError``); the per-explanation skip loop must still catch it.
+    """
+
+    def _reject(self: object, *args: object, **kwargs: object) -> None:
+        raise VisualiserIncompatibilityError(
+            visualiser="InputThumbnailVisualiser",
+            axis="input metadata",
+            declared="tabular",
+            accepted="image",
+        )
+
+    monkeypatch.setattr(InputThumbnailVisualiser, "validate_explanation", _reject)
+
+    explanation = SimpleNamespace(
+        original_sample_index=None,
+        attributions=torch.zeros(2, 10),
+        inputs=torch.zeros(2, 10),
+        kwargs={},
+        name="exp",
+        run_dir=tmp_path,
+    )
+    outputs = SimpleNamespace(explanations=[explanation])
+    selected = SimpleNamespace(summary=SimpleNamespace(sample_index=0))
+
+    result = _stage_sample_thumbnail(
+        outputs,  # type: ignore[arg-type]
+        selected=selected,  # type: ignore[arg-type]
+        assets_dir=tmp_path,
+        target_name="thumb.png",
+    )
+
+    assert result is None

--- a/src/raitap/transparency/visualisers/base_visualiser.py
+++ b/src/raitap/transparency/visualisers/base_visualiser.py
@@ -18,6 +18,7 @@ from raitap.transparency.contracts import (
     VisualisationContext,
     VisualSummarySpec,
 )
+from raitap.transparency.exceptions import VisualiserIncompatibilityError
 
 if TYPE_CHECKING:
     import torch
@@ -122,9 +123,11 @@ class BaseVisualiser(ABC, AdapterMixin):
             )
 
     def _raise_incompatibility(self, dimension: str, actual: str, expected: str) -> None:
-        raise ValueError(
-            f"Visualiser {type(self).__name__!r} is incompatible with this explanation: "
-            f"{dimension} {actual!r} is not supported; expected {expected}."
+        raise VisualiserIncompatibilityError(
+            visualiser=type(self).__name__,
+            axis=dimension,
+            declared=actual,
+            accepted=expected,
         )
 
     @abstractmethod

--- a/src/raitap/transparency/visualisers/tests/test_visualisers.py
+++ b/src/raitap/transparency/visualisers/tests/test_visualisers.py
@@ -34,6 +34,7 @@ from raitap.transparency.visualisers import (
     ShapImageVisualiser,
     ShapWaterfallVisualiser,
     TabularBarChartVisualiser,
+    VisualiserIncompatibilityError,
 )
 
 if TYPE_CHECKING:
@@ -138,7 +139,9 @@ class TestBaseVisualiserContract:
         explanation: SimpleNamespace,
         dimension: str,
     ) -> None:
-        with pytest.raises(ValueError, match=rf"_ContractVisualiser.*{dimension}"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=rf"_ContractVisualiser.*{dimension}"
+        ):
             _ContractVisualiser().validate_explanation(explanation, torch.zeros(4, 10), None)
 
 
@@ -187,7 +190,9 @@ class TestCaptumImageVisualiser:
     def test_validate_explanation_rejects_tabular_semantics(self) -> None:
         explanation = _explanation(input_kind="tabular", shape=(2, 10))
 
-        with pytest.raises(ValueError, match=r"CaptumImageVisualiser.*input metadata"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"CaptumImageVisualiser.*input metadata"
+        ):
             CaptumImageVisualiser().validate_explanation(explanation, torch.zeros(2, 10), None)
 
     def test_validate_explanation_rejects_contradictory_non_image_nchw_metadata(self) -> None:
@@ -198,7 +203,9 @@ class TestCaptumImageVisualiser:
             shape=(2, 3, 32, 32),
         )
 
-        with pytest.raises(ValueError, match=r"CaptumImageVisualiser.*input metadata"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"CaptumImageVisualiser.*input metadata"
+        ):
             CaptumImageVisualiser().validate_explanation(
                 explanation,
                 torch.zeros(2, 3, 32, 32),
@@ -213,7 +220,9 @@ class TestCaptumImageVisualiser:
             shape=None,
         )
 
-        with pytest.raises(ValueError, match=r"CaptumImageVisualiser.*input metadata"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"CaptumImageVisualiser.*input metadata"
+        ):
             CaptumImageVisualiser().validate_explanation(explanation, object(), None)  # type: ignore[arg-type]
 
     @pytest.mark.usefixtures("needs_captum")
@@ -556,7 +565,7 @@ class TestTabularBarChartVisualiser:
         self,
         explanation: SimpleNamespace,
     ) -> None:
-        with pytest.raises(ValueError, match="TabularBarChartVisualiser"):
+        with pytest.raises(VisualiserIncompatibilityError, match="TabularBarChartVisualiser"):
             TabularBarChartVisualiser().validate_explanation(explanation, torch.zeros(2, 10), None)
 
     def test_initialization_with_feature_names(self, feature_names: list[str]) -> None:
@@ -623,7 +632,7 @@ class TestCaptumTimeSeriesVisualiser:
         self,
         explanation: SimpleNamespace,
     ) -> None:
-        with pytest.raises(ValueError, match="CaptumTimeSeriesVisualiser"):
+        with pytest.raises(VisualiserIncompatibilityError, match="CaptumTimeSeriesVisualiser"):
             CaptumTimeSeriesVisualiser().validate_explanation(
                 explanation,
                 torch.zeros(12),
@@ -649,7 +658,9 @@ class TestCaptumTimeSeriesVisualiser:
             method_families=method_families,
         )
 
-        with pytest.raises(ValueError, match=r"CaptumTimeSeriesVisualiser.*method family"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"CaptumTimeSeriesVisualiser.*method family"
+        ):
             CaptumTimeSeriesVisualiser().validate_explanation(
                 explanation,
                 torch.zeros(2, 12, 3),
@@ -674,7 +685,7 @@ class TestCaptumTimeSeriesVisualiser:
         self,
         explanation: SimpleNamespace,
     ) -> None:
-        with pytest.raises(ValueError, match="CaptumTimeSeriesVisualiser"):
+        with pytest.raises(VisualiserIncompatibilityError, match="CaptumTimeSeriesVisualiser"):
             CaptumTimeSeriesVisualiser().validate_explanation(
                 explanation,
                 torch.zeros(2, 12, 3),
@@ -749,7 +760,7 @@ class TestCaptumTextVisualiser:
         self,
         explanation: SimpleNamespace,
     ) -> None:
-        with pytest.raises(ValueError, match="CaptumTextVisualiser"):
+        with pytest.raises(VisualiserIncompatibilityError, match="CaptumTextVisualiser"):
             CaptumTextVisualiser().validate_explanation(
                 explanation,
                 torch.zeros(2, 10),
@@ -776,7 +787,9 @@ class TestCaptumTextVisualiser:
             method_families=method_families,
         )
 
-        with pytest.raises(ValueError, match=r"CaptumTextVisualiser.*method family"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"CaptumTextVisualiser.*method family"
+        ):
             CaptumTextVisualiser().validate_explanation(explanation, torch.zeros(12), None)
 
     @pytest.mark.parametrize(
@@ -803,7 +816,7 @@ class TestCaptumTextVisualiser:
         self,
         explanation: SimpleNamespace,
     ) -> None:
-        with pytest.raises(ValueError, match="CaptumTextVisualiser"):
+        with pytest.raises(VisualiserIncompatibilityError, match="CaptumTextVisualiser"):
             CaptumTextVisualiser().validate_explanation(explanation, torch.zeros(12), None)
 
     def test_visualise_1d_tensor(self, sample_text_attributions: torch.Tensor) -> None:
@@ -856,7 +869,9 @@ class TestShapBarVisualiser:
             method_families={MethodFamily.SHAPLEY, MethodFamily.GRADIENT},
         )
 
-        with pytest.raises(ValueError, match=r"ShapBarVisualiser.*tabular layout"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"ShapBarVisualiser.*tabular layout"
+        ):
             ShapBarVisualiser().validate_explanation(explanation, torch.zeros(2, 3, 32, 32), None)
 
     def test_validate_explanation_rejects_shape_only_semantics(self) -> None:
@@ -868,7 +883,9 @@ class TestShapBarVisualiser:
             method_families={MethodFamily.SHAPLEY},
         )
 
-        with pytest.raises(ValueError, match=r"ShapBarVisualiser.*tabular layout"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"ShapBarVisualiser.*tabular layout"
+        ):
             ShapBarVisualiser().validate_explanation(explanation, torch.zeros(4, 10), None)
 
     @pytest.mark.usefixtures("needs_shap")
@@ -919,7 +936,9 @@ class TestShapBeeswarmVisualiser:
             method_families={MethodFamily.SHAPLEY, MethodFamily.GRADIENT},
         )
 
-        with pytest.raises(ValueError, match=r"ShapBeeswarmVisualiser.*tabular layout"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"ShapBeeswarmVisualiser.*tabular layout"
+        ):
             ShapBeeswarmVisualiser().validate_explanation(
                 explanation,
                 torch.zeros(2, 3, 32, 32),
@@ -935,7 +954,9 @@ class TestShapBeeswarmVisualiser:
             method_families={MethodFamily.SHAPLEY},
         )
 
-        with pytest.raises(ValueError, match=r"ShapBeeswarmVisualiser.*tabular layout"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"ShapBeeswarmVisualiser.*tabular layout"
+        ):
             ShapBeeswarmVisualiser().validate_explanation(
                 explanation,
                 torch.zeros(4, 10),
@@ -1055,7 +1076,9 @@ class TestShapImageVisualiser:
             method_families={MethodFamily.SHAPLEY, MethodFamily.GRADIENT},
         )
 
-        with pytest.raises(ValueError, match=r"ShapImageVisualiser.*input metadata"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"ShapImageVisualiser.*input metadata"
+        ):
             ShapImageVisualiser().validate_explanation(
                 explanation,
                 torch.zeros(2, 3, 32, 32),
@@ -1071,7 +1094,9 @@ class TestShapImageVisualiser:
             method_families={MethodFamily.SHAPLEY, MethodFamily.GRADIENT},
         )
 
-        with pytest.raises(ValueError, match=r"ShapImageVisualiser.*input metadata"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"ShapImageVisualiser.*input metadata"
+        ):
             ShapImageVisualiser().validate_explanation(explanation, object(), None)  # type: ignore[arg-type]
 
     @pytest.mark.parametrize(
@@ -1093,7 +1118,9 @@ class TestShapImageVisualiser:
             method_families=method_families,
         )
 
-        with pytest.raises(ValueError, match=r"ShapImageVisualiser.*method family"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"ShapImageVisualiser.*method family"
+        ):
             ShapImageVisualiser().validate_explanation(
                 explanation,
                 torch.zeros(2, 3, 32, 32),
@@ -1349,7 +1376,9 @@ class TestInputThumbnailVisualiser:
     def test_rejects_unsupported_input_kind(self) -> None:
         visualiser = InputThumbnailVisualiser()
 
-        with pytest.raises(ValueError, match=r"InputThumbnailVisualiser.*input metadata"):
+        with pytest.raises(
+            VisualiserIncompatibilityError, match=r"InputThumbnailVisualiser.*input metadata"
+        ):
             visualiser.validate_explanation(
                 _explanation(input_kind="tabular", shape=(1, 4)),
                 torch.zeros(1, 4),


### PR DESCRIPTION
@
## Summary

Closes #257.

The transparency visualiser-compat gates raised the same conceptual failure ("this visualiser cant render this explanation") three inconsistent ways: a typed `VisualiserIncompatibilityError` (algorithm axis), a typed `PayloadVisualiserIncompatibilityError` (payload kind), and **bare `ValueError`** (the §4.3 semantic axes — output space / scope / method family). This unifies them onto one axis-aware typed error, and uses that to fix a real masking bug.

### The concrete win

`report.py::_stage_sample_thumbnail` loops visualisers and skips the ones that cant render a given explanation (`except ... continue`). It caught bare `ValueError` — which also swallowed *any unrelated* `ValueError` bug inside `validate_explanation`, silently producing a missing thumbnail instead of surfacing the error.

Now `validate_explanation` rejects only via the typed `VisualiserIncompatibilityError`, and the staging loop catches **only** that. An incompatibility is skipped (intended); any other error propagates and surfaces. The fallback no longer masks genuine bugs. Regression tests cover both directions (skip-on-incompat, propagate-on-bug).

### The plumbing that enables it

- `VisualiserIncompatibilityError(*, visualiser, axis, declared, accepted)` — single typed failure for every gate. The incompatibility predicate (subset / intersection / membership) stays **inline** at each call site; only the build-and-raise is shared.
- `PayloadVisualiserIncompatibilityError` folded in and deleted.
- `base_visualiser._raise_incompatibility` is the choke point, so all subclass `validate_explanation` overrides (shap / captum / tabular / input_thumbnail) funnel through the typed error automatically.
- Docs: `logging.md` gains a "when to define a custom error type" rule (type only on a catch / test / facade boundary — the frame already renders any error via traceback classification) and the old misleading "subclass needed for chips" line is corrected.

### Why breaking

Removes the public `PayloadVisualiserIncompatibilityError` export and changes `VisualiserIncompatibilityError`s constructor signature (positional `framework/algorithm/...` → keyword `visualiser/axis/declared/accepted`). Pre-1.0, clean break, no shims.

### Out of scope (deliberate)

Backend capability gate, robustness assessors, and `AssessorBackendIncompatibilityError` are untouched — already typed, the one that matters is actively caught, and a cross-module sweep would be churn for tidiness. No repo-wide raw-error typing, and no shared "compatibility gate" abstraction: the three gates use three different set predicates (subset / intersection / membership) over two different type systems (flat `Capability` enum vs typed §4.3 axes); one interface would hide the predicate or erase the typing. See #257 for the full rationale.

### Verification

- Full `transparency` module: 438 passed, 11 skipped.
- `ruff format` + `ruff check` clean; `pyright` 0 errors.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — title uses `!`; necessary pre-1.0 clean break of two public error symbols.
- [x] **Contributor guide** — read.

## Optional

- [x] **Issue** _(optional)_ — Closes #257.
- [x] **Docs** _(optional)_ — `logging.md` error-typing rule.
- [x] **Tests** _(optional)_ — assertions retargeted to the typed error; `test_report.py` covers skip-on-incompat and propagate-on-bug.
@