### PR TITLE
feat(data): folder-as-label (ImageFolder-style) ingestion (#264)

### DIFF
--- a/docs/modules/data/configuration.md
+++ b/docs/modules/data/configuration.md
@@ -72,7 +72,11 @@ myst:
 :description: Optional path to a labels file (CSV, TSV, or Parquet), URL, or
   named sample set. When set to a sample name (e.g. `"imagenet_samples"`),
   raitap resolves to the labels CSV bundled with that sample. Sample sets
-  without bundled labels raise an error.
+  without bundled labels raise an error. The reserved value `"directory"`
+  derives classification labels from each sample's top-level class
+  subdirectory (torchvision `ImageFolder` style; no labels file) — see
+  {doc}`own-vs-built-in`. In that mode `id_column` and `id_strategy` do not
+  apply.
 
 :option: labels.id_column
 :allowed: string, null

--- a/docs/modules/data/own-vs-built-in.md
+++ b/docs/modules/data/own-vs-built-in.md
@@ -131,6 +131,41 @@ conventional one and the safe default. `stem` collapses ids that share a
 filename across subdirs (`NORMAL/IM-0001.jpeg` and `PNEUMONIA/IM-0001.jpeg`
 both become `IM-0001`), which raises a duplicate-id error.
 
+### Labels from directory structure
+
+If your images are already organised into one folder per class (the
+torchvision `ImageFolder` convention), set `labels.source: "directory"` to use
+the folder names as labels. No labels file needed.
+
+```text
+data/train/
+├── NORMAL/IM-0001.jpeg      # label: NORMAL
+├── NORMAL/IM-0002.jpeg
+└── PNEUMONIA/IM-0001.jpeg   # label: PNEUMONIA
+```
+
+```{config-tabs}
+:yaml:
+data:
+  source: "./data/train"
+  labels:
+    source: "directory"
+
+:python:
+from raitap.data import DataConfig, LabelsConfig
+
+data = DataConfig(
+    source="./data/train",
+    labels=LabelsConfig(source="directory"),
+)
+```
+
+The class is each sample's top-level subdirectory; nesting within a class
+folder is fine. Class ids are assigned alphabetically (`NORMAL` to `0`,
+`PNEUMONIA` to `1`). `id_column` and `id_strategy` do not apply. If images sit
+directly under the source with no class subdirs, RAITAP warns and falls back to
+predictions as metric targets.
+
 If you want to evaluate metrics against ground-truth labels, configure the
 optional `data.labels` block as described in {doc}`configuration`.
 

--- a/docs/modules/data/own-vs-built-in.md
+++ b/docs/modules/data/own-vs-built-in.md
@@ -152,11 +152,11 @@ data:
     source: "directory"
 
 :python:
-from raitap.data import DataConfig, LabelsConfig
+from raitap.data import DIRECTORY_LABELS_SOURCE, DataConfig, LabelsConfig
 
 data = DataConfig(
     source="./data/train",
-    labels=LabelsConfig(source="directory"),
+    labels=LabelsConfig(source=DIRECTORY_LABELS_SOURCE),  # == "directory"
 )
 ```
 

--- a/src/raitap/configs/schema.py
+++ b/src/raitap/configs/schema.py
@@ -71,8 +71,9 @@ class ModelConfig:
 @dataclass
 class LabelsConfig:
     # Optional path to a labels file (currently CSV/TSV/Parquet), OR the reserved
-    # value "directory" to derive classification labels from each sample's
-    # top-level class subdirectory (torchvision ImageFolder style; no labels file).
+    # value "directory" (exposed as ``raitap.data.DIRECTORY_LABELS_SOURCE``) to
+    # derive classification labels from each sample's top-level class
+    # subdirectory (torchvision ImageFolder style; no labels file).
     source: str | None = None
     # Optional sample-id column for filename alignment (e.g. "image").
     id_column: str | None = None

--- a/src/raitap/configs/schema.py
+++ b/src/raitap/configs/schema.py
@@ -70,7 +70,9 @@ class ModelConfig:
 
 @dataclass
 class LabelsConfig:
-    # Optional path to a labels file (currently CSV/TSV/Parquet).
+    # Optional path to a labels file (currently CSV/TSV/Parquet), OR the reserved
+    # value "directory" to derive classification labels from each sample's
+    # top-level class subdirectory (torchvision ImageFolder style; no labels file).
     source: str | None = None
     # Optional sample-id column for filename alignment (e.g. "image").
     id_column: str | None = None

--- a/src/raitap/data/__init__.py
+++ b/src/raitap/data/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .types import IdStrategy, LabelEncoding, Preprocessing
+from .types import DIRECTORY_LABELS_SOURCE, IdStrategy, LabelEncoding, Preprocessing
 
 if TYPE_CHECKING:
     from raitap.configs.schema import DataConfig, LabelsConfig
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "DIRECTORY_LABELS_SOURCE",
     "Data",
     "DataConfig",
     "DataInputMetadata",

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -11,7 +11,13 @@ from PIL import Image
 
 from raitap import raitap_log
 from raitap.data.preprocessing import module_as_per_image_callable, resolve_preprocessing
-from raitap.data.types import MODALITY_EXTENSIONS, IdStrategy, InputModality, LabelEncoding
+from raitap.data.types import (
+    DIRECTORY_LABELS_SOURCE,
+    MODALITY_EXTENSIONS,
+    IdStrategy,
+    InputModality,
+    LabelEncoding,
+)
 from raitap.data.utils import download_file
 from raitap.tracking.base_tracker import BaseTracker, Trackable
 from raitap.types import DetectionInputs, TaskKind
@@ -230,9 +236,6 @@ class Data(Trackable):
         tracker.log_dataset(self.describe())
 
 
-_DIRECTORY_LABELS_SOURCE = "directory"
-
-
 def _load_directory_labels(sample_ids: list[str] | None) -> torch.Tensor | None:
     """Derive classification labels from each sample's top-level class folder
     (torchvision ImageFolder semantics). Returns None (with a warning) when
@@ -275,7 +278,7 @@ def load_classification_labels(
     if not labels_source:
         return None
 
-    if labels_source == _DIRECTORY_LABELS_SOURCE:
+    if labels_source == DIRECTORY_LABELS_SOURCE:
         return _load_directory_labels(sample_ids)
 
     labels_path = get_source_path(labels_source, kind=SourceKind.LABELS)

--- a/src/raitap/data/data.py
+++ b/src/raitap/data/data.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import Counter
 from enum import StrEnum
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -230,6 +230,34 @@ class Data(Trackable):
         tracker.log_dataset(self.describe())
 
 
+_DIRECTORY_LABELS_SOURCE = "directory"
+
+
+def _load_directory_labels(sample_ids: list[str] | None) -> torch.Tensor | None:
+    """Derive classification labels from each sample's top-level class folder
+    (torchvision ImageFolder semantics). Returns None (with a warning) when
+    labels cannot be derived: no sample ids, or a sample with no class subdir."""
+    if not sample_ids:
+        raitap_log.warn(
+            "data.labels.source='directory' needs image samples organised into "
+            "class subdirectories; none were found. Falling back to predictions "
+            "as metric targets."
+        )
+        return None
+    parts_by_id = [PurePosixPath(sid).parts for sid in sample_ids]
+    if any(len(parts) < 2 for parts in parts_by_id):
+        raitap_log.warn(
+            "data.labels.source='directory' expects a <class>/<file> layout, but "
+            "one or more samples sit directly under the data source root (no class "
+            "subdirectory). Falling back to predictions as metric targets."
+        )
+        return None
+    classes = sorted({parts[0] for parts in parts_by_id})
+    class_to_idx = {name: idx for idx, name in enumerate(classes)}
+    labels = [class_to_idx[parts[0]] for parts in parts_by_id]
+    return torch.tensor(labels, dtype=torch.long)
+
+
 def load_classification_labels(
     cfg: AppConfig,
     *,
@@ -246,6 +274,9 @@ def load_classification_labels(
     labels_source = _get_optional_config_value(labels_cfg, "source")
     if not labels_source:
         return None
+
+    if labels_source == _DIRECTORY_LABELS_SOURCE:
+        return _load_directory_labels(sample_ids)
 
     labels_path = get_source_path(labels_source, kind=SourceKind.LABELS)
     labels_df = _load_tabular_frame(labels_path)

--- a/src/raitap/data/tests/test_data_class.py
+++ b/src/raitap/data/tests/test_data_class.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 from raitap.data import Data
 from raitap.data.data import _load_directory_labels, load_classification_labels
-from raitap.data.types import InputModality
+from raitap.data.types import DIRECTORY_LABELS_SOURCE, InputModality
 
 
 def _write_image(path: Path) -> None:
@@ -516,7 +516,7 @@ class TestLoadDirectoryLabels:
 
 class TestLoadClassificationLabelsDirectorySource:
     def test_directory_source_derives_labels(self) -> None:
-        config = _make_config("images", labels_source="directory")
+        config = _make_config("images", labels_source=DIRECTORY_LABELS_SOURCE)
         sample_ids = ["NORMAL/a.jpg", "PNEUMONIA/b.jpg", "NORMAL/c.jpg"]
         tensor = torch.zeros(len(sample_ids), 3, 8, 8)
 
@@ -526,7 +526,7 @@ class TestLoadClassificationLabelsDirectorySource:
         assert torch.equal(result, torch.tensor([0, 1, 0]))
 
     def test_directory_source_none_sample_ids_returns_none(self) -> None:
-        config = _make_config("rows.csv", labels_source="directory")
+        config = _make_config("rows.csv", labels_source=DIRECTORY_LABELS_SOURCE)
         tensor = torch.zeros(3, 4)
 
         with pytest.warns(UserWarning, match="class subdirectories"):

--- a/src/raitap/data/tests/test_data_class.py
+++ b/src/raitap/data/tests/test_data_class.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from raitap.configs.schema import AppConfig
 
 from raitap.data import Data
+from raitap.data.data import _load_directory_labels, load_classification_labels
 from raitap.data.types import InputModality
 
 
@@ -479,3 +480,56 @@ class TestDataLog:
         assert "num_samples" in call_args
         assert "shape" in call_args
         assert "dtype" in call_args
+
+
+class TestLoadDirectoryLabels:
+    def test_derives_labels_from_top_level_class_folder(self) -> None:
+        result = _load_directory_labels(["NORMAL/a.jpg", "PNEUMONIA/b.jpg", "NORMAL/c.jpg"])
+        assert result is not None
+        assert torch.equal(result, torch.tensor([0, 1, 0]))
+
+    def test_nesting_within_class_stays_top_level(self) -> None:
+        result = _load_directory_labels(["NORMAL/sub/a.jpg", "PNEUMONIA/b.jpg"])
+        assert result is not None
+        assert torch.equal(result, torch.tensor([0, 1]))
+
+    def test_single_class_is_all_zeros_not_error(self) -> None:
+        result = _load_directory_labels(["NORMAL/a.jpg", "NORMAL/b.jpg"])
+        assert result is not None
+        assert torch.equal(result, torch.tensor([0, 0]))
+
+    def test_sample_without_class_subdir_returns_none(self) -> None:
+        with pytest.warns(UserWarning, match="class subdirectory"):
+            result = _load_directory_labels(["a.jpg", "NORMAL/b.jpg"])
+        assert result is None
+
+    def test_none_sample_ids_returns_none(self) -> None:
+        with pytest.warns(UserWarning, match="class subdirectories"):
+            result = _load_directory_labels(None)
+        assert result is None
+
+    def test_empty_sample_ids_returns_none(self) -> None:
+        with pytest.warns(UserWarning, match="class subdirectories"):
+            result = _load_directory_labels([])
+        assert result is None
+
+
+class TestLoadClassificationLabelsDirectorySource:
+    def test_directory_source_derives_labels(self) -> None:
+        config = _make_config("images", labels_source="directory")
+        sample_ids = ["NORMAL/a.jpg", "PNEUMONIA/b.jpg", "NORMAL/c.jpg"]
+        tensor = torch.zeros(len(sample_ids), 3, 8, 8)
+
+        result = load_classification_labels(config, tensor=tensor, sample_ids=sample_ids)
+
+        assert result is not None
+        assert torch.equal(result, torch.tensor([0, 1, 0]))
+
+    def test_directory_source_none_sample_ids_returns_none(self) -> None:
+        config = _make_config("rows.csv", labels_source="directory")
+        tensor = torch.zeros(3, 4)
+
+        with pytest.warns(UserWarning, match="class subdirectories"):
+            result = load_classification_labels(config, tensor=tensor, sample_ids=None)
+
+        assert result is None

--- a/src/raitap/data/types.py
+++ b/src/raitap/data/types.py
@@ -33,6 +33,14 @@ class IdStrategy(StrEnum):
     stem = "stem"
 
 
+#: Reserved ``LabelsConfig.source`` value selecting folder-as-label ingestion:
+#: classification labels are derived from each sample's top-level class
+#: subdirectory (torchvision ``ImageFolder`` style; no labels file). Kept as a
+#: plain ``str`` so it round-trips through OmegaConf; ``LabelsConfig.source``
+#: stays ``str | None`` (a path or this sentinel).
+DIRECTORY_LABELS_SOURCE = "directory"
+
+
 class Preprocessing(StrEnum):
     """Named values for ``DataConfig.preprocessing``.
 


### PR DESCRIPTION
## Summary

Closes #264. Adds torchvision `ImageFolder`-style label ingestion: `data.labels.source: "directory"` derives classification labels from each image sample's top-level class subdirectory, with no labels file.

- Single polymorphic `data.labels.source` — the reserved value `"directory"` selects directory-derived labels. No second key, so no contradictory config is expressible. `id_column`/`id_strategy` do not apply in this mode.
- Class = each sample's top-level subdir (`NORMAL/sub/IM-0001.jpeg` → `NORMAL`); nesting within a class folder is allowed. Class ids assigned alphabetically (`class_to_idx`), matching `ImageFolder`.
- Non-derivable cases (no class subdirs, flat dir, no sample ids / tabular) warn and fall back to predictions-as-targets — consistent with the existing empty-labels / alignment-failure convention. Non-fatal.
- Returns an integer label tensor, same contract as the file-based path.

Deferred (not this PR): propagating directory names as display `category_names` (the file-based path doesn't propagate target names either — would be asymmetric). Multi-label and configurable class-depth are out of scope.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — Not breaking. Purely additive: a new reserved value on an existing optional field; default behavior unchanged.
- [x] **Contributor guide** — Read.

## Optional

- [x] **Issue** _(optional)_ — Closes #264.
- [x] **Docs** _(optional)_ — `own-vs-built-in.md` (worked example) + `configuration.md` (`labels.source` reserved value).
- [x] **Tests** _(optional)_ — Unit tests for `_load_directory_labels` (mapping, nesting, single-class, no-subdir fallback, empty/None) and the `load_classification_labels` branch.
