### PR TITLE
feat: communicate reproducibility caveat for stochastic methods (#251)

### DIFF
--- a/docs/contributor/modules/robustness.md
+++ b/docs/contributor/modules/robustness.md
@@ -50,10 +50,13 @@ BaseAssessor                            # root: declares assessment_kind + budge
 Every assessor declares two `ClassVar`s the framework relies on:
 
 - `algorithm_registry: ClassVar[Mapping[str, AssessorSemanticsHints]]`: maps
-  algorithm names to their threat model / norm / families. `assessor_semantics`
-  uses this to build `RobustnessResult.semantics.perturbation`, so the reported
-  metadata always matches what the adapter actually executed. Passed via the
-  `@adapters.robustness(algorithm_registry=...)` decorator kwarg.
+  algorithm names to their threat model / norm / families / `stochastic` flag.
+  `assessor_semantics` uses this to build `RobustnessResult.semantics`, so the
+  reported metadata always matches what the adapter actually executed. The
+  `stochastic: bool` hint is declared explicitly per algorithm (e.g. `True` for
+  PGD random-start and statistical-sampling corruptions, `False` for FGSM / CW);
+  it flows onto `semantics.stochastic` and drives the reproducibility caveat.
+  Passed via the `@adapters.robustness(algorithm_registry=...)` decorator kwarg.
 - `budget_kwarg_source: ClassVar[str]`: `"init_kwargs"` (torchattacks reads
   the budget at construction time) or `"call_kwargs"` (foolbox reads it at
   call time). Defaults to `"init_kwargs"`.

--- a/docs/contributor/modules/transparency.md
+++ b/docs/contributor/modules/transparency.md
@@ -52,6 +52,7 @@ baseline in `metadata.json` + the report (issue #210). The user sets it library-
 | `baseline_kwarg_name` | `@adapters.transparency` decorator kwarg | The call kwarg holding the reference (`"baselines"`, `"background_data"`); omitted (default `None`) = no baseline. Per-**adapter**. Also names where `raitap.baseline` is routed. |
 | `ExplainerSemanticsHints.baseline_default` | per-algorithm `algorithm_registry` entry | Per-**algorithm** implicit default mode (`BaselineMode.ZERO` / `INPUT_BATCH`) used when the kwarg is omitted; `None` when the algorithm takes no baseline. |
 | `ExplainerSemanticsHints.baseline_cardinality` | per-algorithm `algorithm_registry` entry | `BaselineCardinality.SINGLE` (one broadcast reference, e.g. IG) or `SET` (a sample distribution, e.g. SHAP). Used to *warn* on a mismatched `raitap.baseline` (never to reshape it); `None` skips the check. |
+| `ExplainerSemanticsHints.stochastic` | per-algorithm `algorithm_registry` entry | `True` when the algorithm is RNG-dependent (e.g. SHAP `GradientExplainer` / `KernelShap`, Captum `Lime`), `False` for deterministic methods (IG, Saliency). Resolved by `explainer_is_stochastic`, flows onto `ExplanationResult.semantics.stochastic`, and drives the reproducibility caveat. Defaults to `False`. |
 
 Capture happens once at the `AttributionOnlyExplainer.explain` chokepoint via `build_baseline_record`
 (`transparency/baselines.py`), which resolves the `BaselineMode` (`configured` / `user_tensor` /

--- a/docs/modules/reporting/output.md
+++ b/docs/modules/reporting/output.md
@@ -41,14 +41,24 @@ curated subset used in the report.
 
 Generated reports use this structure:
 
-1. **Executive Summary**
-2. **Transparency Details**
-3. **Robustness Details**
-4. **Appendix**
+1. **Reproducibility** (only when the run used a stochastic method)
+2. **Executive Summary**
+3. **Transparency Details**
+4. **Robustness Details**
+5. **Appendix**
 
 Missing metrics, global explanations, aggregated explanations, and robustness sections are omitted. If no
 local explanations are present, the transparency details render a short
 placeholder rather than an empty card.
+
+### Reproducibility
+
+When the run used a stochastic method (for example SHAP `GradientExplainer`, a
+PGD attack, or an image-corruption assessor), the report opens with a banner
+noting that the results are not bit-reproducible unless seeds are pinned, naming
+the stochastic methods. A fully deterministic run omits this section. The same
+caveat is written to `REPRODUCIBILITY.md` in the run directory and logged as a
+warning after the run. The banner renders in both HTML and PDF reports.
 
 ### Metrics
 

--- a/docs/modules/robustness/output.md
+++ b/docs/modules/robustness/output.md
@@ -50,6 +50,7 @@ robustness semantics:
 - `semantics.objective` — `untargeted` or `targeted`.
 - `semantics.perturbation` — worst-case assessors: norm + epsilon + (optional) step size + steps; average-case assessors: corruption name + severity.
 - `semantics.families` — descriptive tags such as `gradient_sign`, `iterative`, `optimization`, or `common_corruption`.
+- `semantics.stochastic` — `true` when the algorithm is RNG-dependent (random start, sampling, statistical sampling), so the result is not bit-reproducible unless seeds are pinned. Drives the run-level reproducibility caveat.
 - `metrics` — empirical-only fields (`adversarial_accuracy`, `attack_success_rate`, `mean_distance`, `max_distance`); formal-only fields (`verified_rate`, `falsified_rate`, `unknown_rate`, `error_rate`, `mean_runtime`); statistical-sampling-only fields (`corrupted_accuracy`, `accuracy_ci_low`, `accuracy_ci_high`, `n_samples`, `n_correct`); `clean_accuracy` is always populated. Unused fields are omitted rather than set to `null`.
 - `kwargs` — RAITAP-owned metadata used for reporting (`sample_names`,
   `show_sample_names`).

--- a/docs/modules/transparency/output.md
+++ b/docs/modules/transparency/output.md
@@ -24,8 +24,11 @@ If an explainer uses more than one visualiser, RAITAP writes one PNG per
 visualiser using the pattern `<VisualiserClassName>_<index>.png`.
 
 `metadata.json` stores typed explanation semantics, including scope, payload
-kind, method families, sample selection, input metadata, and output-space
-metadata. It also keeps two separate runtime buckets:
+kind, method families, sample selection, input metadata, output-space metadata,
+and `semantics.stochastic` (`true` when the algorithm is RNG-dependent — for
+example SHAP `GradientExplainer` or `KernelShap` — so the result is not
+bit-reproducible unless seeds are pinned; drives the run-level reproducibility
+caveat). It also keeps two separate runtime buckets:
 
 - `kwargs`: RAITAP-owned metadata used for downstream visualisation, such as
   `sample_names` and `show_sample_names`

--- a/docs/using-raitap/understanding-outputs.md
+++ b/docs/using-raitap/understanding-outputs.md
@@ -21,6 +21,7 @@ outputs/                                      # Hydra's default output directory
 └── 2026-02-28/                               # Run date
     └── 14-30-45/                             # Run time
         ├── __main__.log                      # Run log
+        ├── REPRODUCIBILITY.md                # Only when the run used a stochastic method
         ├── .hydra/                           # Hydra configuration logs
         │   ├── config.yaml
         │   ├── hydra.yaml
@@ -59,6 +60,13 @@ The `transparency/` and `robustness/` directories keep the full assessor
 artifacts for debugging and tracking. The `reports/` directory contains the
 compact report, a ZIP package with the HTML, manifest, and curated report-only
 figure assets.
+
+`REPRODUCIBILITY.md` is written only when the run used a stochastic method (for
+example SHAP `GradientExplainer`, a PGD attack, or an image-corruption assessor).
+It lists which artefacts are not bit-reproducible. The same caveat appears as a
+banner in the report and as a warning after the run. Deterministic runs write no
+such file. Each stochastic method's `metadata.json` also carries a
+`semantics.stochastic: true` field.
 
 You may want to look at each module's output directory for more details:
 

--- a/src/raitap/pipeline/orchestrator.py
+++ b/src/raitap/pipeline/orchestrator.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from raitap import raitap_log
+from raitap.configs import resolve_run_dir
 from raitap.data import Data
 from raitap.data.preprocessing import resolve_preprocessing
 from raitap.models import Model
@@ -19,6 +20,11 @@ from raitap.pipeline.phases.registry import ASSESSMENT_PHASES, PhaseContext
 from raitap.pipeline.ui import print_summary
 from raitap.reporting import build_report, create_report, reporting_enabled
 from raitap.reporting.sample_selection import resolve_report_sample_selection
+from raitap.reproducibility import (
+    reproducibility_caveat,
+    stochastic_methods,
+    write_reproducibility_md,
+)
 from raitap.tracking import BaseTracker
 from raitap.utils.diagnostics import Module
 from raitap.utils.lazy import lazy_import
@@ -91,6 +97,14 @@ def _run_pipeline(
         resolved_preprocessing=resolved_preprocessing,
     )
 
+    # Reproducibility caveat (#251). Derived once from the run's semantics. The
+    # output-dir note and the warning fire whenever a stochastic method ran —
+    # independent of reporting (the run dir + console exist regardless); only the
+    # report banner (inside build_report) is gated on reporting.
+    stochastic = stochastic_methods(outputs)
+    if stochastic:
+        write_reproducibility_md(resolve_run_dir(config), stochastic)
+
     report_generation = None
     if reporting_enabled(config):
         if verbose:
@@ -98,6 +112,10 @@ def _run_pipeline(
             raitap_log.info("Generating report...", module=Module.reporting)
         report = build_report(config, outputs)
         report_generation = create_report(config=config, report=report)
+
+    if stochastic:
+        # After the "Report generated" log so it reads as a closing caveat.
+        raitap_log.warn(reproducibility_caveat(stochastic))
 
     tracking_config = getattr(config, "tracking", None)
     has_tracker = bool(tracking_config and getattr(tracking_config, "_target_", None))

--- a/src/raitap/reporting/builder.py
+++ b/src/raitap/reporting/builder.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from raitap.configs import resolve_run_dir
+from raitap.reproducibility import reproducibility_caveat, stochastic_methods
 
 from .filenames import report_output_filename
 from .manifest import ReportManifest
@@ -83,6 +84,9 @@ def build_report(config: AppConfig, outputs: RunOutputs) -> BuiltReport:
     )
 
     sections: list[ReportSection] = []
+    banner = _reproducibility_banner(outputs)
+    if banner is not None:
+        sections.append(banner)
     ordered_results = sorted(outputs.phase_results.values(), key=lambda result: result.report_order)
     for phase_result in ordered_results:
         sections.extend(phase_result.report_sections(report_ctx))
@@ -186,6 +190,23 @@ def build_merged_report(
         filename=_manifest_filename(config),
     )
     return BuiltReport(report_dir=report_dir, sections=ordered_sections, manifest=manifest)
+
+
+def _reproducibility_banner(outputs: RunOutputs) -> ReportSection | None:
+    """Run-level reproducibility caveat, or ``None`` when the run is fully deterministic.
+
+    Emitted as a ``ReportSection`` (not view metadata) because ``sections`` is the
+    only channel both the HTML and PDF reporters consume. Prepended so it renders
+    first. See issue #251.
+    """
+    methods = stochastic_methods(outputs)
+    if not methods:
+        return None
+    return ReportSection.from_groups(
+        "Reproducibility",
+        [ReportGroup(heading=reproducibility_caveat(methods))],
+        metadata={"section_role": "reproducibility"},
+    )
 
 
 def _manifest_filename(config: AppConfig) -> str:

--- a/src/raitap/reporting/pdf_reporter.py
+++ b/src/raitap/reporting/pdf_reporter.py
@@ -302,6 +302,10 @@ class PDFReporter(BaseReporter):
         )
 
         for section in sections:
+            if section.metadata.get("section_role") == "reproducibility":
+                self._add_reproducibility(doc, section, b)
+                continue
+
             section_open = False
             layout: Any = None
 
@@ -344,6 +348,32 @@ class PDFReporter(BaseReporter):
                         layout.append_layout_element(
                             b.Paragraph(_pdf_display_text(f"(Failed to load: {image_path.name})"))
                         )
+
+    def _add_reproducibility(
+        self,
+        doc: Any,
+        section: ReportSection,
+        b: SimpleNamespace,
+    ) -> None:
+        """Render the run-level reproducibility caveat as a heading + paragraph.
+
+        The banner group carries only a ``heading`` (no images/table_rows), so the
+        normal ``_add_sections`` group loop would skip it. Issue #251.
+        """
+        text = next((group.heading for group in section.groups if group.heading), None)
+        if not text:
+            return
+        page = b.Page()
+        doc.append_page(page)
+        layout = b.SingleColumnLayout(page)
+        layout.append_layout_element(
+            b.Paragraph(
+                _pdf_display_text(section.title),
+                font_size=20,
+                font="Helvetica-Bold",
+            )
+        )
+        layout.append_layout_element(b.Paragraph(_pdf_display_text(text)))
 
     def _add_table(self, layout: Any, group: ReportGroup, b: SimpleNamespace) -> None:
         """Render ``group.table_rows`` as a two-column borb table."""

--- a/src/raitap/reporting/templates/_reproducibility.html.j2
+++ b/src/raitap/reporting/templates/_reproducibility.html.j2
@@ -1,0 +1,4 @@
+<aside class="repro-banner" id="reproducibility-banner" role="note">
+  <p class="eyebrow">Reproducibility</p>
+  <p>{{ view.reproducibility }}</p>
+</aside>

--- a/src/raitap/reporting/templates/report.css
+++ b/src/raitap/reporting/templates/report.css
@@ -99,6 +99,19 @@ th {
   font-size: 10px;
 }
 
+.repro-banner {
+  margin-bottom: 16px;
+  padding: 10px 14px;
+  border: 1px solid var(--warn);
+  border-left: 4px solid var(--warn);
+  border-radius: 6px;
+  background: #fff8c5;
+}
+
+.repro-banner .eyebrow {
+  color: var(--warn);
+}
+
 .summary-page,
 .detail-section {
   break-after: page;

--- a/src/raitap/reporting/templates/report.html.j2
+++ b/src/raitap/reporting/templates/report.html.j2
@@ -1,6 +1,9 @@
 {% extends "base.html.j2" %}
 
 {% block body %}
+  {% if view.reproducibility %}
+    {% include "_reproducibility.html.j2" %}
+  {% endif %}
   {% include "_summary.html.j2" %}
   {% include "_local.html.j2" %}
   {% include "_robustness.html.j2" %}

--- a/src/raitap/reporting/tests/test_builder.py
+++ b/src/raitap/reporting/tests/test_builder.py
@@ -511,6 +511,62 @@ def test_build_report_skips_global_section_for_local_only_outputs(tmp_path: Path
     assert [section.title for section in report.sections] == ["Local Explanations"]
 
 
+def _explanation_with_stochastic(tmp_path: Path, *, stochastic: bool) -> Any:
+    from dataclasses import replace
+
+    semantics = replace(_local_image_semantics((3, 1, 4, 4)), stochastic=stochastic)
+    return ExplanationResult(
+        attributions=torch.rand(3, 1, 4, 4),
+        inputs=torch.rand(3, 1, 4, 4),
+        run_dir=tmp_path / "transparency" / "exp",
+        experiment_name="repro",
+        adapter_target="t",
+        algorithm="GradientExplainer",
+        semantics=semantics,
+        name="shap_grad",
+        visualisers=[ConfiguredVisualiser(visualiser=_LocalImageVisualiser())],
+    )
+
+
+def _repro_outputs(explanation: Any) -> RunOutputs:
+    return _run_outputs(
+        explanations=[explanation],
+        visualisations=[],
+        forward_output=_fo(torch.tensor([[0.1, 0.9], [0.8, 0.2], [0.95, 0.05]])),
+        prediction_summaries=(
+            PredictionSummary(sample_index=0, predicted_class=1, confidence=0.9, correct=None),
+            PredictionSummary(sample_index=1, predicted_class=0, confidence=0.8, correct=None),
+            PredictionSummary(sample_index=2, predicted_class=0, confidence=0.95, correct=None),
+        ),
+    )
+
+
+def test_build_report_prepends_reproducibility_banner_when_stochastic(tmp_path: Path) -> None:
+    config = AppConfig(experiment_name="repro")
+    set_output_root(config, tmp_path)
+    config.reporting = ReportingConfig(_target_="PDFReporter", filename="report.pdf")
+
+    outputs = _repro_outputs(_explanation_with_stochastic(tmp_path, stochastic=True))
+
+    report = build_report(config, outputs)
+
+    assert report.sections[0].title == "Reproducibility"
+    assert "not bit-reproducible" in report.sections[0].groups[0].heading
+    assert "shap_grad" in report.sections[0].groups[0].heading
+
+
+def test_build_report_no_banner_when_all_deterministic(tmp_path: Path) -> None:
+    config = AppConfig(experiment_name="repro")
+    set_output_root(config, tmp_path)
+    config.reporting = ReportingConfig(_target_="PDFReporter", filename="report.pdf")
+
+    outputs = _repro_outputs(_explanation_with_stochastic(tmp_path, stochastic=False))
+
+    report = build_report(config, outputs)
+
+    assert all(section.title != "Reproducibility" for section in report.sections)
+
+
 def test_build_report_places_aggregated_visualisations_between_global_and_local(
     tmp_path: Path,
 ) -> None:

--- a/src/raitap/reporting/tests/test_html_reporter.py
+++ b/src/raitap/reporting/tests/test_html_reporter.py
@@ -242,6 +242,37 @@ def test_html_reporter_renders_baseline_image_and_view_link(tmp_path: Path) -> N
     assert [href for href in parser.fragment_hrefs if href not in parser.ids] == []
 
 
+def test_html_reporter_renders_reproducibility_banner_before_summary(tmp_path: Path) -> None:
+    caveat = (
+        "This run includes stochastic methods (pgd); results are not "
+        "bit-reproducible unless seeds are pinned."
+    )
+    sections = (
+        ReportSection.from_groups(
+            "Reproducibility",
+            [ReportGroup(heading=caveat)],
+            metadata={"section_role": "reproducibility"},
+        ),
+        *_synthetic_sections(),
+    )
+
+    HTMLReporter(_config()).generate(sections, report_dir=tmp_path)
+
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+    assert 'id="reproducibility-banner"' in html
+    assert "not bit-reproducible" in html
+    # The banner renders before the summary hero.
+    assert html.index('id="reproducibility-banner"') < html.index('class="report-hero"')
+
+
+def test_html_reporter_omits_reproducibility_banner_for_deterministic_run(tmp_path: Path) -> None:
+    HTMLReporter(_config()).generate(_synthetic_sections(), report_dir=tmp_path)
+
+    html = (tmp_path / "report.html").read_text(encoding="utf-8")
+    assert 'id="reproducibility-banner"' not in html
+    assert 'class="repro-banner"' not in html
+
+
 def _config(*, filename: str = "report.pdf") -> AppConfig:
     config = AppConfig(experiment_name="html-report-test")
     config.reporting = ReportingConfig(

--- a/src/raitap/reporting/tests/test_pdf_reporter.py
+++ b/src/raitap/reporting/tests/test_pdf_reporter.py
@@ -185,6 +185,27 @@ def test_pdf_reporter_sanitizes_all_paragraph_text(mock_config: AppConfig) -> No
     )
 
 
+def test_pdf_reporter_renders_reproducibility_caveat_paragraph(mock_config: AppConfig) -> None:
+    """The heading-only reproducibility banner emits a visible heading + paragraph."""
+    caveat = (
+        "This run includes stochastic methods (pgd); results are not "
+        "bit-reproducible unless seeds are pinned."
+    )
+    borb = _mock_borb()
+    section = ReportSection.from_groups(
+        "Reproducibility",
+        [ReportGroup(heading=caveat)],
+        metadata={"section_role": "reproducibility"},
+    )
+
+    with patch("raitap.reporting.pdf_reporter._borb_pdf_ns", return_value=borb):
+        PDFReporter(mock_config).generate((section,))
+
+    paragraph_texts = [call.args[0] for call in borb.Paragraph.call_args_list]
+    assert "Reproducibility" in paragraph_texts
+    assert any("not bit-reproducible" in str(text) for text in paragraph_texts)
+
+
 def test_prepare_raster_scales_large_png_to_bounds(tmp_path: Path) -> None:
     from PIL import Image as PILImage
 

--- a/src/raitap/reporting/tests/test_view_model.py
+++ b/src/raitap/reporting/tests/test_view_model.py
@@ -8,6 +8,44 @@ from raitap.reporting.sections import ReportGroup, ReportSection
 from raitap.reporting.view_model import build_view
 
 
+def test_build_view_captures_reproducibility_banner_and_excludes_from_appendix() -> None:
+    caveat = (
+        "This run includes stochastic methods (pgd); results are not "
+        "bit-reproducible unless seeds are pinned."
+    )
+    sections = (
+        ReportSection.from_groups(
+            "Reproducibility",
+            [ReportGroup(heading=caveat)],
+            metadata={"section_role": "reproducibility"},
+        ),
+        ReportSection.from_groups(
+            "Metrics",
+            [ReportGroup(heading="Performance Metrics", table_rows=(("accuracy", "0.9"),))],
+            metadata={"section_role": "metrics"},
+        ),
+    )
+
+    view = build_view(sections)
+
+    assert view.reproducibility == caveat
+    assert "Reproducibility" not in [section.title for section in view.appendix.sections]
+
+
+def test_build_view_reproducibility_none_for_deterministic_run() -> None:
+    sections = (
+        ReportSection.from_groups(
+            "Metrics",
+            [ReportGroup(heading="Performance Metrics", table_rows=(("accuracy", "0.9"),))],
+            metadata={"section_role": "metrics"},
+        ),
+    )
+
+    view = build_view(sections)
+
+    assert view.reproducibility is None
+
+
 def test_build_view_groups_local_explainers_and_splits_metadata_tiers() -> None:
     manifest = _snapshot_manifest()
 

--- a/src/raitap/reporting/view_model.py
+++ b/src/raitap/reporting/view_model.py
@@ -182,6 +182,9 @@ class ReportView:
     local_samples: tuple[LocalSampleView, ...]
     robustness_assessors: tuple[RobustnessAssessorView, ...]
     appendix: AppendixView
+    # Run-level reproducibility caveat (issue #251); ``None`` for fully
+    # deterministic runs. Rendered as a top banner, not an appendix row.
+    reproducibility: str | None = None
 
 
 def build_view(
@@ -198,6 +201,7 @@ def build_view(
     aggregated_groups: tuple[GenericGroupView, ...] = ()
     local_samples: tuple[LocalSampleView, ...] = ()
     robustness_assessors: tuple[RobustnessAssessorView, ...] = ()
+    reproducibility: str | None = None
 
     for section in sections:
         role = _section_role(section)
@@ -211,6 +215,8 @@ def build_view(
             local_samples = _build_local_samples(section)
         elif role == "robustness":
             robustness_assessors = _build_robustness_assessors(section)
+        elif role == "reproducibility":
+            reproducibility = _reproducibility_text(section)
 
     experiment_name = _none_if_blank(metadata.get("experiment_name")) or "n/a"
     model_name = _compact_model_label(metadata.get("model_source"))
@@ -250,7 +256,12 @@ def build_view(
         aggregated_groups=aggregated_groups,
         local_samples=local_samples,
         robustness_assessors=robustness_assessors,
-        appendix=AppendixView(sections=tuple(sections)),
+        appendix=AppendixView(
+            sections=tuple(
+                section for section in sections if _section_role(section) != "reproducibility"
+            )
+        ),
+        reproducibility=reproducibility,
     )
 
 
@@ -262,6 +273,14 @@ def _section_role(section: ReportSection) -> str:
         "local_explanations": "local",
     }
     return aliases.get(raw, raw)
+
+
+def _reproducibility_text(section: ReportSection) -> str | None:
+    """Caveat text carried as the first non-empty group heading, or ``None``."""
+    for group in section.groups:
+        if group.heading:
+            return group.heading
+    return None
 
 
 def _build_metrics_view(section: ReportSection) -> MetricsView | None:

--- a/src/raitap/reproducibility.py
+++ b/src/raitap/reproducibility.py
@@ -1,0 +1,87 @@
+"""Reproducibility caveat for stochastic methods (issue #251).
+
+A run is bit-reproducible only if every method it ran is deterministic. Methods
+declare ``stochastic`` per algorithm in their ``algorithm_registry``; the flag
+flows onto each result's ``semantics``. This module derives, from a finished
+:class:`~raitap.pipeline.outputs.RunOutputs`, the list of stochastic methods and
+renders the caveat for the three surfaces (report banner, ``REPRODUCIBILITY.md``,
+CLI warning). It is pure: callers own the side effects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from raitap.pipeline.outputs import RunOutputs
+
+REPRODUCIBILITY_FILENAME = "REPRODUCIBILITY.md"
+
+
+@dataclass(frozen=True)
+class StochasticMethod:
+    """A method in a run whose result is not bit-reproducible."""
+
+    module: str  # "transparency" | "robustness"
+    name: str  # user-facing label (config name, falling back to algorithm)
+    algorithm: str
+
+
+def stochastic_methods(outputs: RunOutputs) -> list[StochasticMethod]:
+    """Every method in this run whose semantics mark it stochastic.
+
+    Reads ``result.semantics.stochastic`` (set from the per-algorithm registry),
+    not live adapter hints — results carry their semantics. Order is stable:
+    transparency artefacts first, then robustness, each in run order.
+    """
+    found: list[StochasticMethod] = []
+    for module, results in (
+        ("transparency", outputs.transparency),
+        ("robustness", outputs.robustness),
+    ):
+        for result in results:
+            semantics = getattr(result, "semantics", None)
+            if not getattr(semantics, "stochastic", False):
+                continue
+            algorithm = str(getattr(result, "algorithm", "") or "")
+            name = str(getattr(result, "name", None) or algorithm or "<unnamed>")
+            found.append(StochasticMethod(module=module, name=name, algorithm=algorithm))
+    return found
+
+
+def reproducibility_caveat(methods: Sequence[StochasticMethod]) -> str:
+    """One-line caveat naming the stochastic methods."""
+    names = ", ".join(sorted({method.name for method in methods}))
+    return (
+        f"This run includes stochastic methods ({names}); results are not "
+        "bit-reproducible unless seeds are pinned."
+    )
+
+
+def write_reproducibility_md(run_dir: Path, methods: Sequence[StochasticMethod]) -> Path:
+    """Write ``REPRODUCIBILITY.md`` into ``run_dir`` listing the stochastic artefacts.
+
+    Returns the written path. Callers should only invoke this when ``methods`` is
+    non-empty (a fully-deterministic run writes no file).
+    """
+    lines = [
+        "# Reproducibility",
+        "",
+        reproducibility_caveat(methods),
+        "",
+        "## Stochastic artefacts",
+        "",
+    ]
+    lines.extend(
+        f"- `{method.name}` ({method.module}, algorithm `{method.algorithm}`)"
+        for method in sorted(methods, key=lambda item: (item.module, item.name))
+    )
+    lines.append("")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    path = run_dir / REPRODUCIBILITY_FILENAME
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path

--- a/src/raitap/robustness/assessors/foolbox_assessor.py
+++ b/src/raitap/robustness/assessors/foolbox_assessor.py
@@ -31,6 +31,7 @@ else:
             PerturbationNorm.LINF,
             families={"gradient_sign", "iterative"},
             requires={Capability.AUTOGRAD},
+            stochastic=True,  # random_start=True default
         ),
         "L2PGD": AssessorSemanticsHints(
             AssessmentKind.EMPIRICAL_ATTACK,
@@ -39,6 +40,7 @@ else:
             PerturbationNorm.L2,
             families={"gradient_sign", "iterative"},
             requires={Capability.AUTOGRAD},
+            stochastic=True,  # random_start=True default
         ),
         "LinfFastGradientAttack": AssessorSemanticsHints(
             AssessmentKind.EMPIRICAL_ATTACK,
@@ -81,6 +83,7 @@ else:
             # requires=AUTOGRAD preserves current gating; conceptually black-box,
             # could be relaxed later.
             requires={Capability.AUTOGRAD},
+            stochastic=True,  # gaussian random-walk + stochastic init
         ),
     },
 )

--- a/src/raitap/robustness/assessors/imagecorruptions_assessor.py
+++ b/src/raitap/robustness/assessors/imagecorruptions_assessor.py
@@ -49,6 +49,7 @@ _CORRUPTIONS: dict[str, frozenset[str]] = {
             ThreatModel.NOT_APPLICABLE,
             Objective.UNTARGETED,
             families=families,
+            stochastic=True,  # statistical-sampling corruptions draw RNG
         )
         for name, families in _CORRUPTIONS.items()
     },

--- a/src/raitap/robustness/assessors/torchattacks_assessor.py
+++ b/src/raitap/robustness/assessors/torchattacks_assessor.py
@@ -46,6 +46,7 @@ else:
             PerturbationNorm.LINF,
             families={"gradient_sign", "iterative"},
             requires={Capability.AUTOGRAD},
+            stochastic=True,  # random_start=True default (uniform init)
         ),
         "PGDL2": AssessorSemanticsHints(
             AssessmentKind.EMPIRICAL_ATTACK,
@@ -54,6 +55,7 @@ else:
             PerturbationNorm.L2,
             families={"gradient_sign", "iterative"},
             requires={Capability.AUTOGRAD},
+            stochastic=True,  # random_start=True default (uniform init)
         ),
         "MIFGSM": AssessorSemanticsHints(
             AssessmentKind.EMPIRICAL_ATTACK,
@@ -86,6 +88,7 @@ else:
             PerturbationNorm.LINF,
             families={"ensemble", "auto"},
             requires={Capability.AUTOGRAD},
+            stochastic=True,  # default seed=None -> time-seeded; random APGD/FAB/Square init
         ),
         # Square/OnePixel are score-based (conceptually black-box); requires=AUTOGRAD
         # preserves current gating via the torchattacks torch model, could be relaxed later.
@@ -96,6 +99,7 @@ else:
             PerturbationNorm.LINF,
             families={"score_based"},
             requires={Capability.AUTOGRAD},
+            stochastic=True,  # random search
         ),
         "OnePixel": AssessorSemanticsHints(
             AssessmentKind.EMPIRICAL_ATTACK,
@@ -104,6 +108,7 @@ else:
             PerturbationNorm.L0,
             families={"score_based", "evolutionary"},
             requires={Capability.AUTOGRAD},
+            stochastic=True,  # differential evolution (unseeded)
         ),
     },
 )

--- a/src/raitap/robustness/contracts.py
+++ b/src/raitap/robustness/contracts.py
@@ -198,6 +198,8 @@ class RobustnessSemantics:
     target_classes: Sequence[int] | None = None
     sample_selection: SampleSelection | None = None
     input_spec: InputSpec | None = None
+    # Non-deterministic result (RNG-dependent); drives the reproducibility caveat (#251).
+    stochastic: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "families", frozenset(self.families))

--- a/src/raitap/robustness/semantics.py
+++ b/src/raitap/robustness/semantics.py
@@ -51,6 +51,10 @@ class AssessorSemanticsHints:
     families: AbstractSet[str] = field(default_factory=frozenset)
     default_epsilon: float | None = None
     requires: AbstractSet[Capability] = field(default_factory=frozenset)
+    # Whether this algorithm's result depends on RNG (random start/sampling), so
+    # it is not bit-reproducible unless seeds are pinned (issue #251). Declared
+    # explicitly per algorithm.
+    stochastic: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "families", frozenset(self.families))
@@ -267,4 +271,5 @@ def assessor_semantics(
         target_classes=_extract_target_classes(call_kwargs),
         sample_selection=sample_selection,
         input_spec=input_spec,
+        stochastic=hints.stochastic,
     )

--- a/src/raitap/robustness/tests/test_stochastic_semantics.py
+++ b/src/raitap/robustness/tests/test_stochastic_semantics.py
@@ -1,0 +1,57 @@
+"""Robustness stochastic propagation + registry flags (issue #251)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from raitap.robustness.assessors.foolbox_assessor import FoolboxAssessor
+from raitap.robustness.assessors.imagecorruptions_assessor import ImageCorruptionsAssessor
+from raitap.robustness.assessors.torchattacks_assessor import TorchattacksAssessor
+from raitap.robustness.semantics import assessor_semantics
+
+
+def test_registry_stochastic_flags() -> None:
+    assert TorchattacksAssessor.algorithm_registry["PGD"].stochastic is True
+    assert TorchattacksAssessor.algorithm_registry["PGDL2"].stochastic is True
+    assert TorchattacksAssessor.algorithm_registry["AutoAttack"].stochastic is True
+    assert TorchattacksAssessor.algorithm_registry["Square"].stochastic is True
+    assert TorchattacksAssessor.algorithm_registry["OnePixel"].stochastic is True
+    assert TorchattacksAssessor.algorithm_registry["FGSM"].stochastic is False
+    assert TorchattacksAssessor.algorithm_registry["CW"].stochastic is False
+
+    assert FoolboxAssessor.algorithm_registry["LinfPGD"].stochastic is True
+    assert FoolboxAssessor.algorithm_registry["BoundaryAttack"].stochastic is True
+    assert FoolboxAssessor.algorithm_registry["LinfFastGradientAttack"].stochastic is False
+
+    # imagecorruptions: every corruption is statistical-sampling -> stochastic.
+    assert all(hints.stochastic for hints in ImageCorruptionsAssessor.algorithm_registry.values())
+
+
+def test_assessor_semantics_carries_stochastic() -> None:
+    assessor = TorchattacksAssessor(algorithm="PGD", eps=0.03, steps=10)
+    inputs = SimpleNamespace(shape=(1, 3, 8, 8))
+
+    semantics = assessor_semantics(
+        assessor,
+        call_kwargs={},
+        raitap_kwargs={},
+        inputs=inputs,
+        targets=None,
+    )
+
+    assert semantics.stochastic is True
+
+
+def test_assessor_semantics_deterministic_attack_is_false() -> None:
+    assessor = TorchattacksAssessor(algorithm="FGSM", eps=0.03)
+    inputs = SimpleNamespace(shape=(1, 3, 8, 8))
+
+    semantics = assessor_semantics(
+        assessor,
+        call_kwargs={},
+        raitap_kwargs={},
+        inputs=inputs,
+        targets=None,
+    )
+
+    assert semantics.stochastic is False

--- a/src/raitap/tests/test_reproducibility.py
+++ b/src/raitap/tests/test_reproducibility.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from raitap.reproducibility import (
     REPRODUCIBILITY_FILENAME,
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
+    from raitap.pipeline.outputs import RunOutputs
+
 
 def _result(name: str | None, algorithm: str, *, stochastic: bool) -> SimpleNamespace:
     return SimpleNamespace(
@@ -28,8 +30,13 @@ def _result(name: str | None, algorithm: str, *, stochastic: bool) -> SimpleName
 
 def _outputs(
     transparency: Sequence[object] = (), robustness: Sequence[object] = ()
-) -> SimpleNamespace:
-    return SimpleNamespace(transparency=list(transparency), robustness=list(robustness))
+) -> RunOutputs:
+    # ``stochastic_methods`` reads results structurally (getattr); a namespace
+    # stand-in is enough and avoids constructing a full RunOutputs.
+    return cast(
+        "RunOutputs",
+        SimpleNamespace(transparency=list(transparency), robustness=list(robustness)),
+    )
 
 
 def test_stochastic_methods_filters_on_semantics() -> None:

--- a/src/raitap/tests/test_reproducibility.py
+++ b/src/raitap/tests/test_reproducibility.py
@@ -28,9 +28,7 @@ def _result(name: str | None, algorithm: str, *, stochastic: bool) -> SimpleName
     )
 
 
-def _outputs(
-    transparency: Sequence[object] = (), robustness: Sequence[object] = ()
-) -> RunOutputs:
+def _outputs(transparency: Sequence[object] = (), robustness: Sequence[object] = ()) -> RunOutputs:
     # ``stochastic_methods`` reads results structurally (getattr); a namespace
     # stand-in is enough and avoids constructing a full RunOutputs.
     return cast(

--- a/src/raitap/tests/test_reproducibility.py
+++ b/src/raitap/tests/test_reproducibility.py
@@ -1,0 +1,79 @@
+"""Tests for the reproducibility caveat derivation (issue #251)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from raitap.reproducibility import (
+    REPRODUCIBILITY_FILENAME,
+    StochasticMethod,
+    reproducibility_caveat,
+    stochastic_methods,
+    write_reproducibility_md,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+
+def _result(name: str | None, algorithm: str, *, stochastic: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        algorithm=algorithm,
+        semantics=SimpleNamespace(stochastic=stochastic),
+    )
+
+
+def _outputs(
+    transparency: Sequence[object] = (), robustness: Sequence[object] = ()
+) -> SimpleNamespace:
+    return SimpleNamespace(transparency=list(transparency), robustness=list(robustness))
+
+
+def test_stochastic_methods_filters_on_semantics() -> None:
+    outputs = _outputs(
+        transparency=[
+            _result("sal", "Saliency", stochastic=False),
+            _result("grad", "GradientExplainer", stochastic=True),
+        ],
+        robustness=[_result("pgd", "PGD", stochastic=True)],
+    )
+
+    got = stochastic_methods(outputs)
+
+    assert {m.name for m in got} == {"grad", "pgd"}
+    assert {m.module for m in got} == {"transparency", "robustness"}
+
+
+def test_stochastic_methods_empty_when_all_deterministic() -> None:
+    outputs = _outputs(transparency=[_result("sal", "Saliency", stochastic=False)])
+    assert stochastic_methods(outputs) == []
+
+
+def test_name_falls_back_to_algorithm_when_unnamed() -> None:
+    outputs = _outputs(robustness=[_result(None, "PGD", stochastic=True)])
+    assert stochastic_methods(outputs)[0].name == "PGD"
+
+
+def test_caveat_names_methods() -> None:
+    msg = reproducibility_caveat([StochasticMethod("robustness", "PGD", "PGD")])
+    assert "PGD" in msg
+    assert "not" in msg
+    assert "bit-reproducible" in msg
+
+
+def test_write_reproducibility_md(tmp_path: Path) -> None:
+    methods = [
+        StochasticMethod("robustness", "PGD", "PGD"),
+        StochasticMethod("transparency", "grad", "GradientExplainer"),
+    ]
+
+    path = write_reproducibility_md(tmp_path, methods)
+
+    assert path.name == REPRODUCIBILITY_FILENAME
+    text = path.read_text(encoding="utf-8")
+    assert "Stochastic artefacts" in text
+    assert "PGD" in text
+    assert "GradientExplainer" in text

--- a/src/raitap/tests/test_reproducibility_orchestrator.py
+++ b/src/raitap/tests/test_reproducibility_orchestrator.py
@@ -1,0 +1,90 @@
+"""Orchestrator fan-out for the reproducibility caveat (issue #251).
+
+The output-dir note and the CLI warning must fire whenever a stochastic method
+ran, independent of reporting. These tests patch the heavy model/data
+construction and drive ``_run_pipeline`` with a fake stochastic run.
+"""
+
+from __future__ import annotations
+
+import warnings
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import torch
+
+from raitap.pipeline import orchestrator
+from raitap.pipeline.outputs import ForwardOutput, RunOutputs
+from raitap.reproducibility import REPRODUCIBILITY_FILENAME
+from raitap.types import TaskKind
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+def _fo() -> ForwardOutput:
+    return ForwardOutput(
+        task_kind=TaskKind.classification,
+        batch_size=1,
+        payload=torch.tensor([[0.1, 0.9]]),
+    )
+
+
+def _outputs(*, stochastic: bool) -> RunOutputs:
+    explanation = SimpleNamespace(
+        name="shap_grad",
+        algorithm="GradientExplainer",
+        semantics=SimpleNamespace(stochastic=stochastic),
+    )
+    transparency_phase = SimpleNamespace(explanations=[explanation], report_order=10)
+    return RunOutputs(
+        forward_output=_fo(),
+        phase_results={"transparency": transparency_phase},  # type: ignore[dict-item]
+    )
+
+
+def _patch_pipeline(monkeypatch: MonkeyPatch, run_dir: Path, outputs: RunOutputs) -> None:
+    fake_model = SimpleNamespace(backend=SimpleNamespace(task_kind=TaskKind.classification))
+    monkeypatch.setattr(orchestrator, "resolve_preprocessing", lambda *a, **k: None)
+    monkeypatch.setattr(orchestrator, "Model", lambda *a, **k: fake_model)
+    monkeypatch.setattr(orchestrator, "Data", lambda *a, **k: SimpleNamespace())
+    monkeypatch.setattr(orchestrator, "_validate_report_sample_selection", lambda *a, **k: None)
+    monkeypatch.setattr(orchestrator, "run_without_tracking", lambda *a, **k: outputs)
+    monkeypatch.setattr(orchestrator, "reporting_enabled", lambda config: False)
+    monkeypatch.setattr(orchestrator, "resolve_run_dir", lambda config: run_dir)
+
+
+def test_stochastic_run_writes_md_and_warns_with_reporting_off(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    config = SimpleNamespace(
+        experiment_name="repro",
+        model=SimpleNamespace(source="resnet50"),
+        data=SimpleNamespace(),
+    )
+    _patch_pipeline(monkeypatch, tmp_path, _outputs(stochastic=True))
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        orchestrator._run_pipeline(config, verbose=False)  # type: ignore[arg-type]
+
+    assert (tmp_path / REPRODUCIBILITY_FILENAME).exists()
+    assert any("not bit-reproducible" in str(w.message) for w in caught)
+
+
+def test_deterministic_run_emits_nothing(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    config = SimpleNamespace(
+        experiment_name="repro",
+        model=SimpleNamespace(source="resnet50"),
+        data=SimpleNamespace(),
+    )
+    _patch_pipeline(monkeypatch, tmp_path, _outputs(stochastic=False))
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        orchestrator._run_pipeline(config, verbose=False)  # type: ignore[arg-type]
+
+    assert not (tmp_path / REPRODUCIBILITY_FILENAME).exists()
+    assert not any("not bit-reproducible" in str(w.message) for w in caught)

--- a/src/raitap/transparency/contracts.py
+++ b/src/raitap/transparency/contracts.py
@@ -142,6 +142,10 @@ class ExplainerSemanticsHints:
     baseline_default: BaselineMode | None = None
     baseline_cardinality: BaselineCardinality | None = None
     requires: AbstractSet[Capability] = field(default_factory=frozenset)
+    # Whether this algorithm's result depends on RNG (random init/sampling), so
+    # it is not bit-reproducible unless seeds are pinned. Surfaced by the
+    # reproducibility caveat (issue #251). Declared explicitly per algorithm.
+    stochastic: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "families", frozenset(self.families))
@@ -298,6 +302,8 @@ class ExplanationSemantics:
     sample_selection: SampleSelection | None
     input_spec: InputSpec | None
     output_space: OutputSpaceSpec
+    # Non-deterministic result (RNG-dependent); drives the reproducibility caveat (#251).
+    stochastic: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "method_families", frozenset(self.method_families))

--- a/src/raitap/transparency/explainers/base_explainer.py
+++ b/src/raitap/transparency/explainers/base_explainer.py
@@ -35,7 +35,12 @@ from ..contracts import (
     explainer_output_scope,
 )
 from ..results import ConfiguredVisualiser, ExplanationResult
-from ..semantics import infer_input_spec, infer_output_space, method_families_for_explainer
+from ..semantics import (
+    explainer_is_stochastic,
+    infer_input_spec,
+    infer_output_space,
+    method_families_for_explainer,
+)
 
 _NON_BATCHABLE_KWARGS = frozenset({"background_data"})
 
@@ -144,6 +149,7 @@ class AttributionOnlyExplainer(BaseExplainer, ABC):
             ),
             input_spec=input_spec,
             output_space=output_space,
+            stochastic=explainer_is_stochastic(self),
         )
 
         resolved_run_dir = (

--- a/src/raitap/transparency/explainers/captum_explainer.py
+++ b/src/raitap/transparency/explainers/captum_explainer.py
@@ -47,14 +47,17 @@ if TYPE_CHECKING:
         "FeaturePermutation": ExplainerSemanticsHints({MethodFamily.PERTURBATION}),
         "Occlusion": ExplainerSemanticsHints({MethodFamily.PERTURBATION}),
         "ShapleyValueSampling": ExplainerSemanticsHints(
-            {MethodFamily.SHAPLEY, MethodFamily.PERTURBATION}
+            {MethodFamily.SHAPLEY, MethodFamily.PERTURBATION},
+            stochastic=True,  # random permutation sampling
         ),
         "ShapleyValues": ExplainerSemanticsHints({MethodFamily.SHAPLEY, MethodFamily.PERTURBATION}),
         "KernelShap": ExplainerSemanticsHints(
-            {MethodFamily.SHAPLEY, MethodFamily.PERTURBATION, MethodFamily.MODEL_AGNOSTIC}
+            {MethodFamily.SHAPLEY, MethodFamily.PERTURBATION, MethodFamily.MODEL_AGNOSTIC},
+            stochastic=True,  # random coalition sampling
         ),
         "Lime": ExplainerSemanticsHints(
-            {MethodFamily.PERTURBATION, MethodFamily.MODEL_AGNOSTIC, MethodFamily.SURROGATE}
+            {MethodFamily.PERTURBATION, MethodFamily.MODEL_AGNOSTIC, MethodFamily.SURROGATE},
+            stochastic=True,  # random perturbation sampling
         ),
         "LayerGradCam": ExplainerSemanticsHints(
             {MethodFamily.GRADIENT, MethodFamily.CAM},

--- a/src/raitap/transparency/explainers/shap_explainer.py
+++ b/src/raitap/transparency/explainers/shap_explainer.py
@@ -94,6 +94,8 @@ def _select_target_attributions(
             baseline_default=BaselineMode.INPUT_BATCH,
             baseline_cardinality=BaselineCardinality.SET,
             requires={Capability.AUTOGRAD},
+            # Samples random points along the path + background choice (rseed/nsamples).
+            stochastic=True,
         ),
         "DeepExplainer": ExplainerSemanticsHints(
             {MethodFamily.SHAPLEY, MethodFamily.GRADIENT},
@@ -105,6 +107,8 @@ def _select_target_attributions(
             {MethodFamily.SHAPLEY, MethodFamily.PERTURBATION, MethodFamily.MODEL_AGNOSTIC},
             baseline_default=BaselineMode.INPUT_BATCH,
             baseline_cardinality=BaselineCardinality.SET,
+            # Monte Carlo coalition sampling (np.random.choice / permutation).
+            stochastic=True,
         ),
         # TreeExplainer is a tree-model method; requires=AUTOGRAD preserves current
         # gating, but it is the natural first consumer of the roadmap TREE_MODEL capability.

--- a/src/raitap/transparency/semantics.py
+++ b/src/raitap/transparency/semantics.py
@@ -12,6 +12,7 @@ from raitap.utils.errors import RaitapError
 
 from .contracts import (
     ExplainerCapability,
+    ExplainerSemanticsHints,
     ExplanationOutputSpace,
     InputKind,
     InputSpec,
@@ -59,6 +60,47 @@ def method_families_for_explainer(explainer: object) -> frozenset[MethodFamily]:
         return _method_families_for_algorithm(algorithm)
     except ValueError:
         raise _method_family_error(type(explainer).__name__, algorithm) from None
+
+
+def explainer_is_stochastic(explainer: object) -> bool:
+    """Whether the configured explainer's algorithm is RNG-dependent (issue #251).
+
+    Resolves the explainer's registry hints via the same 3-tier lookup as
+    :func:`method_families_for_explainer` (class registry → framework registry →
+    cross-framework name match) but never raises: any unresolved case (test
+    stubs, unknown/ambiguous algorithm) defaults to ``False``. A missing
+    declaration must never over-claim stochasticity.
+    """
+    hints = _hints_for_explainer(explainer)
+    return bool(hints.stochastic) if hints is not None else False
+
+
+def _hints_for_explainer(explainer: object) -> ExplainerSemanticsHints | None:
+    """Resolve the registry hints for a configured explainer, or ``None``."""
+    try:
+        algorithm = _explainer_algorithm(explainer)
+    except RaitapError:
+        return None
+
+    cls_registry = getattr(type(explainer), "algorithm_registry", None)
+    if isinstance(cls_registry, Mapping) and algorithm in cls_registry:
+        return cls_registry[algorithm]
+
+    framework = _explainer_framework(explainer)
+    if framework is not None:
+        adapter_cls = _adapter_class_for_framework(framework)
+        if adapter_cls is not None and algorithm in adapter_cls.algorithm_registry:
+            return adapter_cls.algorithm_registry[algorithm]
+
+    matches = []
+    from raitap.transparency.explainers.captum_explainer import CaptumExplainer
+    from raitap.transparency.explainers.shap_explainer import ShapExplainer
+
+    for adapter_cls in (ShapExplainer, CaptumExplainer):
+        registry = adapter_cls.algorithm_registry
+        if algorithm in registry:
+            matches.append(registry[algorithm])
+    return matches[0] if len(matches) == 1 else None
 
 
 def _adapter_class_for_framework(framework: str) -> type | None:

--- a/src/raitap/transparency/tests/test_contracts.py
+++ b/src/raitap/transparency/tests/test_contracts.py
@@ -119,6 +119,7 @@ def test_explanation_semantics_has_only_contract_fields() -> None:
         "sample_selection",
         "input_spec",
         "output_space",
+        "stochastic",
     ]
     assert "primary_method_family" not in {field.name for field in fields(ExplanationSemantics)}
 

--- a/src/raitap/transparency/tests/test_stochastic_semantics.py
+++ b/src/raitap/transparency/tests/test_stochastic_semantics.py
@@ -1,0 +1,33 @@
+"""Transparency stochastic resolution + registry flags (issue #251)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from raitap.transparency.explainers.captum_explainer import CaptumExplainer
+from raitap.transparency.explainers.shap_explainer import ShapExplainer
+from raitap.transparency.semantics import explainer_is_stochastic
+
+
+def test_explainer_is_stochastic_reads_registry() -> None:
+    assert explainer_is_stochastic(CaptumExplainer(algorithm="KernelShap")) is True
+    assert explainer_is_stochastic(CaptumExplainer(algorithm="IntegratedGradients")) is False
+    assert explainer_is_stochastic(ShapExplainer(algorithm="GradientExplainer")) is True
+    assert explainer_is_stochastic(ShapExplainer(algorithm="DeepExplainer")) is False
+
+
+def test_explainer_is_stochastic_defaults_false_for_unknown() -> None:
+    stub = SimpleNamespace(algorithm="<unknown>")
+    assert explainer_is_stochastic(stub) is False
+
+
+def test_registry_stochastic_flags() -> None:
+    assert ShapExplainer.algorithm_registry["GradientExplainer"].stochastic is True
+    assert ShapExplainer.algorithm_registry["KernelExplainer"].stochastic is True
+    assert ShapExplainer.algorithm_registry["DeepExplainer"].stochastic is False
+    assert ShapExplainer.algorithm_registry["TreeExplainer"].stochastic is False
+
+    assert CaptumExplainer.algorithm_registry["ShapleyValueSampling"].stochastic is True
+    assert CaptumExplainer.algorithm_registry["Lime"].stochastic is True
+    assert CaptumExplainer.algorithm_registry["IntegratedGradients"].stochastic is False
+    assert CaptumExplainer.algorithm_registry["LayerGradCam"].stochastic is False


### PR DESCRIPTION
## Summary

Surfaces a reproducibility caveat whenever a run uses a stochastic method, so users know results are not bit-reproducible unless seeds are pinned. Closes #251.

- Per-algorithm `stochastic: bool` hint on the explainer/assessor registries (`ExplainerSemanticsHints`, `AssessorSemanticsHints`), explicitly declared (no auto-derivation). Verified classifications against installed library source (SHAP `GradientExplainer`/`KernelExplainer` stochastic; `DeepExplainer`/`TreeExplainer` not; captum `ShapleyValueSampling`/`KernelShap`/`Lime`; torchattacks `PGD`/`PGDL2`/`AutoAttack`/`Square`/`OnePixel`; foolbox PGD/`BoundaryAttack`; all image corruptions).
- Flows onto the typed per-result semantics (`ExplanationResult.semantics.stochastic`, `RobustnessResult.semantics.stochastic`) and serialises into `metadata.json` for free.
- Pure derivation helper (`raitap/reproducibility.py`) collects the run's stochastic methods and surfaces the caveat on three channels when ≥1 stochastic method ran; a fully deterministic run emits none:
  1. **Report banner** — first-class `ReportView.reproducibility` field rendered as a top banner in **both** HTML (`_reproducibility.html.j2`, before the summary hero) and PDF (heading + paragraph). Excluded from the appendix.
  2. **`REPRODUCIBILITY.md`** written to the run directory.
  3. **CLI/log warning** after the run.

Seed-aware wording (issue #251 point 3) and merged/multirun banner aggregation are intentionally deferred.

## Checklist

- [x] **CI** — Required checks are green
- [x] **Breaking changes** — If this PR breaks compatibility (API, configs, file formats, etc.), the title uses `!` after the type or scope (e.g. `feat!:` or `feat(transparency)!:`). I understand that this change will have a **direct, disruptive impact** on package users. I ensured that **this change is absolutely necessary and cannot be delayed**.
- [x] **Contributor guide** — I’ve read [**Pull requests and commit messages**](https://caiivs.github.io/raitap/contributor/pull-requests.html) before requesting review.

## Optional

- [x] **Issue** _(optional)_ — A GitHub issues is linked to this PR ("Development" section in the right sidebar).
- [x] **Docs** _(optional)_ — User or contributor docs updated where needed.
- [x] **Tests** _(optional)_ — New or updated tests cover the change.
