### PR TITLE
refactor(model)!: backend-agnostic explanation contract + backend registry

### DIFF
--- a/docs/contributor/adding/adding-a-backend.md
+++ b/docs/contributor/adding/adding-a-backend.md
@@ -47,7 +47,7 @@ class MyBackend(ModelBackend):
         return self.model(inputs)
 
     @property
-    def hardware_label(self) -> str:  # human-readable runtime label, e.g. "CPU" / "CUDA"
+    def hardware_label(self) -> str:  # free-form display label for the run summary
         return get_hardware_label_for_mybackend(self.device)
 
     def autograd_module(self) -> nn.Module:  # only if AUTOGRAD-capable

--- a/docs/contributor/adding/adding-a-backend.md
+++ b/docs/contributor/adding/adding-a-backend.md
@@ -12,13 +12,16 @@ A **backend** wraps a model runtime and exposes a uniform interface to the pipel
 
 ## Steps
 
-We will use a fictional backend called `MyBackend`. It depends on Torch, but your real backend might not; the following is just an example.
+A backend is a one-file plugin. We will use a fictional backend called `MyBackend`. It depends on Torch, but your real backend might not; the following is just an example.
 
-1. **Subclass `ModelBackend`** and decorate with `@backends.register`.
-2. **Implement the three abstract methods**: `hardware_label`, `__call__`, `as_model_for_explanation`.
-3. **Declare `provides`**: the `frozenset[Capability]` your backend offers. The decorator type-checks it and sets it as a class variable. Torch backends pass `{Capability.AUTOGRAD}`; forward-only runtimes (ONNX) pass `frozenset()`.
+1. **Subclass `ModelBackend`** and decorate with `@backends.register(provides=..., extensions=...)`.
+2. **Declare `provides` and `extensions`**: `provides` is the `frozenset[Capability]` your backend offers; `extensions` is the set of file suffixes it loads. The decorator type-checks both, sets them as class variables, and indexes the backend by extension so model loading resolves the right backend for a given file.
+3. **Implement the abstract methods**: `from_path` (construct from a model file), `__call__` (run inference), and the `hardware_label` property.
+4. **`predict_callable` is inherited**: it returns `self.__call__`, the universal forward-only shape that model-agnostic explainers consume. You do not implement it.
+5. **`autograd_module` is opt-in**: implement it (return the live torch `nn.Module`) and declare `Capability.AUTOGRAD` ONLY if your backend exposes a differentiable torch module. Gradient explainers and attacks get this shape; model-agnostic ones get the predict callable.
 
 ```python
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -29,25 +32,33 @@ from raitap.models.backend import ModelBackend
 from raitap.types import Capability
 
 
-@backends.register(provides={Capability.AUTOGRAD})
+@backends.register(provides={Capability.AUTOGRAD}, extensions={".pth", ".pt"})
 class MyBackend(ModelBackend):
     def __init__(self, model: nn.Module) -> None:
         self.model = model
+
+    @classmethod
+    def from_path(
+        cls, path: Path, *, model_cfg: Any, hardware: str, allow_unsafe_pickle: bool = False
+    ) -> ModelBackend:  # load a model file into this backend
+        ...
+
+    def __call__(self, inputs: torch.Tensor) -> Any:  # run inference, return raw output
+        return self.model(inputs)
 
     @property
     def hardware_label(self) -> str:  # human-readable runtime label, e.g. "CPU" / "CUDA"
         return get_hardware_label_for_mybackend(self.device)
 
-    def __call__(self, inputs: torch.Tensor) -> Any:  # run inference, return raw output
-        return self.model(inputs)
-
-    def as_model_for_explanation(self) -> nn.Module:  # the object explainers consume
+    def autograd_module(self) -> nn.Module:  # only if AUTOGRAD-capable
         return self.model
 ```
 
+A non-torch or forward-only backend (e.g. ONNX) declares `provides=FORWARD_ONLY` (the empty capability set, imported from `raitap.types`), skips `autograd_module`, and runs model-agnostic explainers only.
+
 ## Which capabilities to declare
 
-Most backends provide `{Capability.AUTOGRAD}` (torch) or nothing (forward-only, e.g. ONNX). See {doc}`../capabilities` for the full list, what each means, and which algorithms require it.
+Most backends provide `{Capability.AUTOGRAD}` (torch) or `FORWARD_ONLY` (forward-only, e.g. ONNX). See {doc}`../capabilities` for the full list, what each means, and which algorithms require it.
 
 ## Optional attributes
 

--- a/src/raitap/backends.py
+++ b/src/raitap/backends.py
@@ -3,12 +3,12 @@
     from raitap import backends
     from raitap.types import Capability
 
-    @backends.register(provides={Capability.AUTOGRAD})
+    @backends.register(provides={Capability.AUTOGRAD}, extensions={".pth", ".pt"})
     class MyBackend(ModelBackend): ...
 
-Backends are not Hydra-config adapters (no registry, no entry-point plugins);
-the decorator only sets + type-checks the required ``provides``
-class constant at the decoration site.
+The decorator sets the ``provides`` + ``extensions`` class constants and indexes
+the backend by file extension, so ``model._load_from_path`` resolves it without a
+hardcoded dispatch. In-tree only (no external entry-point plugins yet).
 """
 
 from __future__ import annotations

--- a/src/raitap/models/access.py
+++ b/src/raitap/models/access.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from raitap.types import Capability
-from raitap.utils.errors import BackendIncompatibilityError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -41,10 +40,9 @@ def _require(backend: ModelBackend, proto: type) -> Any:
     so a failure here means the backend declared the capability but did not
     implement its Protocol (a backend-author bug)."""
     if not isinstance(backend, proto):
-        raise BackendIncompatibilityError(
-            adapter="explanation_model",
-            backend=type(backend).__name__,
-            missing=[proto.__name__],
+        raise TypeError(
+            f"{type(backend).__name__} declares its capability but does not implement "
+            f"{proto.__name__}. This is a backend-implementation bug."
         )
     return backend
 
@@ -67,5 +65,10 @@ def explanation_model(backend: ModelBackend, adapter: Any) -> ExplanationModel:
     shapes = adapter.required_capabilities() & SHAPE_CAPABILITIES
     if not shapes:
         return backend.predict_callable()
+    if len(shapes) != 1:
+        raise RuntimeError(
+            f"Adapter {type(adapter).__name__} declares {len(shapes)} model-shape "
+            f"capabilities ({sorted(str(c) for c in shapes)}); exactly one is required."
+        )
     (capability,) = shapes
     return _SHAPE_BY_CAPABILITY[capability](backend)

--- a/src/raitap/models/access.py
+++ b/src/raitap/models/access.py
@@ -1,0 +1,71 @@
+"""Capability-typed model access for explainers/assessors.
+
+The explanation pipeline asks a backend for the model SHAPE an adapter needs,
+keyed by the adapter's declared ``requires`` capability. Each shape is one
+capability; backends opt into a shape by implementing its Protocol. The base
+``ModelBackend`` carries only the universal ``predict_callable`` shape.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from raitap.types import Capability
+from raitap.utils.errors import BackendIncompatibilityError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import torch
+    import torch.nn as nn
+
+    from raitap.models.backend import ModelBackend
+
+    #: What an explainer receives: a torch ``nn.Module`` (autograd shape) or a
+    #: forward-only predict callable. Precise for type-checkers; ``Any`` at
+    #: runtime (below) keeps this module torch-free for the deps bootstrap.
+    ExplanationModel = nn.Module | Callable[[torch.Tensor], torch.Tensor]
+else:
+    ExplanationModel = Any
+
+
+@runtime_checkable
+class AutogradModelProvider(Protocol):
+    """A backend that can hand out a live differentiable torch ``nn.Module``."""
+
+    def autograd_module(self) -> nn.Module: ...
+
+
+def _require(backend: ModelBackend, proto: type) -> Any:
+    """Narrow ``backend`` to ``proto`` or raise. The capability gate runs first,
+    so a failure here means the backend declared the capability but did not
+    implement its Protocol (a backend-author bug)."""
+    if not isinstance(backend, proto):
+        raise BackendIncompatibilityError(
+            adapter="explanation_model",
+            backend=type(backend).__name__,
+            missing=[proto.__name__],
+        )
+    return backend
+
+
+#: Single authoritative binding: capability -> how to extract its model shape.
+#: ``EstimatorProvider`` / ``TREE_MODEL`` join here with the tree backend (#246).
+_SHAPE_BY_CAPABILITY: dict[Capability, Callable[[ModelBackend], ExplanationModel]] = {
+    Capability.AUTOGRAD: lambda b: _require(b, AutogradModelProvider).autograd_module(),
+}
+SHAPE_CAPABILITIES = frozenset(_SHAPE_BY_CAPABILITY)
+
+
+def explanation_model(backend: ModelBackend, adapter: Any) -> ExplanationModel:
+    """Return the model shape ``adapter`` needs from ``backend``.
+
+    ``adapter`` is any ``AdapterMixin`` (explainer or assessor); both expose
+    ``required_capabilities()``. Invariant: an adapter declares at most one
+    shape-capability. Model-agnostic adapters get the universal predict callable.
+    """
+    shapes = adapter.required_capabilities() & SHAPE_CAPABILITIES
+    if not shapes:
+        return backend.predict_callable()
+    (capability,) = shapes
+    return _SHAPE_BY_CAPABILITY[capability](backend)

--- a/src/raitap/models/backend.py
+++ b/src/raitap/models/backend.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar, overload
@@ -8,14 +7,14 @@ from typing import TYPE_CHECKING, Any, ClassVar, overload
 import numpy as np
 
 from raitap.models.registration import register
-from raitap.types import Capability, TaskKind
+from raitap.types import FORWARD_ONLY, Capability, TaskKind
 from raitap.utils.errors import ModelInputShapeError
 from raitap.utils.lazy import lazy_import
 
 from .runtime import _ONNX_RUNTIME_INSTALL_HINT, resolve_onnx_providers
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
     from pathlib import Path
 
     import onnxruntime as ort
@@ -132,12 +131,26 @@ class ModelBackend(ABC):
     """Backend-agnostic model runtime interface."""
 
     provides: ClassVar[frozenset[Capability]] = frozenset()
+    extensions: ClassVar[frozenset[str]] = frozenset()
     # Declared per-sample input shape with ``None`` marking dynamic dims
     # (typically the batch dim). ``None`` overall = no rank adaptation.
     expected_input_shape: tuple[int | None, ...] | None = None
     # Optional id->name table for the model's output classes (e.g. torchvision
     # detection ``weights.meta["categories"]``). ``None`` when unavailable.
     category_names: list[str] | None = None
+
+    @classmethod
+    def from_path(
+        cls, path: Path, *, model_cfg: Any, hardware: str, allow_unsafe_pickle: bool = False
+    ) -> ModelBackend:
+        """Construct this backend from a model file.
+
+        Default raises: file loading is not universal (in-memory/test backends
+        never load from a path). File-backed backends declared with
+        ``extensions=`` in ``@register`` override this; the registry calls it
+        from ``model._load_from_path``.
+        """
+        raise NotImplementedError(f"{cls.__name__} does not support construction from a file path.")
 
     @property
     @abstractmethod
@@ -161,12 +174,12 @@ class ModelBackend(ABC):
     def __call__(self, inputs: torch.Tensor) -> Any:
         """Run inference for ``inputs``."""
 
-    @abstractmethod
-    def as_model_for_explanation(self) -> nn.Module:
-        """Return the model object that explainers should consume."""
+    def predict_callable(self) -> Callable[[torch.Tensor], torch.Tensor]:
+        """Forward-only predict fn. Universal shape; defaults to ``__call__``."""
+        return self.__call__
 
 
-@register(provides={Capability.AUTOGRAD})
+@register(provides={Capability.AUTOGRAD}, extensions={".pth", ".pt"})
 class TorchBackend(ModelBackend):
     """PyTorch-backed model runtime."""
 
@@ -182,6 +195,19 @@ class TorchBackend(ModelBackend):
         self.device = torch.device("cpu") if device is None else device
         self._task_kind = task_kind if task_kind is not None else self._infer_task_kind(model)
         self.category_names = category_names
+
+    @classmethod
+    def from_path(
+        cls, path: Path, *, model_cfg: Any, hardware: str, allow_unsafe_pickle: bool = False
+    ) -> ModelBackend:
+        from raitap.models.model import _load_torch_module_from_path  # deferred: import cycle
+        from raitap.models.runtime import resolve_torch_device
+
+        device = resolve_torch_device(hardware)
+        module = _load_torch_module_from_path(
+            path, model_cfg=model_cfg, device=device, allow_unsafe_pickle=allow_unsafe_pickle
+        )
+        return cls(module, device=device, task_kind=getattr(model_cfg, "task_kind", None))
 
     @staticmethod
     def _infer_task_kind(model: nn.Module) -> TaskKind:
@@ -226,36 +252,11 @@ class TorchBackend(ModelBackend):
     def __call__(self, inputs: torch.Tensor | list[torch.Tensor]) -> Any:
         return self.model(inputs)
 
-    def as_model_for_explanation(self) -> nn.Module:
+    def autograd_module(self) -> nn.Module:
         return self.model
 
 
-@functools.cache
-def _onnx_explanation_module_cls() -> type:
-    # Class definition is deferred: ``nn.Module`` as a base class is evaluated
-    # at class-def time, which would trigger a real ``import torch`` and break
-    # the partial-extras-venv contract (see ``raitap.utils.lazy``). Building it
-    # lazily means the family ``__init__`` chain stays torch-free for the deps
-    # bootstrap; the first ``OnnxBackend`` instance trips this factory once.
-
-    class _OnnxExplanationModule(nn.Module):
-        def __init__(self, backend: OnnxBackend) -> None:
-            super().__init__()
-            self.backend = backend
-
-        def forward(self, inputs: torch.Tensor) -> torch.Tensor:
-            output = self.backend(inputs)
-            if not isinstance(output, torch.Tensor):
-                raise TypeError(
-                    "OnnxBackend explanation bridge expected a torch.Tensor output, "
-                    f"got {type(output).__name__}."
-                )
-            return output
-
-    return _OnnxExplanationModule
-
-
-@register(provides=frozenset())
+@register(provides=FORWARD_ONLY, extensions={".onnx"})
 class OnnxBackend(ModelBackend):
     """ONNX Runtime-backed model runtime."""
 
@@ -280,7 +281,6 @@ class OnnxBackend(ModelBackend):
         self.input_type = inputs[0].type
         self.output_names = [output.name for output in session.get_outputs()]
         self.expected_input_shape = _resolve_onnx_expected_shape(inputs[0].shape)
-        self._explanation_module = _onnx_explanation_module_cls()(self)
 
     @property
     def hardware_label(self) -> str:
@@ -301,7 +301,15 @@ class OnnxBackend(ModelBackend):
         return super()._prepare_inputs(inputs)
 
     @classmethod
-    def from_path(cls, path: Path, *, hardware: str = "gpu") -> OnnxBackend:
+    def from_path(
+        cls,
+        path: Path,
+        *,
+        model_cfg: Any = None,
+        hardware: str = "gpu",
+        allow_unsafe_pickle: bool = False,
+    ) -> OnnxBackend:
+        # model_cfg / allow_unsafe_pickle unused: ONNX needs neither.
         try:
             import onnxruntime as ort
         except ImportError as error:
@@ -348,9 +356,6 @@ class OnnxBackend(ModelBackend):
         input_array = self._tensor_to_numpy(prepared_inputs)
         primary = self.forward_numpy(input_array)
         return torch.from_numpy(np.asarray(primary))
-
-    def as_model_for_explanation(self) -> nn.Module:
-        return self._explanation_module
 
     def _tensor_to_numpy(self, inputs: torch.Tensor) -> np.ndarray[Any, Any]:
         array = inputs.detach().cpu().numpy()

--- a/src/raitap/models/model.py
+++ b/src/raitap/models/model.py
@@ -94,10 +94,12 @@ class Model(Trackable):
                 name, hardware=hardware, task_kind=getattr(config.model, "task_kind", None)
             )
 
+        from raitap.models.registration import supported_model_formats
+
         raise ValueError(
             f"Model source {source!r} is neither an existing path nor a known "
             f"torchvision model.\n"
-            f"Supported file formats: {_supported_model_formats()}\n"
+            f"Supported file formats: {supported_model_formats()}\n"
             f"To use your own model, set source to a valid model file path."
         )
 
@@ -230,21 +232,15 @@ def _load_from_path(
     if not path.exists():
         raise FileNotFoundError(f"Model file not found: {path}")
 
-    if path.suffix.lower() == ".onnx":
-        return OnnxBackend.from_path(path, hardware=hardware)
+    from raitap.models.registration import backend_for_extension, supported_model_formats
 
-    if path.suffix.lower() in {".pth", ".pt"}:
-        device = resolve_torch_device(hardware)
-        module = _load_torch_module_from_path(
-            path,
-            model_cfg=model_cfg,
-            device=device,
-            allow_unsafe_pickle=allow_unsafe_pickle,
+    backend_cls = backend_for_extension(path.suffix.lower())
+    if backend_cls is None:
+        raise ValueError(
+            f"Unsupported format {path.suffix!r}. Supported formats: {supported_model_formats()}"
         )
-        return TorchBackend(module, device=device, task_kind=getattr(model_cfg, "task_kind", None))
-
-    raise ValueError(
-        f"Unsupported model format {path.suffix!r}. Supported formats: {_supported_model_formats()}"
+    return backend_cls.from_path(
+        path, model_cfg=model_cfg, hardware=hardware, allow_unsafe_pickle=allow_unsafe_pickle
     )
 
 
@@ -411,7 +407,3 @@ def _load_pretrained(
         task_kind=task_kind,
         category_names=_default_category_names(model_name),
     )
-
-
-def _supported_model_formats() -> list[str]:
-    return [".onnx", ".pt", ".pth"]

--- a/src/raitap/models/registration.py
+++ b/src/raitap/models/registration.py
@@ -39,7 +39,7 @@ def register(**kwargs: Unpack[_BackendRegKwargs]) -> Callable[[type[B]], type[B]
 
     def wrap(cls: type[B]) -> type[B]:
         cls.provides = frozenset(kwargs["provides"])
-        exts = frozenset(kwargs.get("extensions", frozenset()))
+        exts = frozenset(e.lower() for e in kwargs.get("extensions", frozenset()))
         cls.extensions = exts
         for ext in exts:
             _BACKENDS_BY_EXTENSION[ext] = cls
@@ -50,7 +50,7 @@ def register(**kwargs: Unpack[_BackendRegKwargs]) -> Callable[[type[B]], type[B]
 
 def backend_for_extension(suffix: str) -> type | None:
     """Return the backend class registered for ``suffix`` (e.g. ``".onnx"``), or None."""
-    return _BACKENDS_BY_EXTENSION.get(suffix)
+    return _BACKENDS_BY_EXTENSION.get(suffix.lower())
 
 
 def supported_model_formats() -> list[str]:

--- a/src/raitap/models/registration.py
+++ b/src/raitap/models/registration.py
@@ -1,13 +1,13 @@
-"""Metadata-only decorator for model backends.
+"""Decorator + lookups for model backends.
 
-Backends are not Hydra-config adapters (no registry, no entry-point plugins);
-this decorator only sets and type-checks the required ``provides``
-class constant at the decoration site.
+The ``@register`` decorator sets each backend's ``provides`` and ``extensions``
+class constants at the decoration site and indexes the class by file extension,
+so ``model._load_from_path`` can resolve a backend from a model file's suffix.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Required, TypedDict, TypeVar, Unpack
+from typing import TYPE_CHECKING, NotRequired, Required, TypedDict, TypeVar, Unpack
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -24,16 +24,35 @@ if TYPE_CHECKING:
 
 B = TypeVar("B", bound="ModelBackend")
 
+#: extension (e.g. ``".onnx"``) -> backend class. Populated by ``@register``.
+_BACKENDS_BY_EXTENSION: dict[str, type] = {}
+
 
 class _BackendRegKwargs(TypedDict):
     provides: Required[AbstractSet[Capability]]
+    extensions: NotRequired[AbstractSet[str]]
 
 
 def register(**kwargs: Unpack[_BackendRegKwargs]) -> Callable[[type[B]], type[B]]:
-    """Register a model backend. ``provides`` is required."""
+    """Register a model backend. Sets ``provides`` + ``extensions`` and indexes
+    the class by extension for resolution in ``model._load_from_path``."""
 
     def wrap(cls: type[B]) -> type[B]:
         cls.provides = frozenset(kwargs["provides"])
+        exts = frozenset(kwargs.get("extensions", frozenset()))
+        cls.extensions = exts
+        for ext in exts:
+            _BACKENDS_BY_EXTENSION[ext] = cls
         return cls
 
     return wrap
+
+
+def backend_for_extension(suffix: str) -> type | None:
+    """Return the backend class registered for ``suffix`` (e.g. ``".onnx"``), or None."""
+    return _BACKENDS_BY_EXTENSION.get(suffix)
+
+
+def supported_model_formats() -> list[str]:
+    """Sorted list of registered file extensions."""
+    return sorted(_BACKENDS_BY_EXTENSION)

--- a/src/raitap/models/tests/test_access.py
+++ b/src/raitap/models/tests/test_access.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import Any, cast
 
 import pytest
 
 from raitap.models.access import AutogradModelProvider, explanation_model
 from raitap.types import Capability
-from raitap.utils.errors import BackendIncompatibilityError
-
-if TYPE_CHECKING:
-    from raitap.models.backend import ModelBackend
 
 
 class _FakeAdapter:
@@ -39,13 +35,13 @@ class _AutogradBackend(_CallableBackend):
 
 def test_model_agnostic_adapter_gets_predict_callable() -> None:
     backend = _CallableBackend()
-    model = explanation_model(cast("ModelBackend", backend), _FakeAdapter(frozenset()))
+    model = explanation_model(cast("Any", backend), _FakeAdapter(frozenset()))
     assert model == backend.__call__
 
 
 def test_autograd_adapter_gets_autograd_module() -> None:
     model = explanation_model(
-        cast("ModelBackend", _AutogradBackend()), _FakeAdapter(frozenset({Capability.AUTOGRAD}))
+        cast("Any", _AutogradBackend()), _FakeAdapter(frozenset({Capability.AUTOGRAD}))
     )
     assert model == "the-module"
 
@@ -59,7 +55,5 @@ def test_declared_capability_without_impl_raises() -> None:
     class _Broken(_CallableBackend):  # claims AUTOGRAD but has no autograd_module
         provides = frozenset({Capability.AUTOGRAD})
 
-    with pytest.raises(BackendIncompatibilityError):
-        explanation_model(
-            cast("ModelBackend", _Broken()), _FakeAdapter(frozenset({Capability.AUTOGRAD}))
-        )
+    with pytest.raises(TypeError):
+        explanation_model(cast("Any", _Broken()), _FakeAdapter(frozenset({Capability.AUTOGRAD})))

--- a/src/raitap/models/tests/test_access.py
+++ b/src/raitap/models/tests/test_access.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+
 import pytest
 
 from raitap.models.access import AutogradModelProvider, explanation_model
 from raitap.types import Capability
 from raitap.utils.errors import BackendIncompatibilityError
+
+if TYPE_CHECKING:
+    from raitap.models.backend import ModelBackend
 
 
 class _FakeAdapter:
@@ -34,12 +39,14 @@ class _AutogradBackend(_CallableBackend):
 
 def test_model_agnostic_adapter_gets_predict_callable() -> None:
     backend = _CallableBackend()
-    model = explanation_model(backend, _FakeAdapter(frozenset()))
+    model = explanation_model(cast("ModelBackend", backend), _FakeAdapter(frozenset()))
     assert model == backend.__call__
 
 
 def test_autograd_adapter_gets_autograd_module() -> None:
-    model = explanation_model(_AutogradBackend(), _FakeAdapter(frozenset({Capability.AUTOGRAD})))
+    model = explanation_model(
+        cast("ModelBackend", _AutogradBackend()), _FakeAdapter(frozenset({Capability.AUTOGRAD}))
+    )
     assert model == "the-module"
 
 
@@ -53,4 +60,6 @@ def test_declared_capability_without_impl_raises() -> None:
         provides = frozenset({Capability.AUTOGRAD})
 
     with pytest.raises(BackendIncompatibilityError):
-        explanation_model(_Broken(), _FakeAdapter(frozenset({Capability.AUTOGRAD})))
+        explanation_model(
+            cast("ModelBackend", _Broken()), _FakeAdapter(frozenset({Capability.AUTOGRAD}))
+        )

--- a/src/raitap/models/tests/test_access.py
+++ b/src/raitap/models/tests/test_access.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from raitap.models.access import AutogradModelProvider, explanation_model
+from raitap.types import Capability
+from raitap.utils.errors import BackendIncompatibilityError
+
+
+class _FakeAdapter:
+    def __init__(self, requires: frozenset[Capability]) -> None:
+        self._requires = requires
+
+    def required_capabilities(self) -> frozenset[Capability]:
+        return self._requires
+
+
+class _CallableBackend:
+    provides = frozenset()
+
+    def __call__(self, x):  # noqa: ANN001
+        return x
+
+    def predict_callable(self):  # noqa: ANN202
+        return self.__call__
+
+
+class _AutogradBackend(_CallableBackend):
+    provides = frozenset({Capability.AUTOGRAD})
+
+    def autograd_module(self):  # noqa: ANN202
+        return "the-module"
+
+
+def test_model_agnostic_adapter_gets_predict_callable() -> None:
+    backend = _CallableBackend()
+    model = explanation_model(backend, _FakeAdapter(frozenset()))
+    assert model == backend.__call__
+
+
+def test_autograd_adapter_gets_autograd_module() -> None:
+    model = explanation_model(_AutogradBackend(), _FakeAdapter(frozenset({Capability.AUTOGRAD})))
+    assert model == "the-module"
+
+
+def test_autograd_provider_protocol_is_runtime_checkable() -> None:
+    assert isinstance(_AutogradBackend(), AutogradModelProvider)
+    assert not isinstance(_CallableBackend(), AutogradModelProvider)
+
+
+def test_declared_capability_without_impl_raises() -> None:
+    class _Broken(_CallableBackend):  # claims AUTOGRAD but has no autograd_module
+        provides = frozenset({Capability.AUTOGRAD})
+
+    with pytest.raises(BackendIncompatibilityError):
+        explanation_model(_Broken(), _FakeAdapter(frozenset({Capability.AUTOGRAD})))

--- a/src/raitap/models/tests/test_backend.py
+++ b/src/raitap/models/tests/test_backend.py
@@ -40,6 +40,28 @@ def test_torch_backend_task_kind_can_be_overridden_in_constructor() -> None:
     assert backend.task_kind is TaskKind.regression
 
 
+def test_torch_backend_autograd_module_returns_live_module() -> None:
+    import torch.nn as nn
+
+    from raitap.models.backend import TorchBackend
+
+    module = nn.Linear(2, 2)
+    backend = TorchBackend(module)
+    assert backend.autograd_module() is module
+
+
+def test_predict_callable_runs_forward() -> None:
+    import torch
+    import torch.nn as nn
+
+    from raitap.models.backend import TorchBackend
+
+    backend = TorchBackend(nn.Identity())
+    fn = backend.predict_callable()
+    out = fn(torch.ones(1, 3))
+    assert torch.equal(out, torch.ones(1, 3))
+
+
 def test_register_backend_sets_class_constant() -> None:
     from raitap.models.backend import ModelBackend
     from raitap.models.registration import register
@@ -52,8 +74,5 @@ def test_register_backend_sets_class_constant() -> None:
 
         def __call__(self, inputs: object) -> object:
             return inputs
-
-        def as_model_for_explanation(self) -> nn.Module:
-            return nn.Identity()
 
     assert _B.provides == frozenset({Capability.AUTOGRAD})

--- a/src/raitap/models/tests/test_model_class.py
+++ b/src/raitap/models/tests/test_model_class.py
@@ -51,7 +51,7 @@ class TestModelConstructor:
         model = Model(config)
 
         assert isinstance(model.backend, TorchBackend)
-        assert model.backend.as_model_for_explanation().__class__.__name__ == "ResNet"
+        assert model.backend.autograd_module().__class__.__name__ == "ResNet"
 
     def test_model_loads_from_local_pth_file(self, tmp_path: Path) -> None:
         dummy_model = torch.nn.Linear(10, 5)
@@ -62,7 +62,8 @@ class TestModelConstructor:
         with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
             model = Model(config, allow_unsafe_pickle=True)
 
-        assert isinstance(model.backend.as_model_for_explanation(), torch.nn.Module)
+        assert isinstance(model.backend, TorchBackend)
+        assert isinstance(model.backend.autograd_module(), torch.nn.Module)
 
     def test_model_refuses_pickled_module_without_opt_in(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -86,7 +87,8 @@ class TestModelConstructor:
         config = _make_config(str(model_path), arch="resnet18", num_classes=2)
         model = Model(config)
 
-        loaded = model.backend.as_model_for_explanation()
+        assert isinstance(model.backend, TorchBackend)
+        loaded = model.backend.autograd_module()
         assert loaded.__class__.__name__ == "ResNet"
         # State dict round-trips: parameters should compare equal.
         for (n1, p1), (n2, p2) in zip(
@@ -122,7 +124,8 @@ class TestModelConstructor:
         config = _make_config(str(model_path))
         model = Model(config)
 
-        loaded = model.backend.as_model_for_explanation()
+        assert isinstance(model.backend, TorchBackend)
+        loaded = model.backend.autograd_module()
         assert isinstance(loaded, torch.jit.ScriptModule)
         # Sanity: forward pass produces same output as the eager reference.
         x = torch.randn(3, 4)

--- a/src/raitap/models/tests/test_models.py
+++ b/src/raitap/models/tests/test_models.py
@@ -182,19 +182,21 @@ class TestLoadModelFromPath:
         with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
             model = Model(cfg, allow_unsafe_pickle=True)
         assert isinstance(model.backend, TorchBackend)
-        assert isinstance(model.backend.as_model_for_explanation(), nn.Module)
+        assert isinstance(model.backend.autograd_module(), nn.Module)
 
     def test_loads_pt_file(self, saved_pt: Path) -> None:
         cfg = _make_config(str(saved_pt))
         with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
             model = Model(cfg, allow_unsafe_pickle=True)
         assert isinstance(model.backend, TorchBackend)
-        assert isinstance(model.backend.as_model_for_explanation(), nn.Module)
+        assert isinstance(model.backend.autograd_module(), nn.Module)
 
     def test_returns_eval_mode(self, saved_pth: Path) -> None:
         cfg = _make_config(str(saved_pth))
         with pytest.warns(DeprecationWarning, match="pickled nn.Module"):
-            model = Model(cfg, allow_unsafe_pickle=True).backend.as_model_for_explanation()
+            backend = Model(cfg, allow_unsafe_pickle=True).backend
+        assert isinstance(backend, TorchBackend)
+        model = backend.autograd_module()
         assert not model.training
 
     def test_pickled_module_load_refused_without_opt_in(
@@ -214,7 +216,7 @@ class TestLoadModelFromPath:
         bad = tmp_path / "model.xyz"
         bad.touch()
         cfg = _make_config(str(bad))
-        with pytest.raises(ValueError, match="Unsupported model format"):
+        with pytest.raises(ValueError, match="Unsupported format"):
             Model(cfg)
 
     def test_state_dict_loads_with_arch_and_num_classes(self, tmp_path: Path) -> None:
@@ -226,7 +228,7 @@ class TestLoadModelFromPath:
         cfg = _make_config(str(path), arch="resnet18", num_classes=3)
         model = Model(cfg)
         assert isinstance(model.backend, TorchBackend)
-        loaded = model.backend.as_model_for_explanation()
+        loaded = model.backend.autograd_module()
         # Round-trip: identical parameter values.
         for k, v in ref.state_dict().items():
             assert torch.equal(v, loaded.state_dict()[k].cpu())
@@ -252,7 +254,9 @@ class TestLoadModelFromPath:
         path = tmp_path / "scripted.pt"
         scripted.save(str(path))
         cfg = _make_config(str(path), hardware="cpu")
-        loaded = Model(cfg).backend.as_model_for_explanation()
+        backend = Model(cfg).backend
+        assert isinstance(backend, TorchBackend)
+        loaded = backend.autograd_module()
         assert isinstance(loaded, torch.jit.ScriptModule)
         x = torch.randn(2, 4)
         torch.testing.assert_close(loaded(x), ref(x))
@@ -590,11 +594,13 @@ class TestLoadModelFromName:
         cfg = _make_config("resnet18")
         model = Model(cfg)
         assert isinstance(model.backend, TorchBackend)
-        assert isinstance(model.backend.as_model_for_explanation(), nn.Module)
+        assert isinstance(model.backend.autograd_module(), nn.Module)
 
     def test_returns_eval_mode(self) -> None:
         cfg = _make_config("resnet18")
-        model = Model(cfg).backend.as_model_for_explanation()
+        backend = Model(cfg).backend
+        assert isinstance(backend, TorchBackend)
+        model = backend.autograd_module()
         assert not model.training
 
     def test_unknown_name_raises_value_error(self) -> None:
@@ -1245,3 +1251,12 @@ def test_resnet_state_dict_with_model_bundled_preprocessing_keeps_gradcam_path(
     assert len(children) == 2
     assert isinstance(children[1], ResNet)
     assert children[1].layer4[2].conv3 is not None
+
+
+def test_unsupported_extension_lists_registered_formats(tmp_path: Path) -> None:
+    from raitap.models.model import _load_from_path
+
+    bogus = tmp_path / "model.xyz"
+    bogus.write_bytes(b"x")
+    with pytest.raises(ValueError, match=r"Unsupported format"):
+        _load_from_path(bogus, model_cfg=None, hardware="cpu")

--- a/src/raitap/models/tests/test_registration.py
+++ b/src/raitap/models/tests/test_registration.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+
+def test_register_indexes_backend_by_extension() -> None:
+    from raitap.models import registration
+    from raitap.models.registration import (
+        backend_for_extension,
+        register,
+        supported_model_formats,
+    )
+
+    # ``@register`` mutates the module-global index at class-statement time;
+    # snapshot before and restore in-place after so the fake extensions don't leak.
+    saved = registration._BACKENDS_BY_EXTENSION.copy()
+    try:
+        # ``register`` is bound to ``ModelBackend``; this fake intentionally is not one
+        # (the registry only stores/looks up the class object), so silence the bound check.
+        @register(provides=frozenset(), extensions={".fake1", ".fake2"})  # pyright: ignore[reportArgumentType]
+        class _FakeBackend:  # minimal; registry only needs the class
+            pass
+
+        assert backend_for_extension(".fake1") is _FakeBackend
+        assert backend_for_extension(".fake2") is _FakeBackend
+        assert backend_for_extension(".nope") is None
+        assert {".fake1", ".fake2"} <= set(supported_model_formats())
+        assert supported_model_formats() == sorted(supported_model_formats())
+    finally:
+        registration._BACKENDS_BY_EXTENSION.clear()
+        registration._BACKENDS_BY_EXTENSION.update(saved)
+
+
+def test_real_backends_resolve_by_extension() -> None:
+    from raitap.models.backend import OnnxBackend, TorchBackend
+    from raitap.models.registration import backend_for_extension
+
+    assert backend_for_extension(".onnx") is OnnxBackend
+    assert backend_for_extension(".pth") is TorchBackend
+    assert backend_for_extension(".pt") is TorchBackend

--- a/src/raitap/pipeline/phases/tests/test_forward_pass.py
+++ b/src/raitap/pipeline/phases/tests/test_forward_pass.py
@@ -12,7 +12,6 @@ from typing import Any, cast
 
 import pytest
 import torch
-from torch import nn
 
 from raitap.models.backend import ModelBackend
 from raitap.pipeline.phases.forward_pass import forward_pass
@@ -71,9 +70,6 @@ class _FakeDetectionBackend(ModelBackend):
             for _ in inputs
         ]
 
-    def as_model_for_explanation(self) -> nn.Module:
-        raise NotImplementedError
-
 
 class _FakeClassificationBackend(ModelBackend):
     """Minimal classification backend that echoes a fixed prediction tensor."""
@@ -98,9 +94,6 @@ class _FakeClassificationBackend(ModelBackend):
     def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
         n = inputs.shape[0]
         return torch.zeros(n, self.num_classes)
-
-    def as_model_for_explanation(self) -> nn.Module:
-        raise NotImplementedError
 
 
 # ---------------------------------------------------------------------------

--- a/src/raitap/robustness/factory.py
+++ b/src/raitap/robustness/factory.py
@@ -17,6 +17,7 @@ from raitap.configs.adapter_factory import (
     resolve_call_data_sources,
     resolve_per_image_transform,
 )
+from raitap.models.access import explanation_model
 from raitap.models.backend import ModelBackend
 from raitap.utils.errors import SampleNamesLengthError
 
@@ -167,7 +168,7 @@ class RobustnessAssessment:
             merged_kwargs = backend._prepare_kwargs(merged_kwargs)
 
             return assessor.assess(
-                backend.as_model_for_explanation(),
+                explanation_model(backend, assessor),
                 inputs,
                 targets,
                 backend=backend,

--- a/src/raitap/robustness/tests/test_e2e_real_data.py
+++ b/src/raitap/robustness/tests/test_e2e_real_data.py
@@ -58,7 +58,7 @@ class _BackendStub(ModelBackend):
     def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
         return self._model(inputs)
 
-    def as_model_for_explanation(self) -> torch.nn.Module:
+    def autograd_module(self) -> torch.nn.Module:
         return self._model
 
 

--- a/src/raitap/robustness/tests/test_e2e_robustness_matrix.py
+++ b/src/raitap/robustness/tests/test_e2e_robustness_matrix.py
@@ -54,7 +54,7 @@ class _BackendStub(ModelBackend):
     def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
         return self._model(inputs)
 
-    def as_model_for_explanation(self) -> torch.nn.Module:
+    def autograd_module(self) -> torch.nn.Module:
         return self._model
 
 

--- a/src/raitap/robustness/tests/test_e2e_statistical_sampling.py
+++ b/src/raitap/robustness/tests/test_e2e_statistical_sampling.py
@@ -45,7 +45,7 @@ class _BackendStub(ModelBackend):
     def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
         return self._model(inputs)
 
-    def as_model_for_explanation(self) -> torch.nn.Module:
+    def autograd_module(self) -> torch.nn.Module:
         return self._model
 
 

--- a/src/raitap/robustness/tests/test_factory.py
+++ b/src/raitap/robustness/tests/test_factory.py
@@ -48,7 +48,7 @@ class _BackendStub(ModelBackend):
     def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
         return self._model(inputs)
 
-    def as_model_for_explanation(self) -> torch.nn.Module:
+    def autograd_module(self) -> torch.nn.Module:
         return self._model
 
 
@@ -164,6 +164,11 @@ def test_robustness_uses_model_resolved_preprocessing_for_call_data(
 
         def check_backend_compat(self, backend: object) -> None:
             del backend
+
+        def required_capabilities(self) -> frozenset[Capability]:
+            # PGD is a gradient-based empirical attack -> needs the live nn.Module,
+            # so the resolver routes to autograd_module().
+            return frozenset({Capability.AUTOGRAD})
 
         def assess(self, *_args: Any, **kwargs: Any) -> RobustnessResult:
             self.last_assess_kwargs = dict(kwargs)

--- a/src/raitap/task_families/classification.py
+++ b/src/raitap/task_families/classification.py
@@ -110,6 +110,7 @@ class ClassificationFamily:
         full-dict ``_prepare_kwargs`` did), enforces the sample-names length
         invariant, then drives the explainer once over the dense input tensor.
         """
+        from raitap.models.access import explanation_model
         from raitap.transparency.phase import resolve_explainer_runtime_kwargs
         from raitap.utils.errors import SampleNamesLengthError
 
@@ -139,7 +140,7 @@ class ClassificationFamily:
                 )
 
         result = prepared.explainer.explain(
-            prepared.backend.as_model_for_explanation(),
+            explanation_model(prepared.backend, prepared.explainer),
             inputs,
             backend=prepared.backend,
             run_dir=prepared.base_run_dir,

--- a/src/raitap/tests/test_capability.py
+++ b/src/raitap/tests/test_capability.py
@@ -10,3 +10,9 @@ def test_seeded_members_exist() -> None:
 def test_is_str_enum() -> None:
     assert Capability.AUTOGRAD == "autograd"
     assert isinstance(Capability.AUTOGRAD, str)
+
+
+def test_forward_only_is_empty_capability_set() -> None:
+    from raitap.types import FORWARD_ONLY
+
+    assert frozenset() == FORWARD_ONLY

--- a/src/raitap/tests/test_memory_leaks.py
+++ b/src/raitap/tests/test_memory_leaks.py
@@ -159,7 +159,7 @@ def test_run_without_tracking_forward_output_is_cpu_and_detached() -> None:
         def __call__(self, x: torch.Tensor) -> torch.Tensor:
             return net(x)
 
-        def as_model_for_explanation(self) -> object:
+        def autograd_module(self) -> torch.nn.Module:
             return net
 
     from typing import cast
@@ -176,9 +176,12 @@ def test_run_without_tracking_forward_output_is_cpu_and_detached() -> None:
     fake_explanation._visualise.return_value = []
 
     from raitap.transparency.phase import PreparedExplainer
+    from raitap.types import Capability
 
     fake_explainer = MagicMock()
     fake_explainer.explain.return_value = fake_explanation
+    # Real adapters expose this; the resolver reads it to pick the model shape.
+    fake_explainer.required_capabilities.return_value = frozenset({Capability.AUTOGRAD})
     fake_prepared = PreparedExplainer(
         name="explainer1",
         explainer=fake_explainer,

--- a/src/raitap/tests/test_run_labels.py
+++ b/src/raitap/tests/test_run_labels.py
@@ -14,7 +14,7 @@ import raitap.pipeline.orchestrator as run_pipeline
 from raitap.metrics import phase as _metrics_phase
 from raitap.metrics import resolve_metric_targets
 from raitap.transparency import phase as _transparency_phase
-from raitap.types import TaskKind
+from raitap.types import Capability, TaskKind
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -40,7 +40,7 @@ class _BackendStub:
         del inputs
         return self._output
 
-    def as_model_for_explanation(self) -> object:
+    def autograd_module(self) -> torch.nn.Module:
         return torch.nn.Identity()
 
 
@@ -99,6 +99,9 @@ def test_run_without_tracking_passes_ground_truth_labels_to_metrics(
     class _DummyExplainer:
         def explain(self, *_args: object, **_kwargs: object) -> _DummyResult:
             return _DummyResult()
+
+        def required_capabilities(self) -> frozenset[Capability]:
+            return frozenset({Capability.AUTOGRAD})
 
     def _fake_prepare(
         cfg: object,

--- a/src/raitap/tests/test_run_main.py
+++ b/src/raitap/tests/test_run_main.py
@@ -36,6 +36,7 @@ from raitap.robustness.report import RobustnessPhaseResult
 from raitap.tracking import BaseTracker
 from raitap.transparency import phase as _transparency_phase
 from raitap.transparency.report import TransparencyPhaseResult
+from raitap.types import Capability
 from raitap.types import TaskKind as _TaskKind
 
 
@@ -117,7 +118,7 @@ class _BackendStub:
     def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
         return self._model(inputs)
 
-    def as_model_for_explanation(self) -> torch.nn.Module:
+    def autograd_module(self) -> torch.nn.Module:
         return self._model
 
 
@@ -255,6 +256,9 @@ class _CapturingExplainer:
     def explain(self, *_args: object, **kwargs: object) -> _FakeExplainerResult:
         self._captured.update(kwargs)
         return self._result
+
+    def required_capabilities(self) -> frozenset[Capability]:
+        return frozenset({Capability.AUTOGRAD})
 
 
 def _make_prepared(

--- a/src/raitap/tracking/base_tracker.py
+++ b/src/raitap/tracking/base_tracker.py
@@ -14,8 +14,6 @@ _TRACKING_PREFIX = "raitap.tracking."
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from torch import nn
-
     from raitap.configs.schema import AppConfig
     from raitap.models.backend import ModelBackend
 
@@ -82,7 +80,7 @@ class BaseTracker(ABC, AdapterMixin):
     def log_config(self) -> None: ...
 
     @abstractmethod
-    def log_model(self, model: ModelBackend | nn.Module) -> None: ...
+    def log_model(self, model: ModelBackend) -> None: ...
 
     @abstractmethod
     def log_dataset(self, description: dict[str, Any]) -> None: ...

--- a/src/raitap/tracking/mlflow_tracker.py
+++ b/src/raitap/tracking/mlflow_tracker.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from raitap import raitap_log
 from raitap.configs import cfg_to_dict, resolve_run_dir
-from raitap.models.backend import OnnxBackend, TorchBackend
+from raitap.models.backend import OnnxBackend
 from raitap.tracking.registration import tracker
 from raitap.utils.diagnostics import Module
 
@@ -408,15 +408,15 @@ class MLFlowTracker(BaseTracker):
             self._log_onnx_model(model, artifact_path)
             return
 
-        if isinstance(model, TorchBackend):
-            pytorch_model = model.as_model_for_explanation()
-        else:
-            pytorch_model = model
+        from raitap.models.access import AutogradModelProvider
 
-        self._mlflow.pytorch.log_model(  # type: ignore[attr-defined]
-            pytorch_model=pytorch_model,
-            artifact_path=artifact_path,
-        )
+        if isinstance(model, AutogradModelProvider):
+            pytorch_model = model.autograd_module()
+            self._mlflow.pytorch.log_model(  # type: ignore[attr-defined]
+                pytorch_model=pytorch_model,
+                artifact_path=artifact_path,
+            )
+        # else: no torch nn.Module to log (e.g. ONNX); skip the pytorch artifact.
 
     def _log_onnx_model(self, model: OnnxBackend, artifact_path: str) -> None:
         if model.model_path is None:

--- a/src/raitap/transparency/README.md
+++ b/src/raitap/transparency/README.md
@@ -41,8 +41,11 @@ CLI / Config
 - `ShapExplainer` — wraps any `shap.*Explainer` algorithm
 
 Both implement `compute_attributions(model, inputs, **kwargs) → torch.Tensor`.
-The pipeline passes each explainer a backend-specific model object through
-`ModelBackend.as_model_for_explanation()`.
+The pipeline resolves the model shape each explainer needs via
+`explanation_model(backend, explainer)` (`raitap.models.access`), keyed by the
+explainer's required capabilities: gradient methods get the live `nn.Module`
+(`backend.autograd_module()`), model-agnostic methods get the forward-only
+`backend.predict_callable()`.
 
 ### Visualisers (`visualisers/`)
 

--- a/src/raitap/transparency/explain_detection.py
+++ b/src/raitap/transparency/explain_detection.py
@@ -9,7 +9,7 @@ second forward pass), filters per sample by ``score_threshold`` then top
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
 
@@ -23,6 +23,8 @@ from raitap.utils.errors import RaitapError
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
     from pathlib import Path
+
+    import torch.nn as nn
 
     from raitap.models.backend import ModelBackend
     from raitap.pipeline.outputs import ForwardOutput
@@ -167,7 +169,7 @@ def explain_detection(
                 reference_label=reference_label,
                 iou_threshold=iou_threshold,
             )
-            wrapped = ScalarDetectionWrapper(base_model, target=target)
+            wrapped = ScalarDetectionWrapper(cast("nn.Module", base_model), target=target)
 
             per_box_run_dir = base_run_dir / f"sample_{sample_index}" / f"box_{raw_index}"
             per_box_run_dir.mkdir(parents=True, exist_ok=True)

--- a/src/raitap/transparency/explain_detection.py
+++ b/src/raitap/transparency/explain_detection.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 
 from raitap import raitap_log
+from raitap.models.access import explanation_model
 from raitap.models.task_wrappers import DetectionTarget, ScalarDetectionWrapper
 from raitap.transparency.contracts import DetectionBox
 from raitap.types import DetectionInputs, TaskKind
@@ -112,7 +113,11 @@ def explain_detection(
     normalised_call_kwargs = dict(call_kwargs)
     normalised_call_kwargs["target"] = 0
 
-    base_model = backend.as_model_for_explanation()
+    # Invariant: detection explainers require AUTOGRAD, so the resolver returns a
+    # live ``nn.Module`` here. ``ScalarDetectionWrapper`` below subclasses
+    # ``nn.Module`` and registers this as a submodule, so a model-agnostic
+    # (predict-callable) detection explainer would break it — none exist today.
+    base_model = explanation_model(backend, explainer)
 
     # One baseline preview is shared by every box of a sample (same inputs +
     # call kwargs). Render it once and copy for the rest, keyed by content hash.

--- a/src/raitap/transparency/explain_detection.py
+++ b/src/raitap/transparency/explain_detection.py
@@ -24,8 +24,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
     from pathlib import Path
 
-    import torch.nn as nn
-
     from raitap.models.backend import ModelBackend
     from raitap.pipeline.outputs import ForwardOutput
     from raitap.transparency.results import ConfiguredVisualiser, ExplanationResult
@@ -169,7 +167,7 @@ def explain_detection(
                 reference_label=reference_label,
                 iou_threshold=iou_threshold,
             )
-            wrapped = ScalarDetectionWrapper(cast("nn.Module", base_model), target=target)
+            wrapped = ScalarDetectionWrapper(cast("Any", base_model), target=target)
 
             per_box_run_dir = base_run_dir / f"sample_{sample_index}" / f"box_{raw_index}"
             per_box_run_dir.mkdir(parents=True, exist_ok=True)

--- a/src/raitap/transparency/explainers/base_explainer.py
+++ b/src/raitap/transparency/explainers/base_explainer.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     import torch
+
+    from raitap.models.access import ExplanationModel
 else:
     torch = lazy_import("torch")
 
@@ -78,7 +80,7 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
 
     def explain(
         self,
-        model: torch.nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         *,
         backend: object | None = None,
@@ -194,7 +196,7 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
 
     def _compute_with_optional_batches(
         self,
-        model: torch.nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         attribution_kwargs: dict[str, Any],
         backend: object | None,
@@ -357,7 +359,7 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
     @abstractmethod
     def compute_attributions(
         self,
-        model: torch.nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
@@ -365,7 +367,8 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
         Compute attributions for the given inputs.
 
         Args:
-            model: PyTorch model to explain.
+            model: The model shape this explainer needs (nn.Module for gradient
+                methods, a predict callable for model-agnostic methods).
             inputs: Input tensor (shape depends on modality).
             **kwargs: Framework-specific keyword arguments (e.g. ``target``,
                 ``baselines``, ``background_data``).

--- a/src/raitap/transparency/explainers/captum_explainer.py
+++ b/src/raitap/transparency/explainers/captum_explainer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from raitap.transparency.contracts import (
     BaselineCardinality,
@@ -18,6 +18,8 @@ from .base_explainer import AttributionOnlyExplainer
 if TYPE_CHECKING:
     import torch
     import torch.nn as nn
+
+    from raitap.models.access import ExplanationModel
 
 
 @transparency_adapter(
@@ -86,7 +88,7 @@ class CaptumExplainer(AttributionOnlyExplainer):
 
     def compute_attributions(
         self,
-        model: nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         backend: object | None = None,
         target: int | list[int] | torch.Tensor | None = None,
@@ -126,7 +128,9 @@ class CaptumExplainer(AttributionOnlyExplainer):
         if self.algorithm in ("LayerGradCam", "GuidedGradCam"):
             layer_path = init_kwargs.pop("layer_path", None)
             if layer_path is not None and "layer" not in init_kwargs:
-                init_kwargs["layer"] = _resolve_layer(model, str(layer_path))
+                # LayerGradCam/GuidedGradCam require AUTOGRAD, so ``model`` is
+                # always a live ``nn.Module`` here (never a predict callable).
+                init_kwargs["layer"] = _resolve_layer(cast("nn.Module", model), str(layer_path))
 
         if self.algorithm == "Occlusion":
             attr_kwargs = _normalise_occlusion_kwargs(attr_kwargs)

--- a/src/raitap/transparency/explainers/shap_explainer.py
+++ b/src/raitap/transparency/explainers/shap_explainer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from raitap import raitap_log
 from raitap.utils.lazy import lazy_import
@@ -183,19 +183,12 @@ class ShapExplainer(AttributionOnlyExplainer):
                 )
                 background_data = inputs
 
-            if (
-                self.algorithm == "KernelExplainer"
-                and backend is not None
-                and Capability.AUTOGRAD not in getattr(backend, "provides", frozenset())
-            ):
-                if not callable(backend):
-                    raise TypeError(
-                        "SHAP ONNX path requires a callable backend for KernelExplainer."
-                    )
-                callable_backend = cast("Callable[[torch.Tensor], torch.Tensor]", backend)
+            if self.algorithm == "KernelExplainer":
+                # model-agnostic: ``model`` is a predict callable; SHAP needs a
+                # numpy fn. Wrap it (torch -> numpy) uniformly, regardless of backend.
                 background_np = _to_numpy(background_data)
                 explainer = explainer_class(
-                    _make_backend_prediction_fn(callable_backend),
+                    _make_backend_prediction_fn(model),
                     background_np,
                     **self.init_kwargs,
                 )

--- a/src/raitap/transparency/explainers/shap_explainer.py
+++ b/src/raitap/transparency/explainers/shap_explainer.py
@@ -184,6 +184,11 @@ class ShapExplainer(AttributionOnlyExplainer):
                 background_data = inputs
 
             if self.algorithm == "KernelExplainer":
+                if not callable(model):
+                    raise TypeError(
+                        "KernelExplainer requires a callable (predict) model; "
+                        f"got {type(model).__name__}."
+                    )
                 # model-agnostic: ``model`` is a predict callable; SHAP needs a
                 # numpy fn. Wrap it (torch -> numpy) uniformly, regardless of backend.
                 background_np = _to_numpy(background_data)

--- a/src/raitap/transparency/explainers/shap_explainer.py
+++ b/src/raitap/transparency/explainers/shap_explainer.py
@@ -9,10 +9,8 @@ from raitap.utils.lazy import lazy_import
 
 if TYPE_CHECKING:
     import torch
-    from torch import nn
 else:
     torch = lazy_import("torch")
-    nn = lazy_import("torch.nn")
 from raitap.transparency.contracts import (
     BaselineCardinality,
     BaselineMode,
@@ -26,6 +24,8 @@ from .base_explainer import AttributionOnlyExplainer
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from raitap.models.access import ExplanationModel
 
 
 def _normalise_target_indices(
@@ -135,7 +135,7 @@ class ShapExplainer(AttributionOnlyExplainer):
 
     def compute_attributions(
         self,
-        model: nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         backend: object | None = None,
         background_data: torch.Tensor | None = None,

--- a/src/raitap/transparency/explainers/tests/test_base_explainer.py
+++ b/src/raitap/transparency/explainers/tests/test_base_explainer.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
 
+    from raitap.models.access import ExplanationModel
+
 import raitap.transparency.explainers.base_explainer as base_explainer_module
 from raitap.transparency.contracts import (
     BaselineMode,
@@ -31,7 +33,7 @@ class _StrictExplainer(AttributionOnlyExplainer):
 
     def compute_attributions(
         self,
-        model: torch.nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         target: int | None = None,
         **kwargs: Any,
@@ -54,7 +56,7 @@ class _UnknownAlgorithmExplainer(AttributionOnlyExplainer):
 
     def compute_attributions(
         self,
-        model: torch.nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         **kwargs: Any,
     ) -> torch.Tensor:
@@ -73,7 +75,7 @@ class _BatchRecordingExplainer(AttributionOnlyExplainer):
 
     def compute_attributions(
         self,
-        model: torch.nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         target: list[int] | torch.Tensor | None = None,
         background_data: torch.Tensor | None = None,
@@ -103,7 +105,7 @@ class _BaselineDeclaringExplainer(AttributionOnlyExplainer):
 
     def compute_attributions(
         self,
-        model: torch.nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         target: int | None = None,
         baselines: torch.Tensor | None = None,
@@ -118,7 +120,7 @@ class _GradTrackingExplainer(AttributionOnlyExplainer):
 
     def compute_attributions(
         self,
-        model: torch.nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         **kwargs: Any,
     ) -> torch.Tensor:
@@ -132,7 +134,7 @@ class _TupleExplainer(AttributionOnlyExplainer):
 
     def compute_attributions(
         self,
-        model: torch.nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         **kwargs: Any,
     ) -> Any:
@@ -145,7 +147,7 @@ class _ListExplainer(AttributionOnlyExplainer):
 
     def compute_attributions(
         self,
-        model: torch.nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         **kwargs: Any,
     ) -> Any:

--- a/src/raitap/transparency/explainers/tests/test_captum_explainer.py
+++ b/src/raitap/transparency/explainers/tests/test_captum_explainer.py
@@ -167,7 +167,7 @@ class TestCaptumExplainer:
 
         explainer.check_backend_compat(onnx_linear_backend)
         result = explainer.explain(
-            onnx_linear_backend.as_model_for_explanation(),
+            onnx_linear_backend.predict_callable(),
             inputs,
             run_dir=tmp_path / "transparency",
             backend=onnx_linear_backend,
@@ -197,7 +197,7 @@ class TestCaptumExplainer:
 
         explainer.check_backend_compat(onnx_linear_backend)
         result = explainer.explain(
-            onnx_linear_backend.as_model_for_explanation(),
+            onnx_linear_backend.predict_callable(),
             inputs,
             run_dir=tmp_path / "transparency",
             backend=onnx_linear_backend,

--- a/src/raitap/transparency/explainers/tests/test_registration.py
+++ b/src/raitap/transparency/explainers/tests/test_registration.py
@@ -3,8 +3,9 @@ under the transparency group and pass the algorithm/payload metadata through."""
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import torch
-import torch.nn as nn
 
 from raitap import adapters
 from raitap.transparency.contracts import (
@@ -13,6 +14,9 @@ from raitap.transparency.contracts import (
     MethodFamily,
 )
 from raitap.transparency.explainers.base_explainer import AttributionOnlyExplainer
+
+if TYPE_CHECKING:
+    from raitap.models.access import ExplanationModel
 
 
 def test_transparency_adapter_registers_and_assigns_classvars() -> None:
@@ -32,7 +36,7 @@ def test_transparency_adapter_registers_and_assigns_classvars() -> None:
 
         def compute_attributions(
             self,
-            model: nn.Module,
+            model: ExplanationModel,
             inputs: torch.Tensor,
             backend: object | None = None,
             **kw: object,

--- a/src/raitap/transparency/explainers/tests/test_shap_explainer.py
+++ b/src/raitap/transparency/explainers/tests/test_shap_explainer.py
@@ -198,7 +198,7 @@ class TestShapExplainer:
 
         explainer.check_backend_compat(onnx_linear_backend)
         result = explainer.explain(
-            onnx_linear_backend.as_model_for_explanation(),
+            onnx_linear_backend.predict_callable(),
             inputs,
             run_dir=tmp_path / "transparency",
             backend=onnx_linear_backend,

--- a/src/raitap/transparency/tests/e2e_case_matrix.py
+++ b/src/raitap/transparency/tests/e2e_case_matrix.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 from omegaconf import OmegaConf
 
+from raitap.models.access import ExplanationModel, explanation_model
 from raitap.models.backend import TorchBackend
 from raitap.transparency import ExplanationResult, VisualisationResult
 from raitap.transparency.contracts import InputKind, InputSpec, TensorLayout
@@ -194,7 +195,7 @@ def _run_factory_case(
     return cast(
         "ExplanationResult",
         prepared.explainer.explain(  # type: ignore[attr-defined]
-            backend.as_model_for_explanation(),
+            explanation_model(backend, prepared.explainer),
             inputs,
             backend=backend,
             run_dir=prepared.base_run_dir,
@@ -326,7 +327,9 @@ def _run_explain_case(
     visualisers = _build_visualisers(case)
     run_dir = expected_run_dir(case, tmp_path)
     extra_call_kwargs: dict[str, Any] = dict(case.explain_call_kwargs)
-    runtime_model: nn.Module = model if backend is None else backend.as_model_for_explanation()
+    runtime_model: ExplanationModel = (
+        model if backend is None else explanation_model(backend, explainer)
+    )
 
     if backend is not None:
         explainer.check_backend_compat(backend)

--- a/src/raitap/transparency/tests/test_assess_transparency_detection.py
+++ b/src/raitap/transparency/tests/test_assess_transparency_detection.py
@@ -55,9 +55,6 @@ class _FakeBackend(ModelBackend):
     def __call__(self, inputs: torch.Tensor) -> Any:
         raise NotImplementedError("routing test mocks the explain path")
 
-    def as_model_for_explanation(self) -> Any:
-        raise NotImplementedError("routing test mocks the explain path")
-
 
 class _FakeModel:
     def __init__(self) -> None:

--- a/src/raitap/transparency/tests/test_e2e_integration.py
+++ b/src/raitap/transparency/tests/test_e2e_integration.py
@@ -11,6 +11,7 @@ import pytest
 from omegaconf import OmegaConf
 
 from raitap.configs import set_output_root
+from raitap.models.access import explanation_model
 from raitap.models.backend import TorchBackend
 from raitap.transparency import ExplanationResult, VisualisationResult
 from raitap.transparency.contracts import InputSpec
@@ -199,7 +200,7 @@ def test_config_helpers_support_visualiser_for_loop(
     explanation: ExplanationResult = cast(
         "ExplanationResult",
         prepared.explainer.explain(  # type: ignore[attr-defined]
-            backend.as_model_for_explanation(),
+            explanation_model(backend, prepared.explainer),
             sample_images,
             backend=backend,
             run_dir=prepared.base_run_dir,

--- a/src/raitap/transparency/tests/test_explain_detection.py
+++ b/src/raitap/transparency/tests/test_explain_detection.py
@@ -26,7 +26,7 @@ from raitap.transparency.contracts import (
 )
 from raitap.transparency.explain_detection import explain_detection
 from raitap.transparency.results import ExplanationResult
-from raitap.types import TaskKind
+from raitap.types import Capability, TaskKind
 from raitap.utils.errors import RaitapError
 
 
@@ -62,6 +62,11 @@ class _RecordingExplainer:
 
     def check_backend_compat(self, backend: Any) -> None:
         del backend
+
+    def required_capabilities(self) -> frozenset[Capability]:
+        # Detection uses gradient methods (IntegratedGradients) -> needs the live
+        # nn.Module, so the resolver routes to autograd_module().
+        return frozenset({Capability.AUTOGRAD})
 
     def explain(
         self,

--- a/src/raitap/transparency/tests/test_factory.py
+++ b/src/raitap/transparency/tests/test_factory.py
@@ -43,6 +43,21 @@ if TYPE_CHECKING:
     from raitap.models import Model
 
 
+#: Explainer algorithms that run forward-only (model-agnostic). Everything else
+#: in these doubles (Saliency, IntegratedGradients, GradientExplainer, ...) is a
+#: gradient method needing the live nn.Module. Mirrors the production registries
+#: in ``captum_explainer``/``shap_explainer``.
+_MODEL_AGNOSTIC_ALGORITHMS = frozenset({"KernelExplainer", "FeatureAblation"})
+
+
+def _caps_for(algorithm: str) -> frozenset[Capability]:
+    """Capabilities a double's algorithm needs, so ``explanation_model`` routes it
+    exactly as the real explainer would (autograd_module vs predict_callable)."""
+    if algorithm in _MODEL_AGNOSTIC_ALGORITHMS:
+        return frozenset()
+    return frozenset({Capability.AUTOGRAD})
+
+
 class _BackendStub(ModelBackend):
     def __init__(self, model: torch.nn.Module, *, autograd: bool = True) -> None:
         self._model = model
@@ -61,7 +76,7 @@ class _BackendStub(ModelBackend):
     def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
         return self._model(inputs)
 
-    def as_model_for_explanation(self) -> torch.nn.Module:
+    def autograd_module(self) -> torch.nn.Module:
         return self._model
 
 
@@ -293,6 +308,9 @@ def test_explanation_validates_visualisers_before_compute(
             del backend
             return None
 
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
+
         def explain(self, *args: Any, **kwargs: Any) -> None:
             self.explain_called = True
             raise AssertionError("explain() should not be called for incompatible visualisers")
@@ -435,6 +453,9 @@ def test_explanation_passes_sample_ids_display_names_and_input_metadata(
         def check_backend_compat(self, backend: object) -> None:
             del backend
 
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
+
         def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
             self.last_raitap_kwargs = dict(kwargs["raitap_kwargs"])
             return MagicMock(spec=ExplanationResult)
@@ -500,6 +521,9 @@ def test_explanation_rejects_method_family_mismatch_before_compute(
 
         def check_backend_compat(self, backend: object) -> None:
             del backend
+
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
 
         def explain(self, *_args: Any, **_kwargs: Any) -> ExplanationResult:
             self.explain_called = True
@@ -570,6 +594,9 @@ def test_explanation_rejects_candidate_output_space_mismatch_before_compute(
         def check_backend_compat(self, backend: object) -> None:
             del backend
 
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
+
         def explain(self, *_args: Any, **_kwargs: Any) -> ExplanationResult:
             self.explain_called = True
             return MagicMock(spec=ExplanationResult)
@@ -636,6 +663,9 @@ def test_explanation_allows_any_supported_candidate_output_space_before_compute(
 
         def check_backend_compat(self, backend: object) -> None:
             del backend
+
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
 
         def explain(self, *_args: Any, **_kwargs: Any) -> ExplanationResult:
             self.explain_called = True
@@ -955,6 +985,9 @@ def test_explanation_merges_call_before_run_kwargs(
             del backend
             return None
 
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
+
         def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
             self.last_explain_kwargs = dict(kwargs)
             return MagicMock(spec=ExplanationResult)
@@ -1018,6 +1051,9 @@ def test_explanation_routes_raitap_baseline_to_adapter_kwarg(
             del backend
             return None
 
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
+
         def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
             self.last_explain_kwargs = dict(kwargs)
             return MagicMock(spec=ExplanationResult)
@@ -1080,6 +1116,9 @@ def test_raitap_baseline_wins_over_runtime_kwarg(
             del backend
             return None
 
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
+
         def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
             self.last_explain_kwargs = dict(kwargs)
             return MagicMock(spec=ExplanationResult)
@@ -1138,6 +1177,9 @@ def test_explanation_uses_real_shap_preset_defaults_and_runtime_overrides(
         def check_backend_compat(self, backend: object) -> None:
             del backend
             return None
+
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
 
         def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
             self.last_explain_kwargs = dict(kwargs)
@@ -1203,6 +1245,9 @@ def test_explanation_injects_runtime_sample_names_into_raitap_kwargs(
             del backend
             return None
 
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
+
         def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
             self.last_explain_kwargs = dict(kwargs)
             return MagicMock(spec=ExplanationResult)
@@ -1255,6 +1300,9 @@ def test_explanation_runtime_sample_names_override_raitap_config(
         def check_backend_compat(self, backend: object) -> None:
             del backend
             return None
+
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
 
         def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
             self.last_explain_kwargs = dict(kwargs)
@@ -1313,6 +1361,9 @@ def test_explanation_warns_on_unknown_raitap_keys(
             del backend
             return None
 
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
+
         def explain(self, *_args: Any, **_kwargs: Any) -> ExplanationResult:
             return MagicMock(spec=ExplanationResult)
 
@@ -1355,6 +1406,9 @@ def test_explanation_warns_once_on_misplaced_raitap_call_keys(
         def check_backend_compat(self, backend: object) -> None:
             del backend
             return None
+
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
 
         def explain(self, *_args: Any, **_kwargs: Any) -> ExplanationResult:
             return MagicMock(spec=ExplanationResult)
@@ -1407,6 +1461,9 @@ def test_explanation_migrates_misplaced_raitap_call_keys_into_raitap_kwargs(
         def check_backend_compat(self, backend: object) -> None:
             del backend
             return None
+
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
 
         def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
             self.last_explain_kwargs = dict(kwargs)
@@ -1464,6 +1521,9 @@ def test_explanation_clears_parsed_config_cache_on_visualiser_compat_failure(
             del backend
             return None
 
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
+
         def explain(self, *_args: Any, **_kwargs: Any) -> ExplanationResult:
             raise AssertionError("explain() should not be called on incompatibility")
 
@@ -1507,6 +1567,9 @@ def test_explanation_rejects_removed_max_batch_size_raitap_key(
         def check_backend_compat(self, backend: object) -> None:
             del backend
             return None
+
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
 
         def explain(self, *_args: Any, **_kwargs: Any) -> ExplanationResult:
             return MagicMock(spec=ExplanationResult)
@@ -1556,6 +1619,9 @@ def test_explanation_prepares_runtime_tensor_kwargs_with_backend(
         def check_backend_compat(self, backend: object) -> None:
             del backend
             return None
+
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
 
         def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
             self.last_explain_kwargs = dict(kwargs)
@@ -1776,6 +1842,9 @@ class TestResolveCallDataSources:
                 del backend
                 return None
 
+            def required_capabilities(self) -> frozenset[Capability]:
+                return _caps_for(self.algorithm)
+
             def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
                 self.last_explain_kwargs = dict(kwargs)
                 return MagicMock(spec=ExplanationResult)
@@ -1842,6 +1911,9 @@ class TestResolveCallDataSources:
 
             def check_backend_compat(self, backend: object) -> None:
                 del backend
+
+            def required_capabilities(self) -> frozenset[Capability]:
+                return _caps_for(self.algorithm)
 
             def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
                 self.last_explain_kwargs = dict(kwargs)
@@ -1944,6 +2016,9 @@ def _make_stub_explainer() -> Any:
 
         def check_backend_compat(self, backend: object) -> None:
             del backend
+
+        def required_capabilities(self) -> frozenset[Capability]:
+            return _caps_for(self.algorithm)
 
         def explain(self, *_args: Any, **_kwargs: Any) -> ExplanationResult:
             return MagicMock(spec=ExplanationResult)

--- a/src/raitap/transparency/tests/test_results.py
+++ b/src/raitap/transparency/tests/test_results.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
     from matplotlib.figure import Figure
 
+    from raitap.models.access import ExplanationModel
     from raitap.transparency.contracts import VisualisationContext
 
 
@@ -90,7 +91,7 @@ class _IdentityExplainer(AttributionOnlyExplainer):
 
     def compute_attributions(
         self,
-        model: torch.nn.Module,
+        model: ExplanationModel,
         inputs: torch.Tensor,
         **kwargs: Any,
     ) -> torch.Tensor:

--- a/src/raitap/types.py
+++ b/src/raitap/types.py
@@ -73,3 +73,9 @@ class Capability(StrEnum):
         "tree_model"  # roadmap: tree-ensemble structure (TreeSHAP). No provider/requirer yet.
     )
     PREDICT_PROBA = "predict_proba"  # roadmap: class-probability outputs. No provider/requirer yet.
+
+
+#: A backend that exposes only the universal forward path (no special model
+#: shapes). Model-agnostic explainers (requires == empty) run on it; gradient
+#: and tree explainers gate out. Named for legibility over a bare ``frozenset()``.
+FORWARD_ONLY: frozenset[Capability] = frozenset()

--- a/src/raitap/utils/lazy.py
+++ b/src/raitap/utils/lazy.py
@@ -50,9 +50,7 @@ the contract. Wrap such classes in a lazy factory function::
         return Foo
 
 …and call ``_foo_cls()(...)`` at construction sites. See
-``raitap.models.backend._onnx_explanation_module_cls`` and
-``raitap.data.preprocessing._preset_wrapper_cls`` for the two production
-examples.
+``raitap.data.preprocessing._preset_wrapper_cls`` for a production example.
 
 **``isinstance`` checks against wrapped-lib classes.** ``isinstance(x, FooClass)``
 needs ``FooClass`` to be a real type — lazy proxies fail


### PR DESCRIPTION
## Summary

Closes #209. Two coupled changes on the backend axis, making a backend a self-contained one-file plugin.

**1. Capability-typed explanation contract (the `!`).** Removes `ModelBackend.as_model_for_explanation() -> nn.Module` and the `_OnnxExplanationModule` bridge. An explainer/assessor now gets the model SHAPE its `requires` capability implies, via `explanation_model(backend, adapter)`:
- `AUTOGRAD` → a live torch `nn.Module` (`backend.autograd_module()`), gate-enforced to torch backends;
- model-agnostic (empty `requires`) → a forward-only predict callable (`backend.predict_callable()`, the universal default).

The base ABC stays lean; capability-specific shapes are opt-in Protocols (`AutogradModelProvider`). A table-driven resolver (`_SHAPE_BY_CAPABILITY` in `raitap/models/access.py`) is the single capability→shape binding. The old `shap_explainer` branch that read `backend.provides` is gone — explainers no longer introspect backends.

**2. Backend discovery registry.** `@register(provides=..., extensions=...)` indexes backends by file extension; `model._load_from_path` resolves via lookup instead of a hardcoded `.onnx`/`.pth` if/elif; backends implement a uniform `from_path`. Adding an in-tree backend is now one file. `FORWARD_ONLY` names the empty capability set for legibility.

## Breaking change

`ModelBackend.as_model_for_explanation()` is removed from the backend contract (and the `_OnnxExplanationModule` adapter with it). Out-of-tree backends/consumers must switch to `autograd_module()` / `predict_callable()` and let `explanation_model(...)` resolve the shape. Pre-1.0, no shim.

## Reserved seam (not built)

The estimator shape (`Capability.TREE_MODEL`, SHAP `TreeExplainer`) is documented as a clean extension point: a future tree backend lands as one file + one resolver-table row + one Protocol, with no base-ABC change. That is #246.

## Out of scope

External entry-point plugin backends (in-tree registry only); non-torch gradient ecosystems (JAX/TF native) — `AUTOGRAD` stays torch-specific.

## Tests

- New: `test_access.py`, `test_registration.py`. Migrated ~16 test doubles to the capability contract (added `required_capabilities()` / `autograd_module()` where they reach the resolver).
- `uv run pytest` over models/transparency/robustness/tracking/pipeline + the run/memory tests: **492 passed, 51 skipped, 5 failed** — the 5 are pre-existing and environmental (4 need the `shap` extra, 1 is an XPU device mismatch), failing identically on `main`.
- `ruff check` + `ruff format` clean; `pyright` clean (only pre-existing `onnxruntime`/`onnx` optional-dep import errors).
- Grep guards: zero `as_model_for_explanation` call sites; bridge gone; no `backend.provides` reads in explainer/assessor bodies.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — Removes `as_model_for_explanation` from the backend contract; the title uses `!` (`refactor(model)!`). Necessary and cannot be delayed: it is the contract overhaul #209 tracks and #246 is blocked on.
- [x] **Contributor guide** — read.

## Optional

- [x] **Issue** _(optional)_ — Closes #209; unblocks #246.
- [x] **Docs** _(optional)_ — `adding-a-backend.md` + `transparency/README.md` updated.
- [x] **Tests** _(optional)_ — new + migrated doubles cover the contract.
