### PR TITLE
refactor: remove backward-compat / legacy code

### DIFF
--- a/docs/contributor/modules/data.md
+++ b/docs/contributor/modules/data.md
@@ -82,7 +82,7 @@ Label alignment is governed by `data.labels.id_strategy`:
   `/` or `\`, switches to `"relative_path"`; otherwise `"stem"`.
 - `"relative_path"` — strips only the file extension; directory components
   retained.
-- `"stem"` — legacy flat-dir behaviour (`Path(id).stem`).
+- `"stem"` — flat-dir / basename matching (`Path(id).stem`).
 
 Both sides (sample ids from disk + label ids from the file) are normalised
 the same way before lookup. Duplicate normalised label ids raise a

--- a/docs/contributor/modules/robustness.md
+++ b/docs/contributor/modules/robustness.md
@@ -122,9 +122,10 @@ there is no adversary; empirical and formal assessors use
   `FOOLBOX_REGISTRY`) and the `assessor_semantics(...)` resolver.
 - `assessors/base_assessor.py`: the framework-owned `assess()` pipelines for
   both empirical attacks and formal verification.
-- `factory.py`: typed config parsing, `_resolve_call_data_sources`, and the
-  `RobustnessAssessment` Hydra entry point. Adapter paths are resolved via the
-  `@adapters.robustness` decorator (no manual path table to maintain).
+- `factory.py`: typed config parsing and the `RobustnessAssessment` Hydra entry
+  point (data-source resolution is shared via `configs/adapter_factory`). Adapter
+  paths are resolved via the `@adapters.robustness` decorator (no manual path
+  table to maintain).
 - `results.py`: `RobustnessResult`, `RobustnessMetrics`, verdict encoding.
 - `visualisers/base_visualiser.py`: `BaseRobustnessVisualiser` +
   `AssessmentKind` compatibility check.

--- a/docs/modules/data/configuration.md
+++ b/docs/modules/data/configuration.md
@@ -99,8 +99,7 @@ myst:
   `"relative_path"` if any value contains `/` or `\`, otherwise falls back
   to `"stem"`. `"relative_path"` keeps directory components and supports
   nested ImageFolder layouts (e.g. `NORMAL/IM-0001.jpeg`) — required when
-  filename stems collide across class subdirs. `"stem"` is the legacy
-  flat-dir behaviour.
+  filename stems collide across class subdirs. `"stem"` matches by basename only (flat-dir layouts).
 
 :option: input_metadata
 :allowed: dict, null

--- a/docs/modules/data/own-vs-built-in.md
+++ b/docs/modules/data/own-vs-built-in.md
@@ -45,6 +45,17 @@ data = DataConfig(
 )
 ```
 
+with `labels.csv` rows like:
+
+```text
+image,label
+IM-0001.jpeg,0
+IM-0002.jpeg,1
+```
+
+The ids are bare filenames (no path separators), so `auto` matches by
+`stem`. See [How labels match to samples](#how-labels-match-to-samples) below.
+
 Example (nested ImageFolder layout — `data/test/<class>/<file>.jpg`):
 
 ```text
@@ -92,6 +103,33 @@ matches by relative path (extension is stripped during comparison, so
 `NORMAL/IM-0001.jpeg` and `NORMAL/IM-0001` both work). Sample order is
 sorted by relative posix path. See {doc}`configuration` for the full
 `id_strategy` reference.
+
+### How labels match to samples
+
+Labels come from the `data.labels` file, not from folder names. RAITAP does
+not infer the class from a parent directory the way torchvision `ImageFolder`
+does. Each labels row is tied to a sample two ways:
+
+- **By id** — when `labels.id_column` is set, its value is matched against the
+  discovered sample files.
+- **By order** — when no `id_column` is set, labels align to samples by sorted
+  file order (row 1 to the first file, and so on).
+
+For id matching, `id_strategy` controls how both sides are normalised before
+the lookup. The same rule is applied to the sample paths (from disk) and the
+label ids (from the file):
+
+| `id_strategy`    | strips          | `NORMAL/IM-0001.jpeg` becomes | use when                                 |
+| ---------------- | --------------- | ----------------------------- | ---------------------------------------- |
+| `relative_path`  | extension only  | `NORMAL/IM-0001`              | label ids carry the directory (manifest) |
+| `stem`           | directory + ext | `IM-0001`                     | flat dir, label ids are bare filenames   |
+| `auto` (default) | picks per id    | depends on the id column      | leave it; detects which form fits        |
+
+`auto` switches to `relative_path` as soon as any label id contains `/` or
+`\`, otherwise `stem`. The manifest form (`relative_path`/`auto`) is the
+conventional one and the safe default. `stem` collapses ids that share a
+filename across subdirs (`NORMAL/IM-0001.jpeg` and `PNEUMONIA/IM-0001.jpeg`
+both become `IM-0001`), which raises a duplicate-id error.
 
 If you want to evaluate metrics against ground-truth labels, configure the
 optional `data.labels` block as described in {doc}`configuration`.

--- a/docs/modules/reporting/output.md
+++ b/docs/modules/reporting/output.md
@@ -98,9 +98,9 @@ attribution-only figures. If a thumbnail cannot be rendered for a selected
 sample, that sample's visualiser figures keep their original panels.
 
 Set
-`reporting.show_original_per_explainer=true` to restore the older local layout
-where each explainer figure includes its own original input panel, the legacy
-overview/detail grouping is used, and no sample thumbnails are emitted.
+`reporting.show_original_per_explainer=true` for a more verbose local layout
+where each explainer figure includes its own original input panel, samples use
+overview/detail grouping, and no sample thumbnails are emitted.
 
 Report-local asset names for compact local explanations use
 `sample_<sample_index>_thumbnail_<n>.png` and

--- a/src/raitap/configs/adapter_factory.py
+++ b/src/raitap/configs/adapter_factory.py
@@ -207,27 +207,18 @@ def _validate_raitap_keys(
     )
 
 
-def _warn_on_misplaced_raitap_call_keys(
+def _reject_misplaced_raitap_call_keys(
     call_cfg: dict[str, Any], *, entity_name: str, schema: AdapterSchema
 ) -> None:
     misplaced = sorted(set(call_cfg).intersection(schema.raitap_keys))
     if not misplaced:
         return
     keys = ", ".join(misplaced)
-    raitap_log.warn(
+    raise ValueError(
         f"{schema.entity.capitalize()} {entity_name!r} has RAITAP-owned keys "
-        f"under 'call:': {keys}. These keys belong under 'raitap:' while "
-        "'call:' is intended for library kwargs only.",
+        f"under 'call:': {keys}. These keys belong under 'raitap:' not 'call:' "
+        "('call:' is intended for library kwargs only).",
     )
-
-
-def _migrate_misplaced_raitap_call_keys(
-    call_cfg: dict[str, Any], raitap_cfg: dict[str, Any], schema: AdapterSchema
-) -> None:
-    misplaced = sorted(set(call_cfg).intersection(schema.raitap_keys))
-    for key in misplaced:
-        value = call_cfg.pop(key)
-        raitap_cfg.setdefault(key, value)
 
 
 # ---------------------------------------------------------------------------
@@ -247,8 +238,7 @@ def parse_adapter_config(adapter_config: Any, schema: AdapterSchema) -> ParsedAd
     raitap_plain = _subdict(raw.get("raitap"), label="raitap", schema=schema)
     entity_name = resolved_target or target_path or "?"
     _validate_raitap_keys(raitap_plain, entity_name=entity_name, schema=schema)
-    _warn_on_misplaced_raitap_call_keys(call_plain, entity_name=entity_name, schema=schema)
-    _migrate_misplaced_raitap_call_keys(call_plain, raitap_plain, schema)
+    _reject_misplaced_raitap_call_keys(call_plain, entity_name=entity_name, schema=schema)
 
     return ParsedAdapterConfig(
         raw=raw,

--- a/src/raitap/configs/schema.py
+++ b/src/raitap/configs/schema.py
@@ -82,7 +82,7 @@ class LabelsConfig:
     #   "auto"          — pick "relative_path" if any id contains "/" or "\\"; else "stem".
     #   "relative_path" — ids are resolved as posix-style paths relative to ``data.source``
     #                     (supports nested ImageFolder layouts with colliding stems).
-    #   "stem"          — legacy flat-dir behaviour: match by ``Path(id).stem`` only.
+    #   "stem"          — flat-dir / basename matching: match by ``Path(id).stem`` only.
     id_strategy: IdStrategy = IdStrategy.auto
 
 

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -720,8 +720,8 @@ def _resolve_sample_ids(files: list[Path], root: Path) -> list[str]:
 def _normalise_sample_id(value: object, strategy: str = "stem") -> str:
     """Normalise a label-file id or discovered sample id into a comparable key.
 
-    - ``strategy="stem"``: legacy behaviour. Strip the directory and the
-      extension; e.g. ``"NORMAL/IM-0001.jpeg"`` → ``"IM-0001"``.
+    - ``strategy="stem"``: flat-dir / basename matching. Strip the directory
+      and the extension; e.g. ``"NORMAL/IM-0001.jpeg"`` → ``"IM-0001"``.
     - ``strategy="relative_path"``: keep the directory; strip only the
       extension. e.g. ``"NORMAL\\IM-0001.jpeg"`` → ``"NORMAL/IM-0001"``.
     """

--- a/src/raitap/data/preprocessing.py
+++ b/src/raitap/data/preprocessing.py
@@ -57,7 +57,6 @@ else:
 
 _CONSENT_ENV_VAR = "RAITAP_ALLOW_PREPROCESSING_EXEC"
 _ACKNOWLEDGE_OFF_ENV_VAR = "RAITAP_ACKNOWLEDGE_PREPROCESSING_OFF"
-_LEGACY_FACTORY_NAMES = ("make_preprocessing", "make_data_preprocessing")
 _DATA_PREPROCESSING_FACTORY_ATTR = "__raitap_preprocessing_factory__"
 _MODEL_INPUT_TRANSFORMATION_FACTORY_ATTR = "__raitap_model_input_transformation_factory__"
 _MODEL_BUNDLED_VALUE = Preprocessing.model_bundled.value
@@ -545,7 +544,6 @@ def _resolve_side_custom_file(
     if user_module is None:
         user_module = _import_user_module(path)
         file_cache[path] = user_module
-        _reject_legacy_undecorated_factories(user_module, path)
 
     if side == "data":
         marker_attr = _DATA_PREPROCESSING_FACTORY_ATTR
@@ -600,25 +598,6 @@ def _import_user_module(path: Path) -> Any:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
-
-
-def _reject_legacy_undecorated_factories(user_module: Any, path: Path) -> None:
-    legacy = [
-        name
-        for name in _LEGACY_FACTORY_NAMES
-        if callable(factory := getattr(user_module, name, None))
-        and not getattr(factory, _DATA_PREPROCESSING_FACTORY_ATTR, False)
-        and not getattr(factory, _MODEL_INPUT_TRANSFORMATION_FACTORY_ATTR, False)
-    ]
-    if not legacy:
-        return
-    names = ", ".join(f"`{name}()`" for name in legacy)
-    raise AttributeError(
-        f"{path}: fixed-name factories {names} are no longer supported on their own. "
-        "Use the RAITAP decorators: decorate an arbitrary zero-argument factory with "
-        "`@raitap_preprocessing_factory` for data preprocessing or "
-        "`@raitap_model_input_transformation_factory` for model input transformation."
-    )
 
 
 def _build_decorated_user_factory(

--- a/src/raitap/data/tests/test_preprocessing.py
+++ b/src/raitap/data/tests/test_preprocessing.py
@@ -541,7 +541,7 @@ def test_custom_file_factory_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: 
         )
 
 
-def test_custom_file_fixed_name_factories_require_decorators(
+def test_custom_file_undecorated_factory_raises_no_factory_found(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv(_ENV, "1")
@@ -549,7 +549,9 @@ def test_custom_file_fixed_name_factories_require_decorators(
     bad.write_text(
         "from torch import nn\ndef make_preprocessing() -> nn.Module:\n    return nn.Identity()\n"
     )
-    with pytest.raises(AttributeError, match="decorator"):
+    with pytest.raises(
+        AttributeError, match=r"no factory decorated with `@raitap_preprocessing_factory`"
+    ):
         resolve_preprocessing(
             ModelConfig(source="resnet50"),
             DataConfig(preprocessing=str(bad)),

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -811,7 +811,7 @@ def test_build_report_local_explainer_group_includes_curated_transparency_rows(
     assert "visualiser_call.max_samples" not in second_rows
 
 
-def test_build_report_show_original_per_explainer_uses_legacy_local_layout(
+def test_build_report_show_original_per_explainer_uses_verbose_local_layout(
     tmp_path: Path,
 ) -> None:
     config = AppConfig(experiment_name="legacy_originals")
@@ -1551,7 +1551,7 @@ def test_build_report_robustness_single_pair_keeps_all_panels(tmp_path: Path) ->
     assert len(report.sections[0].groups[0].images) == 1
 
 
-def test_build_report_legacy_robustness_reuses_existing_visualisations_without_kwargs(
+def test_build_report_verbose_robustness_reuses_existing_visualisations_without_kwargs(
     tmp_path: Path,
 ) -> None:
     config = AppConfig(experiment_name="robustness_legacy")

--- a/src/raitap/reporting/tests/test_html_reporter.py
+++ b/src/raitap/reporting/tests/test_html_reporter.py
@@ -148,7 +148,7 @@ def test_html_reporter_falls_back_to_na_when_model_source_blank(tmp_path: Path) 
     assert "<dt>Data</dt><dd>isic2018</dd>" in html
 
 
-def test_html_reporter_renders_legacy_local_detail_images(tmp_path: Path) -> None:
+def test_html_reporter_renders_verbose_local_detail_images(tmp_path: Path) -> None:
     sections = (
         ReportSection.from_groups(
             "Local Explanations",

--- a/src/raitap/reporting/tests/test_view_model.py
+++ b/src/raitap/reporting/tests/test_view_model.py
@@ -134,7 +134,7 @@ def test_build_view_carries_baseline_image_onto_explainer() -> None:
     assert explainer.image_srcs[0] == "_assets/sample_0_shap_grad.png"
 
 
-def test_build_view_renders_legacy_local_detail_groups_as_samples() -> None:
+def test_build_view_renders_verbose_local_detail_groups_as_samples() -> None:
     section = ReportSection.from_groups(
         "Local Explanations",
         [

--- a/src/raitap/reporting/view_model.py
+++ b/src/raitap/reporting/view_model.py
@@ -291,7 +291,7 @@ def _build_generic_groups(section: ReportSection) -> tuple[GenericGroupView, ...
 def _build_local_samples(section: ReportSection) -> tuple[LocalSampleView, ...]:
     samples_by_index: dict[int, LocalSampleView] = {}
     explainers_by_index: dict[int, list[ExplainerView]] = {}
-    legacy_samples: list[LocalSampleView] = []
+    verbose_samples: list[LocalSampleView] = []
     sample_order: list[tuple[str, int]] = []
 
     for group in section.groups:
@@ -303,10 +303,10 @@ def _build_local_samples(section: ReportSection) -> tuple[LocalSampleView, ...]:
             continue
 
         if role in {"local_detail", "local_overview"}:
-            legacy_sample = _build_legacy_local_sample(group, sample_index)
-            if legacy_sample is not None:
-                sample_order.append(("legacy", len(legacy_samples)))
-                legacy_samples.append(legacy_sample)
+            verbose_sample = _build_verbose_local_sample(group, sample_index)
+            if verbose_sample is not None:
+                sample_order.append(("verbose", len(verbose_samples)))
+                verbose_samples.append(verbose_sample)
             continue
 
         if role == "sample_header":
@@ -344,8 +344,8 @@ def _build_local_samples(section: ReportSection) -> tuple[LocalSampleView, ...]:
 
     ordered: list[LocalSampleView] = []
     for kind, index in sample_order:
-        if kind == "legacy":
-            ordered.append(legacy_samples[index])
+        if kind == "verbose":
+            ordered.append(verbose_samples[index])
             continue
         sample_index = index
         sample = samples_by_index[sample_index]
@@ -367,7 +367,7 @@ def _build_local_samples(section: ReportSection) -> tuple[LocalSampleView, ...]:
     return tuple(ordered)
 
 
-def _build_legacy_local_sample(group: ReportGroup, sample_index: int) -> LocalSampleView | None:
+def _build_verbose_local_sample(group: ReportGroup, sample_index: int) -> LocalSampleView | None:
     if not group.table_rows and not group.images:
         return None
 
@@ -378,7 +378,7 @@ def _build_legacy_local_sample(group: ReportGroup, sample_index: int) -> LocalSa
         heading=group.heading,
         rows=group.table_rows,
         thumbnail_srcs=(),
-        explainers=_build_legacy_explainer_views(group),
+        explainers=_build_verbose_explainer_views(group),
         sample_id=_none_if_blank(group.metadata.get("requested_sample")) or rows.get("sample_id"),
         predicted_class=rows.get("predicted_class"),
         confidence=rows.get("confidence"),
@@ -387,7 +387,7 @@ def _build_legacy_local_sample(group: ReportGroup, sample_index: int) -> LocalSa
     )
 
 
-def _build_legacy_explainer_views(group: ReportGroup) -> tuple[ExplainerView, ...]:
+def _build_verbose_explainer_views(group: ReportGroup) -> tuple[ExplainerView, ...]:
     if not group.images:
         return ()
 

--- a/src/raitap/robustness/factory.py
+++ b/src/raitap/robustness/factory.py
@@ -13,7 +13,6 @@ from raitap.configs.adapter_factory import (
     instantiate_adapter,
     instantiate_visualisers,
     parse_adapter_config,
-    raw_config_dict,
     resolve_call_data_sources,
     resolve_per_image_transform,
 )
@@ -213,12 +212,3 @@ def create_robustness_visualisers(
         wrap=lambda viz, call: ConfiguredRobustnessVisualiser(visualiser=viz, call_kwargs=call),
         instantiate_fn=instantiate,
     )
-
-
-# Internal-test back-compat thin wrappers (keep the test surface stable).
-def _raw_assessor_config(assessor_config: Any) -> dict[str, Any]:
-    return raw_config_dict(assessor_config)
-
-
-def _resolve_call_data_sources(call_kwargs: dict[str, Any]) -> dict[str, Any]:
-    return resolve_call_data_sources(call_kwargs, log_label="robustness call")

--- a/src/raitap/robustness/report.py
+++ b/src/raitap/robustness/report.py
@@ -84,7 +84,7 @@ def _build_robustness_section(
     ``RobustnessResult.render_visualisation_for_report`` so duplicate empirical
     facets can be suppressed without changing persisted robustness artifacts or
     ``metadata.json``. This adds extra report-only renders only where compact
-    layout kwargs are needed; legacy mode reuses pre-rendered artifacts.
+    layout kwargs are needed; verbose layout reuses pre-rendered artifacts.
     """
     if not outputs.results:
         return None
@@ -125,7 +125,7 @@ def _build_robustness_section(
             selected_samples=selected_samples,
         )
         staged = (
-            _legacy_robustness_images(
+            _verbose_robustness_images(
                 result.visualisations,
                 assets_dir=assets_dir,
                 result_index=index,
@@ -232,7 +232,7 @@ def _figure_scope_for(result: Any, visualiser_name: str) -> str:
     return type(configured.visualiser).report_figure_scope.value
 
 
-def _legacy_robustness_images(
+def _verbose_robustness_images(
     visualisations: list[RobustnessVisualisationResult],
     *,
     assets_dir: Path,

--- a/src/raitap/robustness/tests/test_factory.py
+++ b/src/raitap/robustness/tests/test_factory.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from omegaconf import OmegaConf
 
+from raitap.configs.adapter_factory import resolve_call_data_sources
 from raitap.models.backend import ModelBackend
 from raitap.robustness.assessors import TorchattacksAssessor
 from raitap.robustness.contracts import AssessmentKind
@@ -15,7 +16,6 @@ from raitap.robustness.exceptions import AssessmentKindVisualiserIncompatibility
 from raitap.robustness.factory import (
     RobustnessAssessment,
     _parse_assessor_config,
-    _resolve_call_data_sources,
     check_assessor_visualiser_compat,
 )
 from raitap.robustness.results import ConfiguredRobustnessVisualiser, RobustnessResult
@@ -132,7 +132,7 @@ def test_parse_rejects_misplaced_raitap_keys() -> None:
 
 
 def test_resolve_call_data_sources_passes_through_non_source_dicts() -> None:
-    out = _resolve_call_data_sources({"target_labels": [0, 1]})
+    out = resolve_call_data_sources({"target_labels": [0, 1]}, log_label="robustness call")
     assert out == {"target_labels": [0, 1]}
 
 

--- a/src/raitap/robustness/tests/test_factory.py
+++ b/src/raitap/robustness/tests/test_factory.py
@@ -116,17 +116,19 @@ def test_parse_validates_top_level_keys() -> None:
         )
 
 
-def test_parse_migrates_misplaced_raitap_keys() -> None:
-    parsed = _parse_assessor_config(
-        {
-            "_target_": "TorchattacksAssessor",
-            "algorithm": "PGD",
-            "call": {"eps": 0.03, "batch_size": 8},
-        }
-    )
-    # batch_size is RAITAP-owned; factory migrates it from `call` to `raitap`.
-    assert "batch_size" not in parsed.call
-    assert parsed.raitap["batch_size"] == 8
+def test_parse_rejects_misplaced_raitap_keys() -> None:
+    # batch_size is RAITAP-owned; placing it under `call:` is a hard error.
+    with pytest.raises(ValueError) as excinfo:
+        _parse_assessor_config(
+            {
+                "_target_": "TorchattacksAssessor",
+                "algorithm": "PGD",
+                "call": {"eps": 0.03, "batch_size": 8},
+            }
+        )
+    text = str(excinfo.value)
+    assert "RAITAP-owned keys under 'call:'" in text
+    assert "batch_size" in text
 
 
 def test_resolve_call_data_sources_passes_through_non_source_dicts() -> None:

--- a/src/raitap/transparency/factory.py
+++ b/src/raitap/transparency/factory.py
@@ -10,8 +10,6 @@ from raitap.configs.adapter_factory import (
     instantiate_adapter,
     instantiate_visualisers,
     parse_adapter_config,
-    raw_config_dict,
-    resolve_call_data_sources,
 )
 from raitap.models.backend import ModelBackend
 
@@ -225,13 +223,3 @@ def _enum_frozenset(value: object, enum_type: type[Any]) -> frozenset[Any]:
         else:
             out.append(enum_type(str(item)))
     return frozenset(out)
-
-
-# Internal-test back-compat: a couple of older tests touch these names. Keep
-# them as thin wrappers so the test surface is unchanged across the refactor.
-def _raw_transparency_config(explainer_config: Any) -> dict[str, Any]:
-    return raw_config_dict(explainer_config)
-
-
-def _resolve_call_data_sources(call_kwargs: dict[str, Any]) -> dict[str, Any]:
-    return resolve_call_data_sources(call_kwargs, log_label="call")

--- a/src/raitap/transparency/phase.py
+++ b/src/raitap/transparency/phase.py
@@ -144,7 +144,10 @@ def prepare_explainer(
     so it stays in ``ClassificationFamily.explain``.
     """
     from raitap.configs import resolve_run_dir
-    from raitap.configs.adapter_factory import resolve_per_image_transform
+    from raitap.configs.adapter_factory import (
+        resolve_call_data_sources,
+        resolve_per_image_transform,
+    )
     from raitap.transparency.baselines import apply_config_baseline
     from raitap.transparency.factory import (
         _PARSED_EXPLAINER_CONFIG_CACHE,
@@ -155,7 +158,6 @@ def prepare_explainer(
         check_explainer_visualiser_semantic_compat,
         create_explainer,
         create_visualisers,
-        resolve_call_data_sources,
     )
 
     backend = _require_model_backend(model)

--- a/src/raitap/transparency/report.py
+++ b/src/raitap/transparency/report.py
@@ -214,7 +214,7 @@ def _build_local_section(
         return None
 
     if show_original_per_explainer or explicit_selection:
-        return _build_legacy_local_section(
+        return _build_verbose_local_section(
             outputs,
             selected_samples=selected_samples,
             assets_dir=assets_dir,
@@ -378,7 +378,7 @@ def _build_local_section(
     )
 
 
-def _build_legacy_local_section(
+def _build_verbose_local_section(
     outputs: TransparencyPhaseResult,
     *,
     selected_samples: list[SelectedSample],

--- a/src/raitap/transparency/tests/test_factory.py
+++ b/src/raitap/transparency/tests/test_factory.py
@@ -830,7 +830,7 @@ def test_create_explainer_warns_on_unknown_raitap_keys(
         create_explainer(config)
 
 
-def test_create_explainer_warns_on_misplaced_raitap_call_keys(
+def test_create_explainer_rejects_misplaced_raitap_call_keys(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _StubExplainer:
@@ -858,9 +858,9 @@ def test_create_explainer_warns_on_misplaced_raitap_call_keys(
         }
     )
 
-    with pytest.warns(UserWarning) as caught:
+    with pytest.raises(ValueError) as excinfo:
         create_explainer(config)
-    text = " ".join(str(w.message) for w in caught)
+    text = str(excinfo.value)
     assert "RAITAP-owned keys under 'call:'" in text
     assert "batch_size" in text
     assert "progress_desc" in text
@@ -868,7 +868,7 @@ def test_create_explainer_warns_on_misplaced_raitap_call_keys(
     assert "show_sample_names" in text
 
 
-def test_create_explainer_warns_on_call_show_progress(
+def test_create_explainer_rejects_call_show_progress(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _StubExplainer:
@@ -891,9 +891,9 @@ def test_create_explainer_warns_on_call_show_progress(
         }
     )
 
-    with pytest.warns(UserWarning) as caught:
+    with pytest.raises(ValueError) as excinfo:
         create_explainer(config)
-    text = " ".join(str(w.message) for w in caught)
+    text = str(excinfo.value)
     assert "RAITAP-owned keys under 'call:'" in text
     assert "show_progress" in text
 
@@ -1395,7 +1395,7 @@ def test_explanation_warns_on_unknown_raitap_keys(
         )
 
 
-def test_explanation_warns_once_on_misplaced_raitap_call_keys(
+def test_explanation_rejects_misplaced_raitap_call_keys(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     sample_images: torch.Tensor,
@@ -1432,7 +1432,7 @@ def test_explanation_warns_once_on_misplaced_raitap_call_keys(
     monkeypatch.setattr("raitap.transparency.factory.create_visualisers", lambda _cfg: [])
 
     model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
-    with pytest.warns(UserWarning) as caught:
+    with pytest.raises(ValueError) as excinfo:
         _prepare_explanation(
             config,
             "test_explainer",
@@ -1440,74 +1440,9 @@ def test_explanation_warns_once_on_misplaced_raitap_call_keys(
             sample_images,
         )
 
-    messages = [
-        str(w.message) for w in caught if "RAITAP-owned keys under 'call:'" in str(w.message)
-    ]
-    assert len(messages) == 1
-    assert "sample_names" in messages[0]
-
-
-def test_explanation_migrates_misplaced_raitap_call_keys_into_raitap_kwargs(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    sample_images: torch.Tensor,
-) -> None:
-    class RecordingExplainer:
-        algorithm = "Saliency"
-
-        def __init__(self) -> None:
-            self.last_explain_kwargs: dict[str, Any] = {}
-
-        def check_backend_compat(self, backend: object) -> None:
-            del backend
-            return None
-
-        def required_capabilities(self) -> frozenset[Capability]:
-            return _caps_for(self.algorithm)
-
-        def explain(self, *_args: Any, **kwargs: Any) -> ExplanationResult:
-            self.last_explain_kwargs = dict(kwargs)
-            return MagicMock(spec=ExplanationResult)
-
-    explainer = RecordingExplainer()
-    config = _make_config(
-        tmp_path,
-        OmegaConf.create(
-            {
-                "_target_": "raitap.transparency.CaptumExplainer",
-                "algorithm": "Saliency",
-                "call": {
-                    "target": 0,
-                    "show_progress": True,
-                    "batch_size": 2,
-                },
-                "visualisers": [],
-            }
-        ),
-    )
-
-    monkeypatch.setattr(
-        "raitap.transparency.factory.create_explainer",
-        lambda _cfg: (explainer, "raitap.transparency.CaptumExplainer"),
-    )
-    monkeypatch.setattr("raitap.transparency.factory.create_visualisers", lambda _cfg: [])
-
-    model = SimpleNamespace(backend=_BackendStub(torch.nn.Identity()))
-    with pytest.warns(UserWarning, match="RAITAP-owned keys under 'call:'"):
-        _build_explanation(
-            config,
-            "test_explainer",
-            cast("Model", model),
-            sample_images,
-        )
-
-    assert explainer.last_explain_kwargs["target"] == 0
-    assert "show_progress" not in explainer.last_explain_kwargs
-    assert "batch_size" not in explainer.last_explain_kwargs
-    assert explainer.last_explain_kwargs["raitap_kwargs"] == {
-        "show_progress": True,
-        "batch_size": 2,
-    }
+    text = str(excinfo.value)
+    assert "RAITAP-owned keys under 'call:'" in text
+    assert "sample_names" in text
 
 
 def test_explanation_clears_parsed_config_cache_on_visualiser_compat_failure(
@@ -1533,7 +1468,7 @@ def test_explanation_clears_parsed_config_cache_on_visualiser_compat_failure(
             {
                 "_target_": "raitap.transparency.ShapExplainer",
                 "algorithm": "KernelExplainer",
-                "call": {"sample_names": ["cfg_a", "cfg_b"]},
+                "raitap": {"sample_names": ["cfg_a", "cfg_b"]},
                 "visualisers": [{"_target_": "raitap.transparency.ShapImageVisualiser"}],
             }
         ),

--- a/src/raitap/transparency/tests/test_factory.py
+++ b/src/raitap/transparency/tests/test_factory.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 from omegaconf import OmegaConf
 
+from raitap.configs.adapter_factory import resolve_call_data_sources
 from raitap.models.backend import ModelBackend
 from raitap.transparency import (
     PayloadVisualiserIncompatibilityError,
@@ -22,11 +23,9 @@ from raitap.transparency.contracts import (
 )
 from raitap.transparency.factory import (
     _PARSED_EXPLAINER_CONFIG_CACHE,
-    _resolve_call_data_sources,
     check_explainer_visualiser_compat,
     create_explainer,
     create_visualisers,
-    resolve_call_data_sources,
 )
 from raitap.transparency.phase import prepare_explainer
 from raitap.transparency.results import ConfiguredVisualiser, ExplanationResult
@@ -1699,22 +1698,22 @@ def test_create_visualisers_splits_constructor_and_call(monkeypatch: pytest.Monk
 
 
 # ---------------------------------------------------------------------------
-# _resolve_call_data_sources
+# resolve_call_data_sources
 # ---------------------------------------------------------------------------
 
 
 class TestResolveCallDataSources:
     def test_passthrough_when_no_data_references(self) -> None:
         kwargs = {"target": 0, "nsamples": 10}
-        assert _resolve_call_data_sources(kwargs) == kwargs
+        assert resolve_call_data_sources(kwargs, log_label="call") == kwargs
 
     def test_passthrough_when_value_is_not_a_dict(self) -> None:
         kwargs = {"background_data": None, "target": 1}
-        assert _resolve_call_data_sources(kwargs) == kwargs
+        assert resolve_call_data_sources(kwargs, log_label="call") == kwargs
 
     def test_passthrough_dict_without_source_key(self) -> None:
         kwargs = {"options": {"n_samples": 5}}
-        assert _resolve_call_data_sources(kwargs) == kwargs
+        assert resolve_call_data_sources(kwargs, log_label="call") == kwargs
 
     def test_loads_tensor_from_source(self, tmp_path: Path) -> None:
         import numpy as np
@@ -1726,7 +1725,9 @@ class TestResolveCallDataSources:
             arr = np.zeros((8, 8, 3), dtype=np.uint8)
             Image.fromarray(arr, "RGB").save(img_dir / f"img{i}.png")
 
-        result = _resolve_call_data_sources({"background_data": {"source": str(img_dir)}})
+        result = resolve_call_data_sources(
+            {"background_data": {"source": str(img_dir)}}, log_label="call"
+        )
 
         assert isinstance(result["background_data"], torch.Tensor)
         assert result["background_data"].shape == (4, 3, 8, 8)
@@ -1741,22 +1742,23 @@ class TestResolveCallDataSources:
             arr = np.zeros((8, 8, 3), dtype=np.uint8)
             Image.fromarray(arr, "RGB").save(img_dir / f"img{i}.png")
 
-        result = _resolve_call_data_sources(
-            {"background_data": {"source": str(img_dir), "n_samples": 3}}
+        result = resolve_call_data_sources(
+            {"background_data": {"source": str(img_dir), "n_samples": 3}}, log_label="call"
         )
 
         assert result["background_data"].shape[0] == 3
 
     def test_invalid_n_samples_type_raises(self, tmp_path: Path) -> None:
         with pytest.raises(TypeError, match="n_samples must be an int"):
-            _resolve_call_data_sources(
-                {"background_data": {"source": str(tmp_path), "n_samples": "bad"}}
+            resolve_call_data_sources(
+                {"background_data": {"source": str(tmp_path), "n_samples": "bad"}},
+                log_label="call",
             )
 
     def test_non_data_source_dict_with_extra_keys_is_passed_through(self) -> None:
         """A dict with keys beyond {source, n_samples} is not treated as a data source."""
         value = {"source": "somewhere", "extra_key": True}
-        result = _resolve_call_data_sources({"some_kwarg": value})
+        result = resolve_call_data_sources({"some_kwarg": value}, log_label="call")
         assert result["some_kwarg"] is value
 
     def test_explanation_injects_background_data_from_call(


### PR DESCRIPTION
## Summary

Closes #245. Pre-1.0 clean break: removes genuine backward-compat code and refactors live features that carried a misleading `legacy` name. One commit per item, bisectable.

- **A1 `refactor(config)!`** — Removes the silent `_migrate_misplaced_raitap_call_keys` auto-relocation of `call:`-vs-`raitap:` keys. Misplaced RAITAP-owned keys under `call:` now raise a clear `ValueError` instead of being silently moved. **Breaking** (configs relying on the silent fix now error).
- **A2 `refactor(misc)`** — Drops the internal-test back-compat thin wrappers in `robustness/factory.py` and `transparency/factory.py` (`_raw_assessor_config`, `_raw_transparency_config`, the `_resolve_call_data_sources` shims); tests call the canonical `raw_config_dict` / `resolve_call_data_sources` directly. `transparency/phase.py` now imports the canonical helper directly (re-export alias removed).
- **B3 `refactor(reporting)`** — Renames the misleading internal `_legacy_*` report symbols to `_verbose_*` (`_build_verbose_local_section`, `_verbose_robustness_images`, `verbose_samples`, sort-tag `"verbose"`). These are user-controlled verbosity options, not back-compat. Public `show_*` config fields unchanged; the `explicit_selection` PDF flow preserved (rename only, no behavior change).
- **B4 `docs(data)`** — `id_strategy: stem` stays a supported value; drops the misleading "legacy" framing from its docs/comments (now described as flat-dir / basename matching).
- **C5 `refactor(data)`** — Removes the `_reject_legacy_undecorated_factories` guard + `_LEGACY_FACTORY_NAMES`. An undecorated `make_preprocessing` now falls through to the existing generic "no factory decorated with `@...`" error.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — Title uses `!`. A1 changes config behavior (misplaced `call:` keys now error instead of silently migrating). This is absolutely necessary as part of the pre-1.0 clean-break sweep and should not be delayed.
- [x] **Contributor guide** — Read.

## Optional

- [x] **Issue** _(optional)_ — Closes #245.
- [x] **Docs** _(optional)_ — Reporting + data docs updated (B3, B4); contributor robustness doc updated (A2).
- [x] **Tests** _(optional)_ — Factory, reporting, and preprocessing tests updated for the new behavior.
