### PR TITLE
refactor(data): make input modality first-class and Data-owned (refs #253)

### DIFF
--- a/docs/contributor/modules/data.md
+++ b/docs/contributor/modules/data.md
@@ -88,6 +88,21 @@ Both sides (sample ids from disk + label ids from the file) are normalised
 the same way before lookup. Duplicate normalised label ids raise a
 warning and disable label-based metrics for that run.
 
+## Input modality
+
+`Data` records the modality it loaded as `Data.input_modality` (`InputModality.image`
+or `InputModality.tabular`, from `raitap.data.types`). The branch taken in
+`Data._load_data` sets it; nothing re-derives it.
+
+`infer_data_input_metadata` reads `input_modality` to pick `kind`/`layout`
+(`image` -> `NCHW`, `tabular` -> `(B,F)`), falling back to source-path sniffing only
+when no modality is recorded. Extension sets live once in
+`MODALITY_EXTENSIONS` (`raitap.data.types`); `data.py` and `metadata.py` import them.
+
+A new non-image modality adds a member to `InputModality`, an extension entry to
+`MODALITY_EXTENSIONS`, a load branch in `_load_data`, and a `kind`/`layout` branch
+in `infer_data_input_metadata` (which switches on the recorded modality).
+
 ## Image preprocessing internals
 
 User-facing surface lives at {doc}`/modules/data/preprocessing` — that doc is

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -60,7 +60,7 @@ class Data(Trackable):
         self.task_kind = task_kind
         self.tensor: torch.Tensor | DetectionInputs
         family = resolve_task_family(task_kind)
-        self.input_modality: InputModality | None
+        self.input_modality: InputModality
         raw_tensor, self.sample_ids, self.input_modality = self._load_data(
             cfg,
             resolved_preprocessing=resolved_preprocessing,
@@ -95,7 +95,11 @@ class Data(Trackable):
             cfg: Application configuration.
 
         Returns:
-            Raw data tensor or ragged list of per-image tensors (detection).
+            ``(tensor, sample_ids, input_modality)`` where ``tensor`` is the raw
+            data tensor (or a ragged ``list[Tensor]`` of per-image tensors for
+            detection), ``sample_ids`` are posix-relative file ids (``None`` for
+            tabular), and ``input_modality`` is the recorded
+            :class:`~raitap.data.types.InputModality`.
         """
         source = cfg.data.source
         if not source or not source.strip():

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -11,7 +11,7 @@ from PIL import Image
 
 from raitap import raitap_log
 from raitap.data.preprocessing import module_as_per_image_callable, resolve_preprocessing
-from raitap.data.types import IdStrategy, LabelEncoding
+from raitap.data.types import MODALITY_EXTENSIONS, IdStrategy, InputModality, LabelEncoding
 from raitap.data.utils import download_file
 from raitap.tracking.base_tracker import BaseTracker, Trackable
 from raitap.types import DetectionInputs, TaskKind
@@ -31,8 +31,11 @@ else:
 
 
 _CACHE_DIR = Path.home() / ".cache" / "raitap"
-_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
-_TABULAR_EXTENSIONS = {".csv", ".tsv", ".parquet"}
+_IMAGE_EXTENSIONS = MODALITY_EXTENSIONS[InputModality.image]
+_TABULAR_EXTENSIONS = MODALITY_EXTENSIONS[InputModality.tabular]
+# Pre-formatted for error messages: deterministic order, no ``frozenset(...)`` repr.
+_IMAGE_FORMATS = ", ".join(sorted(_IMAGE_EXTENSIONS))
+_TABULAR_FORMATS = ", ".join(sorted(_TABULAR_EXTENSIONS))
 
 
 class SourceKind(StrEnum):
@@ -57,7 +60,8 @@ class Data(Trackable):
         self.task_kind = task_kind
         self.tensor: torch.Tensor | DetectionInputs
         family = resolve_task_family(task_kind)
-        raw_tensor, self.sample_ids = self._load_data(
+        self.input_modality: InputModality | None
+        raw_tensor, self.sample_ids, self.input_modality = self._load_data(
             cfg,
             resolved_preprocessing=resolved_preprocessing,
         )
@@ -72,7 +76,7 @@ class Data(Trackable):
         cfg: AppConfig,
         *,
         resolved_preprocessing: ResolvedPreprocessing | None = None,
-    ) -> tuple[torch.Tensor | DetectionInputs, list[str] | None]:
+    ) -> tuple[torch.Tensor | DetectionInputs, list[str] | None, InputModality]:
         """
         Load data from a specified source into a raw tensor.
 
@@ -124,7 +128,7 @@ class Data(Trackable):
             # at their native resolution instead of pre-squashing them to
             # ``_DEMO_SIZE`` before the bundled Resize/CenterCrop sees them.
             tensor, sample_ids = _load_sample(source, per_image_transform=per_image_transform)
-            return tensor, sample_ids
+            return tensor, sample_ids, InputModality.image
 
         path = get_source_path(source, kind=SourceKind.DATA)
 
@@ -141,36 +145,49 @@ class Data(Trackable):
                     ragged = _load_images_ragged(
                         image_files, per_image_transform=per_image_transform
                     )
-                    return ragged, _resolve_sample_ids(image_files, root=path)
+                    return (
+                        ragged,
+                        _resolve_sample_ids(image_files, root=path),
+                        InputModality.image,
+                    )
                 tensor = torch.from_numpy(
                     _stack_images_numpy(image_files, per_image_transform=per_image_transform)
                 )
-                return tensor, _resolve_sample_ids(image_files, root=path)
+                return tensor, _resolve_sample_ids(image_files, root=path), InputModality.image
             if tabular_files:
                 tensor = torch.from_numpy(_concat_tabular_numpy(tabular_files))
-                return _apply_data_module_to_batch(data_module, tensor), None
+                return (
+                    _apply_data_module_to_batch(data_module, tensor),
+                    None,
+                    InputModality.tabular,
+                )
             raise FileNotFoundError(
                 f"No supported files found in {path}.\n"
-                f"Supported image formats: {_IMAGE_EXTENSIONS}\n"
-                f"Supported tabular formats: {_TABULAR_EXTENSIONS}"
+                f"Supported image formats: {_IMAGE_FORMATS}\n"
+                f"Supported tabular formats: {_TABULAR_FORMATS}"
             )
 
         suffix = path.suffix.lower()
         if suffix in _IMAGE_EXTENSIONS:
             if is_detection:
                 ragged = _load_images_ragged([path], per_image_transform=per_image_transform)
-                return ragged, _resolve_sample_ids([path], root=path.parent)
+                return ragged, _resolve_sample_ids([path], root=path.parent), InputModality.image
             return (
                 _load_images(path, per_image_transform=per_image_transform),
                 _resolve_sample_ids([path], root=path.parent),
+                InputModality.image,
             )
         if suffix in _TABULAR_EXTENSIONS:
-            return _apply_data_module_to_batch(data_module, _load_tabular(path)), None
+            return (
+                _apply_data_module_to_batch(data_module, _load_tabular(path)),
+                None,
+                InputModality.tabular,
+            )
 
         raise ValueError(
             f"Cannot infer data type from extension {suffix!r}.\n"
-            f"Supported image formats: {_IMAGE_EXTENSIONS}\n"
-            f"Supported tabular formats: {_TABULAR_EXTENSIONS}"
+            f"Supported image formats: {_IMAGE_FORMATS}\n"
+            f"Supported tabular formats: {_TABULAR_FORMATS}"
         )
 
     def describe(self) -> dict[str, Any]:
@@ -372,8 +389,8 @@ def _load_numpy_from_path(
             return _concat_tabular_numpy(tabular_files)
         raise FileNotFoundError(
             f"No supported files found in {path}.\n"
-            f"Supported image formats: {_IMAGE_EXTENSIONS}\n"
-            f"Supported tabular formats: {_TABULAR_EXTENSIONS}"
+            f"Supported image formats: {_IMAGE_FORMATS}\n"
+            f"Supported tabular formats: {_TABULAR_FORMATS}"
         )
 
     suffix = path.suffix.lower()
@@ -383,8 +400,8 @@ def _load_numpy_from_path(
         return _load_tabular_numpy(path)
     raise ValueError(
         f"Cannot infer data type from extension {suffix!r}.\n"
-        f"Supported image formats: {_IMAGE_EXTENSIONS}\n"
-        f"Supported tabular formats: {_TABULAR_EXTENSIONS}"
+        f"Supported image formats: {_IMAGE_FORMATS}\n"
+        f"Supported tabular formats: {_TABULAR_FORMATS}"
     )
 
 

--- a/src/raitap/data/metadata.py
+++ b/src/raitap/data/metadata.py
@@ -5,11 +5,12 @@ from pathlib import Path
 from typing import Any
 
 from raitap.configs import cfg_to_dict
+from raitap.data.types import MODALITY_EXTENSIONS, InputModality
 
 from .samples import SAMPLE_SOURCES
 
-_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
-_TABULAR_EXTENSIONS = {".csv", ".tsv", ".parquet"}
+_IMAGE_EXTENSIONS = MODALITY_EXTENSIONS[InputModality.image]
+_TABULAR_EXTENSIONS = MODALITY_EXTENSIONS[InputModality.tabular]
 
 
 @dataclass(frozen=True)
@@ -39,10 +40,19 @@ def infer_data_input_metadata(config: object, data: object) -> DataInputMetadata
             metadata=dict(explicit_mapping),
         )
 
+    shape = shape_tuple(getattr(getattr(data, "tensor", None), "shape", None))
+
+    modality = getattr(data, "input_modality", None)
+    if modality is InputModality.image:
+        return DataInputMetadata(kind="image", shape=shape, layout="NCHW")
+    if modality is InputModality.tabular:
+        return DataInputMetadata(kind="tabular", shape=shape, layout="(B,F)")
+
+    # Fallback for callers with no recorded modality (e.g. direct/test use):
+    # sniff the source path as before.
     source = str(
         getattr(data, "source", None) or getattr(getattr(config, "data", None), "source", "")
     )
-    shape = shape_tuple(getattr(getattr(data, "tensor", None), "shape", None))
     if is_image_source(source):
         return DataInputMetadata(kind="image", shape=shape, layout="NCHW")
     if is_tabular_source(source):
@@ -56,7 +66,7 @@ def _case_insensitive_glob(ext: str) -> str:
     return "*" + "".join(f"[{c.lower()}{c.upper()}]" if c.isalpha() else c for c in ext)
 
 
-def _has_extension_recursive(path: Path, extensions: set[str]) -> bool:
+def _has_extension_recursive(path: Path, extensions: frozenset[str]) -> bool:
     """True if any file under ``path`` (recursively) has a matching extension.
 
     Case-insensitive: ``IMG_001.JPG`` matches ``.jpg``. Iterates per-extension

--- a/src/raitap/data/tests/test_data_class.py
+++ b/src/raitap/data/tests/test_data_class.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from raitap.configs.schema import AppConfig
 
 from raitap.data import Data
+from raitap.data.types import InputModality
 
 
 def _write_image(path: Path) -> None:
@@ -351,6 +352,44 @@ class TestDataConstructor:
 
         with pytest.raises(ValueError, match=r"Unsupported data\.labels\.id_strategy"):
             Data(config)
+
+    def test_data_records_image_modality_for_image_dir(self, tmp_path: Path) -> None:
+        img_dir = tmp_path / "imgs"
+        img_dir.mkdir()
+        _write_image(img_dir / "a.png")
+        _write_image(img_dir / "b.png")
+        config = _make_config(str(img_dir))
+
+        data = Data(config)
+
+        assert data.input_modality is InputModality.image
+
+    def test_data_records_tabular_modality_for_csv(self, tmp_path: Path) -> None:
+        csv = tmp_path / "rows.csv"
+        csv.write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
+        config = _make_config(str(csv))
+
+        data = Data(config)
+
+        assert data.input_modality is InputModality.tabular
+
+    def test_data_records_image_modality_for_demo_sample(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Exercise the SAMPLE_SOURCES branch hermetically: stub the networked loader.
+        def _fake_load_sample(
+            name: str, *, per_image_transform: object = None
+        ) -> tuple[torch.Tensor, list[str]]:
+            assert name == "imagenet_samples"
+            assert per_image_transform is None or callable(per_image_transform)
+            return torch.zeros(2, 3, 8, 8), ["x.jpg", "y.jpg"]
+
+        monkeypatch.setattr("raitap.data.data._load_sample", _fake_load_sample)
+        config = _make_config("imagenet_samples")
+
+        data = Data(config)
+
+        assert data.input_modality is InputModality.image
 
     def test_data_raises_for_unsupported_labels_encoding(self, tmp_path: Path) -> None:
         csv_file = tmp_path / "data.csv"

--- a/src/raitap/data/tests/test_metadata.py
+++ b/src/raitap/data/tests/test_metadata.py
@@ -10,9 +10,47 @@ from raitap.data.metadata import (
     is_tabular_source,
     shape_tuple,
 )
+from raitap.data.types import InputModality
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+class _FakeTensor:
+    shape = (2, 3, 8, 8)
+
+
+def _fake_data(modality: InputModality, source: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        input_modality=modality,
+        tensor=_FakeTensor(),
+        source=source,
+        input_metadata=None,
+    )
+
+
+def test_recorded_image_modality_beats_unsniffable_source() -> None:
+    data = _fake_data(InputModality.image, "opaque://not-a-path")
+    md = infer_data_input_metadata(SimpleNamespace(data=None), data)
+    assert md.kind == "image"
+    assert md.layout == "NCHW"
+    assert md.shape == (2, 3, 8, 8)
+
+
+def test_recorded_tabular_modality_beats_unsniffable_source() -> None:
+    data = _fake_data(InputModality.tabular, "opaque://not-a-path")
+    md = infer_data_input_metadata(SimpleNamespace(data=None), data)
+    assert md.kind == "tabular"
+    assert md.layout == "(B,F)"
+
+
+def test_falls_back_to_source_sniff_when_modality_absent(tmp_path: Path) -> None:
+    csv = tmp_path / "rows.csv"
+    csv.write_text("a,b\n1,2\n", encoding="utf-8")
+    data = SimpleNamespace(input_metadata=None, tensor=_FakeTensor(), source=str(csv))
+    md = infer_data_input_metadata(SimpleNamespace(data=None), data)
+    assert md.kind == "tabular"
+    assert md.layout == "(B,F)"
 
 
 def test_infer_data_input_metadata_prefers_explicit_config_metadata() -> None:

--- a/src/raitap/data/tests/test_types.py
+++ b/src/raitap/data/tests/test_types.py
@@ -1,0 +1,16 @@
+from raitap.data.types import MODALITY_EXTENSIONS, InputModality
+
+
+def test_input_modality_has_only_todays_members() -> None:
+    assert {m.value for m in InputModality} == {"image", "tabular"}
+
+
+def test_modality_extensions_cover_every_member() -> None:
+    assert set(MODALITY_EXTENSIONS) == set(InputModality)
+
+
+def test_modality_extensions_values() -> None:
+    assert ".png" in MODALITY_EXTENSIONS[InputModality.image]
+    assert ".jpeg" in MODALITY_EXTENSIONS[InputModality.image]
+    assert ".csv" in MODALITY_EXTENSIONS[InputModality.tabular]
+    assert ".parquet" in MODALITY_EXTENSIONS[InputModality.tabular]

--- a/src/raitap/data/types.py
+++ b/src/raitap/data/types.py
@@ -42,3 +42,25 @@ class Preprocessing(StrEnum):
     """
 
     model_bundled = "model-bundled"
+
+
+class InputModality(StrEnum):
+    """Data modality recorded by :class:`raitap.data.data.Data` at load time.
+
+    Only the modalities raitap loads today. A future non-image family adds its
+    member here, an extension entry in ``MODALITY_EXTENSIONS``, a load branch in
+    ``Data._load_data``, and a ``kind``/``layout`` branch in
+    ``infer_data_input_metadata`` (which switches on the recorded modality).
+    """
+
+    image = "image"
+    tabular = "tabular"
+
+
+#: Single source of truth for which file extensions map to which modality.
+#: Imported by ``data.data`` and ``data.metadata`` so the sets are not
+#: redeclared at each call site.
+MODALITY_EXTENSIONS: dict[InputModality, frozenset[str]] = {
+    InputModality.image: frozenset({".jpg", ".jpeg", ".png", ".bmp", ".webp"}),
+    InputModality.tabular: frozenset({".csv", ".tsv", ".parquet"}),
+}


### PR DESCRIPTION
## What

Safe core of #253: make input **modality** (image vs tabular) first-class and `Data`-owned, so metadata inference reads a recorded tag instead of re-globbing the filesystem, and the duplicated extension literals collapse to one home.

- `data/types.py` — new `InputModality` StrEnum (`image`/`tabular`) + `MODALITY_EXTENSIONS` canonical map (single source of truth for extensions).
- `data/data.py` — `_load_data` tags every successful return with its modality; `Data.input_modality` set in `__init__`; module constants now derive from the map.
- `data/metadata.py` — `infer_data_input_metadata` reads the recorded modality first; the source-path sniff is demoted to a fallback for callers with no recorded modality. Layout strings (`NCHW`/`(B,F)`) unchanged.
- `docs/contributor/modules/data.md` — documents the concept (contributor audience).

## Why

The modality was already determined inside `Data._load_data` but discarded; `metadata.py` then re-derived it by re-globbing the filesystem, duplicating the extension sets and emitting hardcoded layout strings. This removes the image-centric guessing in a layer that already knows the answer, and gives a future non-image family a clean seam.

## Behaviour

Internal refactor. Output is byte-identical for today's image/tabular inputs (the sniff fallback preserves direct/test callers). Not a breaking change.

## Out of scope (deferred, recorded in #253)

- `load_inputs` hook — needs a real torch-currency non-image family (seq2seq/segmentation); signature blocked on the multi-tensor forward + explainer (#101).
- Generalized preprocessing positive path; discovery/`sample_ids` registry.
- Non-torch backends (trees/scikit/TF) — the model axis, tracked in #209 / #246.

## Tests

- New `test_types.py`; modality + non-sniffable-source + fallback + demo-sample cases across `test_data_class.py` / `test_metadata.py`.
- `uv run pytest src/raitap/data/tests` → **160 passed**.
- `ruff check` + `ruff format` clean; `pyright` **0 errors**.

Refs #253 (safe core; remaining scope stays open).

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — Not a breaking change (internal refactor, behaviour byte-identical for image/tabular); no `!` in the title.
- [x] **Contributor guide** — I’ve read [**Pull requests and commit messages**](https://caiivs.github.io/raitap/contributor/pull-requests.html) before requesting review.

## Optional

- [x] **Issue** _(optional)_ — Refs #253.
- [x] **Docs** _(optional)_ — `docs/contributor/modules/data.md` updated.
- [x] **Tests** _(optional)_ — New/updated tests cover the change (160 passed).
